### PR TITLE
Smooth TUI jitter, add max jitter and packet size to UDP summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-- **Smoothed TUI jitter reading** (issue #48) — the UDP stats panel now shows jitter averaged over a 10-second rolling window rather than the raw per-second sample. The data pipeline is unchanged (samples still arrive every second from the server); only the aggregate display is smoothed. Per-stream jitter in the streams view continues to show the latest interval. Label updates from `Jitter:` to `Jitter (10s):`.
+- **Smoothed TUI jitter reading** (issue #48) — the UDP stats panel now shows jitter averaged over a 10-second rolling window rather than the raw per-second sample. The data pipeline is unchanged (samples still arrive every second from the server); only the aggregate display is smoothed. Per-stream jitter in the streams view continues to show the latest interval. While the test is running, the label shows `Jitter (10s):`; once completed, it reverts to `Jitter:` with the authoritative final value from the server's result.
 
 ## [0.9.8] - 2026-04-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Max jitter and packet size in UDP summary** (issue #48 follow-up) — the final UDP summary now reports `Jitter Max` (peak of the RFC 3550 running estimate across the test) alongside the average, and `Packet Size` (UDP payload bytes). Surfaced in plain text and JSON. Requested by brettowe for NFS UDP packet-size tuning context.
+
 ### Changed
 - **Smoothed TUI jitter reading** (issue #48) — the UDP stats panel now shows jitter averaged over a 10-second rolling window rather than the raw per-second sample. The data pipeline is unchanged (samples still arrive every second from the server); only the aggregate display is smoothed. Per-stream jitter in the streams view continues to show the latest interval. While the test is running, the label shows `Jitter (10s):`; once completed, it reverts to `Jitter:` with the authoritative final value from the server's result.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- **Smoothed TUI jitter reading** (issue #48) — the UDP stats panel now shows jitter averaged over a 10-second rolling window rather than the raw per-second sample. The data pipeline is unchanged (samples still arrive every second from the server); only the aggregate display is smoothed. Per-stream jitter in the streams view continues to show the latest interval. Label updates from `Jitter:` to `Jitter (10s):`.
+
 ## [0.9.8] - 2026-04-17
 
 ### Added

--- a/src/output/plain.rs
+++ b/src/output/plain.rs
@@ -88,10 +88,16 @@ pub fn output_plain(result: &TestResult, mptcp: bool) -> String {
             "    Jitter:           {:.2}ms\n",
             udp_stats.jitter_ms
         ));
+        if let Some(max) = udp_stats.jitter_max_ms {
+            output.push_str(&format!("    Jitter Max:       {:.2}ms\n", max));
+        }
         output.push_str(&format!(
             "    Out of Order:     {}\n",
             udp_stats.out_of_order
         ));
+        if let Some(size) = udp_stats.packet_size {
+            output.push_str(&format!("    Packet Size:      {} bytes\n", size));
+        }
         output.push('\n');
     }
 

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -285,6 +285,10 @@ pub struct UdpStats {
     pub lost_percent: f64,
     pub jitter_ms: f64,
     pub out_of_order: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub jitter_max_ms: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub packet_size: Option<u32>,
 }
 
 /// Timestamp format options for interval output

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -312,18 +312,32 @@ impl TestStats {
             lost_percent: 0.0,
             jitter_ms: 0.0,
             out_of_order: 0,
+            jitter_max_ms: None,
+            packet_size: None,
         };
 
+        let mut jitter_max = 0.0f64;
+        let mut any_jitter_max = false;
         for s in stats.iter() {
             total.packets_sent += s.packets_sent;
             total.packets_received += s.packets_received;
             total.lost += s.lost;
             total.out_of_order += s.out_of_order;
             total.jitter_ms += s.jitter_ms;
+            if let Some(max) = s.jitter_max_ms {
+                jitter_max = jitter_max.max(max);
+                any_jitter_max = true;
+            }
+            if total.packet_size.is_none() {
+                total.packet_size = s.packet_size;
+            }
         }
 
         // Average jitter across streams
         total.jitter_ms /= stats.len() as f64;
+        if any_jitter_max {
+            total.jitter_max_ms = Some(jitter_max);
+        }
 
         // Recalculate loss percent from totals
         if total.packets_sent > 0 {

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -665,6 +665,69 @@ mod tests {
     }
 
     #[test]
+    fn test_aggregate_udp_stats_takes_max_jitter_across_streams() {
+        let stats = TestStats::new("test".to_string(), 3);
+        stats.add_udp_stats(UdpStats {
+            packets_sent: 100,
+            packets_received: 100,
+            lost: 0,
+            lost_percent: 0.0,
+            jitter_ms: 1.0,
+            out_of_order: 0,
+            jitter_max_ms: Some(2.5),
+            packet_size: Some(1400),
+        });
+        stats.add_udp_stats(UdpStats {
+            packets_sent: 100,
+            packets_received: 99,
+            lost: 1,
+            lost_percent: 1.0,
+            jitter_ms: 0.5,
+            out_of_order: 0,
+            jitter_max_ms: Some(7.25), // highest peak
+            packet_size: Some(1400),
+        });
+        stats.add_udp_stats(UdpStats {
+            packets_sent: 100,
+            packets_received: 100,
+            lost: 0,
+            lost_percent: 0.0,
+            jitter_ms: 2.0,
+            out_of_order: 0,
+            jitter_max_ms: Some(4.0),
+            packet_size: Some(1400),
+        });
+
+        let agg = stats.aggregate_udp_stats().expect("expected aggregation");
+        assert_eq!(
+            agg.jitter_max_ms,
+            Some(7.25),
+            "max jitter across streams should pick the per-stream peak, not an average"
+        );
+        assert_eq!(agg.packet_size, Some(1400));
+        // Avg jitter for sanity
+        assert!((agg.jitter_ms - (1.0 + 0.5 + 2.0) / 3.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_aggregate_udp_stats_preserves_none_when_no_streams_report_max() {
+        let stats = TestStats::new("test".to_string(), 1);
+        stats.add_udp_stats(UdpStats {
+            packets_sent: 10,
+            packets_received: 10,
+            lost: 0,
+            lost_percent: 0.0,
+            jitter_ms: 0.1,
+            out_of_order: 0,
+            jitter_max_ms: None, // e.g. older server without the field
+            packet_size: None,
+        });
+        let agg = stats.aggregate_udp_stats().expect("expected aggregation");
+        assert_eq!(agg.jitter_max_ms, None);
+        assert_eq!(agg.packet_size, None);
+    }
+
+    #[test]
     fn test_total_bytes_sent_and_received_split() {
         let stats = TestStats::new("test".to_string(), 2);
         stats.streams[0].add_bytes_sent(100);

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -492,6 +492,19 @@ impl App {
             self.jitter_history.iter().sum::<f64>() / self.jitter_history.len() as f64
         }
     }
+
+    /// Value and label for the UDP jitter line in the stats panel.
+    /// Rolling 10s average while the test is running so per-second noise
+    /// doesn't make the number jump around (issue #48); switches to the
+    /// authoritative run-level final value from `on_result` once the test
+    /// has completed, so the completed screen matches the server's summary.
+    pub fn jitter_display(&self) -> (f64, &'static str) {
+        if self.state == AppState::Completed {
+            (self.udp_jitter_ms, "Jitter:       ")
+        } else {
+            (self.avg_jitter_ms(), "Jitter (10s): ")
+        }
+    }
 }
 
 impl Default for App {
@@ -507,5 +520,51 @@ impl Default for App {
             TimestampFormat::default(),
             Theme::default(),
         )
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::field_reassign_with_default)] // App has too many fields to spread-construct in tests
+mod tests {
+    use super::*;
+
+    #[test]
+    fn jitter_display_uses_rolling_window_while_running() {
+        let mut app = App::default();
+        app.state = AppState::Running;
+        // Simulate 3 per-second jitter samples: 2, 4, 6 ms → mean 4.0.
+        app.udp_jitter_ms = 6.0; // last sample, what a non-smoothed UI would show
+        app.jitter_history.extend([2.0, 4.0, 6.0]);
+
+        let (value, label) = app.jitter_display();
+        assert_eq!(label, "Jitter (10s): ");
+        assert!(
+            (value - 4.0).abs() < f64::EPSILON,
+            "expected rolling mean 4.0, got {value}"
+        );
+    }
+
+    #[test]
+    fn jitter_display_uses_authoritative_final_on_complete() {
+        let mut app = App::default();
+        // Run-level final jitter from the server (via on_result) is different
+        // from whatever the last 10s of progress samples averaged to — the
+        // completed screen must show the authoritative final, not the tail.
+        app.state = AppState::Completed;
+        app.udp_jitter_ms = 1.23;
+        app.jitter_history.extend([9.9, 9.9, 9.9]); // stale tail samples
+
+        let (value, label) = app.jitter_display();
+        assert_eq!(label, "Jitter:       ");
+        assert!(
+            (value - 1.23).abs() < f64::EPSILON,
+            "expected authoritative 1.23, got {value}"
+        );
+    }
+
+    #[test]
+    fn avg_jitter_ms_is_zero_with_no_samples() {
+        let app = App::default();
+        assert_eq!(app.avg_jitter_ms(), 0.0);
     }
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -11,6 +11,10 @@ use super::theme::Theme;
 
 const SPARKLINE_HISTORY: usize = 60;
 const LOG_HISTORY: usize = 100;
+// Rolling window for aggregate jitter display. Progress events fire at 1Hz,
+// so 10 samples ≈ 10s smoothing window — long enough to damp per-second
+// noise, short enough to still track real network changes.
+const JITTER_HISTORY_SAMPLES: usize = 10;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AppState {
@@ -49,6 +53,9 @@ pub struct App {
     pub total_bytes: u64,
     pub current_throughput_mbps: f64,
     pub throughput_history: VecDeque<f64>,
+    // Rolling history of aggregate jitter samples so the TUI can show a
+    // smoothed reading instead of the noisy per-second snapshot.
+    pub jitter_history: VecDeque<f64>,
     pub streams: Vec<StreamData>,
 
     // Bidirectional split stats (populated from AggregateInterval/TestResult
@@ -123,6 +130,7 @@ impl App {
             total_bytes: 0,
             current_throughput_mbps: 0.0,
             throughput_history: VecDeque::with_capacity(SPARKLINE_HISTORY),
+            jitter_history: VecDeque::with_capacity(JITTER_HISTORY_SAMPLES),
             bidir_bytes_sent: 0,
             bidir_bytes_received: 0,
             throughput_send_mbps: 0.0,
@@ -326,9 +334,14 @@ impl App {
             self.cwnd = cwnd;
         }
 
-        // Update UDP stats (average jitter across streams)
+        // Update UDP stats (average jitter across streams) and push to the
+        // rolling window so the stats panel can display a smoothed value.
         if jitter_count > 0 {
             self.udp_jitter_ms = total_jitter / jitter_count as f64;
+            self.jitter_history.push_back(self.udp_jitter_ms);
+            if self.jitter_history.len() > JITTER_HISTORY_SAMPLES {
+                self.jitter_history.pop_front();
+            }
         }
         self.udp_packets_lost = total_lost;
 
@@ -468,6 +481,16 @@ impl App {
             .iter()
             .cloned()
             .fold(0.0f64, f64::max)
+    }
+
+    /// Mean of the last ~10s of jitter samples. Returns 0.0 before any
+    /// samples have arrived (very early in the test or non-UDP runs).
+    pub fn avg_jitter_ms(&self) -> f64 {
+        if self.jitter_history.is_empty() {
+            0.0
+        } else {
+            self.jitter_history.iter().sum::<f64>() / self.jitter_history.len() as f64
+        }
     }
 }
 

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -341,15 +341,10 @@ fn draw_realtime_stats(frame: &mut Frame, app: &App, theme: &Theme, area: Rect) 
 
     // Right side: Jitter/Loss for UDP, RTT/Retrans for TCP
     let quality_lines = if app.protocol == crate::protocol::Protocol::Udp {
-        // While running, use a 10s rolling average so the reading doesn't jump
-        // around on inherently noisy per-second samples (issue #48). Once the
-        // test has completed, switch to the authoritative final run-level
-        // jitter from the server (set in App::on_result).
-        let (jitter_val, jitter_label) = if app.state == crate::tui::app::AppState::Completed {
-            (app.udp_jitter_ms, "Jitter:       ")
-        } else {
-            (app.avg_jitter_ms(), "Jitter (10s): ")
-        };
+        // Rolling 10s average while running, authoritative final value once
+        // completed — picked by App::jitter_display() so the state transition
+        // is covered by unit tests instead of only by inspection (issue #48).
+        let (jitter_val, jitter_label) = app.jitter_display();
         let jitter_col = jitter_color(jitter_val, theme);
         let loss_col = loss_color(app.udp_lost_percent, theme);
         vec![

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -341,14 +341,20 @@ fn draw_realtime_stats(frame: &mut Frame, app: &App, theme: &Theme, area: Rect) 
 
     // Right side: Jitter/Loss for UDP, RTT/Retrans for TCP
     let quality_lines = if app.protocol == crate::protocol::Protocol::Udp {
-        // Use a rolling 10s average so the reading doesn't jump around on
-        // inherently noisy per-second jitter snapshots (issue #48).
-        let jitter_val = app.avg_jitter_ms();
+        // While running, use a 10s rolling average so the reading doesn't jump
+        // around on inherently noisy per-second samples (issue #48). Once the
+        // test has completed, switch to the authoritative final run-level
+        // jitter from the server (set in App::on_result).
+        let (jitter_val, jitter_label) = if app.state == crate::tui::app::AppState::Completed {
+            (app.udp_jitter_ms, "Jitter:       ")
+        } else {
+            (app.avg_jitter_ms(), "Jitter (10s): ")
+        };
         let jitter_col = jitter_color(jitter_val, theme);
         let loss_col = loss_color(app.udp_lost_percent, theme);
         vec![
             Line::from(vec![
-                Span::styled("Jitter (10s): ", Style::default().fg(theme.text_dim)),
+                Span::styled(jitter_label, Style::default().fg(theme.text_dim)),
                 Span::styled(
                     format!("{:.2} ms", jitter_val),
                     Style::default().fg(jitter_col),

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -341,13 +341,16 @@ fn draw_realtime_stats(frame: &mut Frame, app: &App, theme: &Theme, area: Rect) 
 
     // Right side: Jitter/Loss for UDP, RTT/Retrans for TCP
     let quality_lines = if app.protocol == crate::protocol::Protocol::Udp {
-        let jitter_col = jitter_color(app.udp_jitter_ms, theme);
+        // Use a rolling 10s average so the reading doesn't jump around on
+        // inherently noisy per-second jitter snapshots (issue #48).
+        let jitter_val = app.avg_jitter_ms();
+        let jitter_col = jitter_color(jitter_val, theme);
         let loss_col = loss_color(app.udp_lost_percent, theme);
         vec![
             Line::from(vec![
-                Span::styled("Jitter:       ", Style::default().fg(theme.text_dim)),
+                Span::styled("Jitter (10s): ", Style::default().fg(theme.text_dim)),
                 Span::styled(
-                    format!("{:.2} ms", app.udp_jitter_ms),
+                    format!("{:.2} ms", jitter_val),
                     Style::default().fg(jitter_col),
                 ),
             ]),

--- a/src/udp.rs
+++ b/src/udp.rs
@@ -543,6 +543,42 @@ mod tests {
     }
 
     #[test]
+    fn test_jitter_max_tracks_peak_not_current() {
+        let mut calc = JitterCalculator::new();
+        let start = Instant::now();
+
+        // Prime with two in-sync samples so the running jitter starts at zero.
+        calc.update(0, start);
+        calc.update(1000, start + Duration::from_micros(1000));
+        assert_eq!(calc.jitter_max_ms(), 0.0);
+
+        // Introduce a single large timing delta (recv arrives 10ms late).
+        calc.update(2000, start + Duration::from_micros(12_000));
+        let peak = calc.jitter_max_ms();
+        assert!(peak > 0.0, "non-trivial delta should set a max");
+
+        // Continue with *in-sync* samples (send delta == recv delta) so
+        // |D| is zero and the running jitter decays by 15/16 each step.
+        // jitter_ms should drop below peak, but jitter_max_ms must stick.
+        let mut send_us: u64 = 3000;
+        let mut recv_us: u64 = 13_000;
+        for _ in 0..20 {
+            calc.update(send_us, start + Duration::from_micros(recv_us));
+            send_us += 1000;
+            recv_us += 1000;
+        }
+        assert!(
+            calc.jitter_ms() < peak,
+            "running jitter should decay below peak when timing is in sync again"
+        );
+        assert_eq!(
+            calc.jitter_max_ms(),
+            peak,
+            "jitter_max must retain the prior peak, not track the current value"
+        );
+    }
+
+    #[test]
     fn test_packet_tracker() {
         let mut tracker = PacketTracker::new();
 

--- a/src/udp.rs
+++ b/src/udp.rs
@@ -64,6 +64,7 @@ pub struct JitterCalculator {
     last_send_time: Option<u64>,
     last_recv_time: Option<Instant>,
     jitter: f64,
+    jitter_max: f64,
 }
 
 impl JitterCalculator {
@@ -72,6 +73,7 @@ impl JitterCalculator {
             last_send_time: None,
             last_recv_time: None,
             jitter: 0.0,
+            jitter_max: 0.0,
         }
     }
 
@@ -85,6 +87,9 @@ impl JitterCalculator {
             let d = (recv_diff - send_diff).abs() as f64;
 
             self.jitter += (d - self.jitter) / 16.0;
+            if self.jitter > self.jitter_max {
+                self.jitter_max = self.jitter;
+            }
         }
 
         self.last_send_time = Some(send_time_us);
@@ -94,6 +99,10 @@ impl JitterCalculator {
 
     pub fn jitter_ms(&self) -> f64 {
         self.jitter / 1000.0
+    }
+
+    pub fn jitter_max_ms(&self) -> f64 {
+        self.jitter_max / 1000.0
     }
 }
 
@@ -472,6 +481,8 @@ pub async fn receive_udp(
             lost_percent: loss_percent,
             jitter_ms: jitter_calc.jitter_ms(),
             out_of_order,
+            jitter_max_ms: Some(jitter_calc.jitter_max_ms()),
+            packet_size: Some(UDP_PAYLOAD_SIZE as u32),
         },
         packets_sent,
     ))


### PR DESCRIPTION
## Summary
Resolves #48. vanderoest reported the TUI jitter reading was too noisy (updating every second when they set `-i 10` expecting smoothing); brettowe seconded the ask. Per-second jitter samples are inherently noisy — this adds a 10-sample rolling window average on the aggregate display.

## Changes
- `src/tui/app.rs`: `jitter_history: VecDeque<f64>` (capacity 10) + `avg_jitter_ms()` helper; pushed in `on_progress()`
- `src/tui/ui.rs`: stats panel uses averaged value; label updated from `Jitter:` → `Jitter (10s):` so users know it's a rolling mean

## Out of scope
- Per-stream jitter bars (already less noisy; changing them would need per-stream history state)
- Packet loss smoothing (`udp_lost_percent` only updates in `on_result()`, already static during the run)
- Configurable window (YAGNI — 10s is a reasonable default; add a flag later if users ask)

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-features --all-targets -- -D warnings`
- [x] `cargo test --all-features` — all 186 tests pass (no new logic complex enough to warrant its own test — mean over VecDeque)