### PR TITLE
Display summary on early exit, propagate DSCP to server

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -118,6 +118,7 @@ impl Default for ClientConfig {
     }
 }
 
+#[derive(Clone)]
 pub struct TestProgress {
     pub elapsed_ms: u64,
     pub total_bytes: u64,
@@ -304,6 +305,7 @@ impl Client {
             bitrate: self.config.bitrate,
             congestion: self.config.tcp_congestion.clone(),
             mptcp: self.config.mptcp,
+            dscp: self.config.dscp,
         };
         writer
             .write_all(format!("{}\n", test_start.serialize()?).as_bytes())
@@ -394,7 +396,7 @@ impl Client {
         } else {
             self.config.duration + Duration::from_secs(30)
         };
-        let deadline = tokio::time::Instant::now() + timeout_duration;
+        let mut deadline = tokio::time::Instant::now() + timeout_duration;
         let local_end_deadline =
             local_stop_deadline(tokio::time::Instant::now(), self.config.duration);
         let mut local_stop_sent = false;
@@ -559,8 +561,11 @@ impl Client {
                     break;
                 }
                 ControlMessage::Cancelled { .. } => {
-                    test_result = Err(anyhow::anyhow!("Test was cancelled"));
-                    break;
+                    // Server acknowledged cancel — it will send Result next.
+                    // Tighten deadline to wait briefly for the final result.
+                    deadline = tokio::time::Instant::now() + Duration::from_secs(3);
+                    line.clear();
+                    continue;
                 }
                 _ => {
                     debug!("Unexpected message: {:?}", msg);
@@ -1119,6 +1124,7 @@ impl Client {
             bitrate: self.config.bitrate,
             congestion: None,
             mptcp: false,
+            dscp: None, // QUIC manages its own TOS via the transport layer
         };
         ctrl_send
             .write_all(format!("{}\n", test_start.serialize()?).as_bytes())
@@ -1245,7 +1251,7 @@ impl Client {
         } else {
             self.config.duration + Duration::from_secs(30)
         };
-        let deadline = tokio::time::Instant::now() + timeout_duration;
+        let mut deadline = tokio::time::Instant::now() + timeout_duration;
 
         loop {
             tokio::select! {
@@ -1326,8 +1332,12 @@ impl Client {
                     return Err(anyhow::anyhow!("Server error: {}", message));
                 }
                 ControlMessage::Cancelled { .. } => {
+                    // Server acknowledged cancel — it will send Result next.
+                    // Tighten deadline to wait briefly for the final result.
                     let _ = cancel_tx.send(true);
-                    return Err(anyhow::anyhow!("Test was cancelled"));
+                    deadline = tokio::time::Instant::now() + Duration::from_secs(3);
+                    line.clear();
+                    continue;
                 }
                 _ => {
                     debug!("Unexpected message: {:?}", msg);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1109,8 +1109,10 @@ async fn run_client_plain(
 
         while let Some(progress) = rx.recv().await {
             // Accumulate cumulative totals for fallback summary
-            cumulative_bytes_writer.fetch_add(progress.total_bytes, std::sync::atomic::Ordering::Relaxed);
-            cumulative_elapsed_writer.store(progress.elapsed_ms, std::sync::atomic::Ordering::Relaxed);
+            cumulative_bytes_writer
+                .fetch_add(progress.total_bytes, std::sync::atomic::Ordering::Relaxed);
+            cumulative_elapsed_writer
+                .store(progress.elapsed_ms, std::sync::atomic::Ordering::Relaxed);
 
             let elapsed_secs = progress.elapsed_ms as f64 / 1000.0;
             let retransmits = interval_retransmits(&progress, &mut last_retransmits);
@@ -1261,9 +1263,7 @@ async fn run_client_plain(
     println!("{}", output_str);
 
     // Don't save incomplete fallback results to file — only save real server results
-    if !interrupted
-        && let Some(path) = output
-    {
+    if !interrupted && let Some(path) = output {
         xfr::output::json::save_json(&result, &path)?;
         info!("Results saved to {}", path.display());
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use anyhow::Result;
 use clap::{Parser, Subcommand};
 use crossterm::ExecutableCommand;
-use crossterm::event::{self, Event, KeyCode, KeyEventKind};
+use crossterm::event::{self, Event, KeyCode, KeyEventKind, KeyModifiers};
 use crossterm::terminal::{
     EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
 };
@@ -883,6 +883,11 @@ async fn main() -> Result<()> {
                 eprintln!("Warning: --dscp is ignored with QUIC (QUIC manages its own socket)");
             }
 
+            #[cfg(not(unix))]
+            if cli.dscp.is_some() && protocol != xfr::protocol::Protocol::Quic {
+                eprintln!("Warning: --dscp is not supported on this platform");
+            }
+
             if cli.mptcp {
                 xfr::net::validate_mptcp().map_err(|e| anyhow::anyhow!("{}", e))?;
             }
@@ -1065,7 +1070,7 @@ async fn run_client_plain(
     opts: OutputOptions,
     output: Option<PathBuf>,
 ) -> Result<()> {
-    let client = Client::new(config.clone());
+    let client = Arc::new(Client::new(config.clone()));
 
     let (tx, mut rx) = mpsc::channel::<TestProgress>(100);
 
@@ -1087,12 +1092,26 @@ async fn run_client_plain(
     let test_start = std::time::Instant::now();
     let test_start_system = std::time::SystemTime::now();
 
+    // Cumulative stats for fallback summary on signal interrupt.
+    // TestProgress fields (total_bytes, streams[*].bytes) are per-interval deltas,
+    // so we must accumulate totals across intervals ourselves.
+    let cumulative_bytes: Arc<std::sync::atomic::AtomicU64> =
+        Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let cumulative_elapsed_ms: Arc<std::sync::atomic::AtomicU64> =
+        Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let cumulative_bytes_writer = cumulative_bytes.clone();
+    let cumulative_elapsed_writer = cumulative_elapsed_ms.clone();
+
     // Print intervals in a separate task
     let print_handle = tokio::spawn(async move {
         let mut last_printed_interval: i64 = -1;
         let mut last_retransmits: u64 = 0;
 
         while let Some(progress) = rx.recv().await {
+            // Accumulate cumulative totals for fallback summary
+            cumulative_bytes_writer.fetch_add(progress.total_bytes, std::sync::atomic::Ordering::Relaxed);
+            cumulative_elapsed_writer.store(progress.elapsed_ms, std::sync::atomic::Ordering::Relaxed);
+
             let elapsed_secs = progress.elapsed_ms as f64 / 1000.0;
             let retransmits = interval_retransmits(&progress, &mut last_retransmits);
 
@@ -1183,12 +1202,54 @@ async fn run_client_plain(
         }
     });
 
-    let result = client.run(Some(tx)).await?;
+    // Spawn the test as a task so we can select between it and Ctrl+C
+    let client_run = client.clone();
+    let mut test_handle = tokio::spawn(async move { client_run.run(Some(tx)).await });
 
-    // Wait for print task to finish
+    // Signal handler: first Ctrl+C = graceful cancel, second = force exit
+    let sigint = Arc::new(tokio::sync::Notify::new());
+    let sigint_bg = sigint.clone();
+    tokio::spawn(async move {
+        let _ = tokio::signal::ctrl_c().await;
+        sigint_bg.notify_one();
+        // Second Ctrl+C = force exit
+        let _ = tokio::signal::ctrl_c().await;
+        std::process::exit(130);
+    });
+
+    // Wait for either test completion or Ctrl+C
+    let (result, interrupted) = tokio::select! {
+        r = &mut test_handle => {
+            (r??, false)
+        }
+        _ = sigint.notified() => {
+            eprintln!("\nInterrupted, waiting for summary...");
+            let _ = client.cancel();
+            // Wait for the test task to finish (client now waits for server Result after cancel)
+            match tokio::time::timeout(Duration::from_secs(5), &mut test_handle).await {
+                Ok(Ok(Ok(result))) => (result, false), // Got real server result after cancel
+                Ok(Ok(Err(_))) | Ok(Err(_)) | Err(_) => {
+                    // Server didn't respond or task failed — abort and build fallback
+                    test_handle.abort();
+                    let bytes = cumulative_bytes.load(std::sync::atomic::Ordering::Relaxed);
+                    let elapsed_ms = cumulative_elapsed_ms.load(std::sync::atomic::Ordering::Relaxed);
+                    if bytes == 0 {
+                        eprintln!("Test interrupted before any data was collected.");
+                        std::process::exit(130);
+                    }
+                    (build_fallback_result(bytes, elapsed_ms), true)
+                }
+            }
+        }
+    };
+
+    // Wait for print task to finish (test task is done or aborted, so tx is dropped)
     let _ = print_handle.await;
 
     // Output result
+    if interrupted {
+        eprintln!("Warning: partial results (server did not respond to cancel)");
+    }
     let output_str = if opts.json || opts.json_stream {
         output_json(&result)
     } else if opts.csv {
@@ -1199,12 +1260,42 @@ async fn run_client_plain(
 
     println!("{}", output_str);
 
-    if let Some(path) = output {
+    // Don't save incomplete fallback results to file — only save real server results
+    if !interrupted
+        && let Some(path) = output
+    {
         xfr::output::json::save_json(&result, &path)?;
         info!("Results saved to {}", path.display());
     }
 
+    if interrupted {
+        std::process::exit(130);
+    }
+
     Ok(())
+}
+
+/// Build a fallback TestResult from cumulative counters.
+/// Used when the server doesn't respond after cancel.
+/// Only provides aggregate totals — no per-stream breakdown is available.
+fn build_fallback_result(cumulative_bytes: u64, elapsed_ms: u64) -> xfr::protocol::TestResult {
+    use xfr::protocol::TestResult;
+
+    let throughput_mbps = if elapsed_ms > 0 {
+        (cumulative_bytes as f64 * 8.0) / (elapsed_ms as f64 / 1000.0) / 1_000_000.0
+    } else {
+        0.0
+    };
+
+    TestResult {
+        id: String::new(),
+        bytes_total: cumulative_bytes,
+        duration_ms: elapsed_ms,
+        throughput_mbps,
+        streams: vec![],
+        tcp_info: None,
+        udp_stats: None,
+    }
 }
 
 async fn run_client_tui(
@@ -1290,7 +1381,18 @@ async fn run_tui_loop(
 
     app.on_connected();
 
+    // Track cancel state: when user presses 'q' or Ctrl+C during a running test,
+    // we cancel and wait briefly for the server Result before exiting.
+    let mut cancel_deadline: Option<std::time::Instant> = None;
+
     loop {
+        // If we're waiting for cancel result and deadline expired, exit now
+        if let Some(deadline) = cancel_deadline
+            && deadline.elapsed() > Duration::ZERO
+        {
+            return Ok((app.result, prefs, print_json_on_exit));
+        }
+
         // Check for update result if not already received
         if !update_check_done {
             match update_rx.try_recv() {
@@ -1365,13 +1467,23 @@ async fn run_tui_loop(
                 continue;
             }
 
-            match key.code {
-                KeyCode::Char('q') => {
-                    // Cancel the test on server before exiting
-                    let _ = client.cancel();
+            // Ctrl+C or 'q': cancel and wait for server Result
+            let is_quit = key.code == KeyCode::Char('q')
+                || (key.code == KeyCode::Char('c')
+                    && key.modifiers.contains(KeyModifiers::CONTROL));
+            if is_quit {
+                if app.state == AppState::Completed || cancel_deadline.is_some() {
+                    // Already completed or already cancelling — exit immediately
                     prefs.theme = Some(app.theme_name().to_string());
                     return Ok((app.result, prefs, print_json_on_exit));
                 }
+                let _ = client.cancel();
+                cancel_deadline = Some(std::time::Instant::now() + Duration::from_secs(3));
+                app.log("Cancelling, waiting for summary...");
+                continue;
+            }
+
+            match key.code {
                 KeyCode::Char('p') => {
                     match client.pause() {
                         PauseResult::Applied => {
@@ -1444,6 +1556,13 @@ async fn run_tui_loop(
             match test_handle.await? {
                 Ok(result) => {
                     app.on_result(result);
+
+                    // If we were waiting for cancel to complete, exit now with result
+                    if cancel_deadline.is_some() {
+                        prefs.theme = Some(app.theme_name().to_string());
+                        return Ok((app.result, prefs, print_json_on_exit));
+                    }
+
                     // Show final result for a moment
                     terminal.draw(|f| draw(f, &app))?;
 
@@ -1501,6 +1620,14 @@ async fn run_tui_loop(
                                 continue;
                             }
 
+                            // Ctrl+C in completed state: exit
+                            if key.code == KeyCode::Char('c')
+                                && key.modifiers.contains(KeyModifiers::CONTROL)
+                            {
+                                prefs.theme = Some(app.theme_name().to_string());
+                                return Ok((app.result, prefs, print_json_on_exit));
+                            }
+
                             match key.code {
                                 KeyCode::Char('q') => {
                                     prefs.theme = Some(app.theme_name().to_string());
@@ -1541,6 +1668,12 @@ async fn run_tui_loop(
                     }
                 }
                 Err(e) => {
+                    // If we were waiting for cancel to complete, just exit
+                    if cancel_deadline.is_some() {
+                        prefs.theme = Some(app.theme_name().to_string());
+                        return Ok((app.result, prefs, print_json_on_exit));
+                    }
+
                     app.on_error(e.to_string());
                     terminal.draw(|f| draw(f, &app))?;
 
@@ -1549,7 +1682,9 @@ async fn run_tui_loop(
                         if event::poll(Duration::from_millis(100))?
                             && let Event::Key(key) = event::read()?
                             && key.kind == KeyEventKind::Press
-                            && key.code == KeyCode::Char('q')
+                            && (key.code == KeyCode::Char('q')
+                                || (key.code == KeyCode::Char('c')
+                                    && key.modifiers.contains(KeyModifiers::CONTROL)))
                         {
                             prefs.theme = Some(app.theme_name().to_string());
                             return Err(anyhow::anyhow!(app.error.unwrap_or_default()));

--- a/src/main.rs
+++ b/src/main.rs
@@ -1524,23 +1524,17 @@ async fn run_tui_loop(
                 KeyCode::Char('d') => {
                     app.toggle_streams();
                 }
-                KeyCode::Esc => {
-                    if app.show_help {
-                        app.show_help = false;
-                    }
+                KeyCode::Esc if app.show_help => {
+                    app.show_help = false;
                 }
-                KeyCode::Char('j') => {
-                    if app.result.is_some() {
-                        // Set flag to print JSON after TUI closes
-                        print_json_on_exit = true;
-                        app.log("JSON output queued for display on exit.");
-                    }
+                KeyCode::Char('j') if app.result.is_some() => {
+                    // Set flag to print JSON after TUI closes
+                    print_json_on_exit = true;
+                    app.log("JSON output queued for display on exit.");
                 }
-                KeyCode::Char('u') => {
+                KeyCode::Char('u') if app.update_available.is_some() => {
                     // Dismiss update notification
-                    if app.update_available.is_some() {
-                        app.update_available = None;
-                    }
+                    app.update_available = None;
                 }
                 _ => {}
             }
@@ -1657,10 +1651,8 @@ async fn run_tui_loop(
                                     print_json_on_exit = true;
                                     app.log("JSON output queued for display on exit.");
                                 }
-                                KeyCode::Char('u') => {
-                                    if app.update_available.is_some() {
-                                        app.update_available = None;
-                                    }
+                                KeyCode::Char('u') if app.update_available.is_some() => {
+                                    app.update_available = None;
                                 }
                                 _ => {}
                             }
@@ -1729,10 +1721,8 @@ async fn run_server_tui(mut config: ServerConfig) -> Result<()> {
                 KeyCode::Char('?') | KeyCode::F(1) => {
                     app.toggle_help();
                 }
-                KeyCode::Esc => {
-                    if app.show_help {
-                        app.show_help = false;
-                    }
+                KeyCode::Esc if app.show_help => {
+                    app.show_help = false;
                 }
                 _ => {}
             }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -102,6 +102,9 @@ pub enum ControlMessage {
         congestion: Option<String>,
         #[serde(default, skip_serializing_if = "std::ops::Not::not")]
         mptcp: bool,
+        /// DSCP/TOS byte for QoS marking on server-side sockets (download/bidir)
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        dscp: Option<u8>,
     },
     TestAck {
         id: String,
@@ -436,6 +439,7 @@ mod tests {
             bitrate: None,
             congestion: None,
             mptcp: false,
+            dscp: None,
         };
         let json = msg.serialize().unwrap();
         let decoded = ControlMessage::deserialize(&json).unwrap();

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -1224,6 +1224,7 @@ async fn handle_test_request(
             bitrate,
             congestion,
             mptcp,
+            dscp,
         } => {
             // Validate stream count
             if streams == 0 || streams > MAX_STREAMS {
@@ -1322,6 +1323,7 @@ async fn handle_test_request(
                 security.tui_tx.clone(),
                 &security.push_gateway_url,
                 client_supports_single_port,
+                dscp,
             )
             .await;
 
@@ -1655,6 +1657,7 @@ async fn run_test(
     tui_tx: Option<mpsc::Sender<ServerEvent>>,
     push_gateway_url: &Option<String>,
     client_supports_single_port: bool,
+    dscp: Option<u8>,
 ) -> anyhow::Result<(u64, u64, f64)> {
     let mut line = String::new();
 
@@ -1813,6 +1816,7 @@ async fn run_test(
                         congestion.clone(),
                         bitrate,
                         pause_clone,
+                        dscp,
                     )
                     .await
                 });
@@ -1830,6 +1834,7 @@ async fn run_test(
                 bitrate.unwrap_or(DEFAULT_BITRATE_BPS),
                 cancel_rx.clone(),
                 pause_rx.clone(),
+                dscp,
             )
             .await;
             (None, handles)
@@ -1989,29 +1994,26 @@ async fn run_test(
         udp_stats: stats.aggregate_udp_stats(),
     });
 
-    // Cleanup active test entry BEFORE sending result
-    // This ensures cleanup happens even if the write fails
+    // Send result FIRST so the client isn't blocked by slow post-processing
+    // (push gateway retries, metrics hooks, etc.)
+    writer
+        .write_all(format!("{}\n", result.serialize()?).as_bytes())
+        .await?;
+
+    // Cleanup and post-processing after client has the result
     active_tests.lock().await.remove(id);
 
-    // Notify metrics that test completed
     #[cfg(feature = "prometheus")]
     crate::output::prometheus::on_test_complete(&stats);
 
-    // Push metrics to gateway if configured
     crate::output::push_gateway::maybe_push_metrics(push_gateway_url, &stats).await;
 
-    // Notify TUI that test completed
     if let Some(tx) = &tui_tx {
         let _ = tx.try_send(ServerEvent::TestCompleted {
             id: id.to_string(),
             bytes: bytes_total,
         });
     }
-
-    // Send result (after cleanup so stale entries don't persist on failure)
-    writer
-        .write_all(format!("{}\n", result.serialize()?).as_bytes())
-        .await?;
 
     info!(
         "Test {} complete: {:.2} Mbps, {} bytes",
@@ -2218,6 +2220,7 @@ async fn spawn_tcp_stream_handlers(
     congestion: Option<String>,
     bitrate: Option<u64>,
     pause: watch::Receiver<bool>,
+    dscp: Option<u8>,
 ) -> Vec<JoinHandle<()>> {
     let per_stream_bitrate = bitrate.map(|b| {
         if b == 0 {
@@ -2298,6 +2301,13 @@ async fn spawn_tcp_stream_handlers(
                     // Capture TCP_INFO before transfer starts
                     if let Some(info) = tcp::get_stream_tcp_info(&stream) {
                         test_stats.add_tcp_info(info);
+                    }
+
+                    // Apply DSCP/TOS marking if requested by client
+                    if let Some(tos) = dscp
+                        && let Err(e) = crate::net::set_tos_on_tcp(&stream, tos)
+                    {
+                        tracing::warn!("Failed to set DSCP on server TCP socket: {}", e);
                     }
 
                     match direction {
@@ -2398,6 +2408,7 @@ async fn spawn_tcp_stream_handlers(
     handles
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn spawn_udp_handlers(
     sockets: Vec<Arc<UdpSocket>>,
     stats: Arc<TestStats>,
@@ -2406,6 +2417,7 @@ async fn spawn_udp_handlers(
     bitrate: u64,
     cancel: watch::Receiver<bool>,
     pause: watch::Receiver<bool>,
+    dscp: Option<u8>,
 ) -> Vec<JoinHandle<()>> {
     let mut handles = Vec::new();
 
@@ -2420,6 +2432,13 @@ async fn spawn_udp_handlers(
     };
 
     for (i, socket) in sockets.into_iter().enumerate() {
+        // Apply DSCP/TOS marking if requested by client
+        if let Some(tos) = dscp
+            && let Err(e) = crate::net::set_tos_on_udp(&socket, tos)
+        {
+            tracing::warn!("Failed to set DSCP on server UDP socket {}: {}", i, e);
+        }
+
         let stream_stats = stats.streams[i].clone();
         let test_stats = stats.clone();
         let cancel = cancel.clone();

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -401,11 +401,7 @@ impl TestStats {
                 count += 1;
             }
         }
-        if count > 0 {
-            Some(((rtt_sum / count) as u32, retransmits, cwnd))
-        } else {
-            None
-        }
+        (rtt_sum.checked_div(count)).map(|avg_rtt| (avg_rtt as u32, retransmits, cwnd))
     }
 
     /// Get final TCP_INFO across all streams, using saved snapshots from completed tasks.
@@ -425,16 +421,15 @@ impl TestStats {
                 count += 1;
             }
         }
-        if count > 0 {
-            Some(TcpInfoSnapshot {
+        rtt_sum.checked_div(count).map(|avg_rtt| {
+            let avg_rtt_var = rtt_var_sum / count; // safe: checked_div confirmed count > 0
+            TcpInfoSnapshot {
                 retransmits,
-                rtt_us: (rtt_sum / count) as u32,
-                rtt_var_us: (rtt_var_sum / count) as u32,
+                rtt_us: avg_rtt as u32,
+                rtt_var_us: avg_rtt_var as u32,
                 cwnd,
-            })
-        } else {
-            None
-        }
+            }
+        })
     }
 }
 

--- a/tests/protocol.rs
+++ b/tests/protocol.rs
@@ -38,6 +38,7 @@ fn test_test_start_roundtrip() {
         bitrate: None,
         congestion: Some("bbr".to_string()),
         mptcp: false,
+        dscp: None,
     };
 
     let json = msg.serialize().unwrap();
@@ -97,6 +98,7 @@ fn test_udp_test_start() {
         bitrate: Some(1_000_000_000),
         congestion: None,
         mptcp: false,
+        dscp: None,
     };
 
     let json = msg.serialize().unwrap();


### PR DESCRIPTION
## Summary
- **Early exit summary (#35)**: Ctrl+C now triggers graceful cancel and displays test summary with accumulated stats instead of silently exiting. Works in both plain text and TUI modes.
- **DSCP server-side propagation**: `--dscp` flag now sent to server via `TestStart` protocol message, applied to server-side TCP/UDP sockets for download/bidir tests. Non-Unix warning added.
- **Server result ordering**: `Result` message sent before slow post-processing (push gateway, metrics) to prevent false cancel timeouts.

### Early exit details
- Plain mode: `tokio::signal::ctrl_c()` triggers `client.cancel()`, waits up to 5s for server `Result`
- TUI mode: Ctrl+C handled as key event (`KeyModifiers::CONTROL`) with 3s cancel deadline
- Client `Cancelled` handler fixed to wait for subsequent `Result` instead of erroring (TCP + QUIC)
- Double Ctrl+C force-exits with code 130
- Fallback from cumulative counters if server unreachable, marked partial (exit 130, no `--output` save)

### DSCP propagation
- `dscp: Option<u8>` added to `TestStart` with `serde(default)` for backward compat
- Server applies TOS on accepted TCP streams and UDP sockets
- `#[cfg(not(unix))]` warning via `eprintln!` before test starts

Closes #35

## Test plan
- [x] `cargo clippy --all-features -- -D warnings` clean
- [x] `cargo test` — 87 unit tests pass
- [x] `cargo test --test integration` — 55 integration tests pass
- [x] `cargo test --test protocol` — 18 protocol tests pass
- [x] Manual: plain mode 30s test, Ctrl+C at 3s → full summary with 3.00s duration, real TCP info
- [x] Manual: TUI exits cleanly on termination
- [x] Codex adversarial review: all findings addressed across 3 review rounds