### PR TITLE
Accept bare integers as seconds for duration arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Max jitter and packet size in UDP summary** (issue #48 follow-up) — the final UDP summary now reports `Jitter Max` (peak of the RFC 3550 running estimate across the test) alongside the average, and `Packet Size` (UDP payload bytes). Surfaced in plain text and JSON. Requested by brettowe for NFS UDP packet-size tuning context.
 
 ### Changed
+- **Bare-integer duration arguments mean seconds** (issue #61) — `-t 10`, `--max-duration 60`, `--rate-limit-window 30`, and discover `--timeout 5` now accept plain integers as seconds, matching iperf3 muscle memory. Unit-suffixed forms (`10s`, `1min`, `500ms`) continue to work unchanged.
 - **Smoothed TUI jitter reading** (issue #48) — the UDP stats panel now shows jitter averaged over a 10-second rolling window rather than the raw per-second sample. The data pipeline is unchanged (samples still arrive every second from the server); only the aggregate display is smoothed. Per-stream jitter in the streams view continues to show the latest interval. While the test is running, the label shows `Jitter (10s):`; once completed, it reverts to `Jitter:` with the authoritative final value from the server's result.
 
 ## [0.9.8] - 2026-04-17

--- a/src/main.rs
+++ b/src/main.rs
@@ -340,7 +340,7 @@ enum Commands {
         rate_limit: Option<u32>,
 
         /// Rate limit time window
-        #[arg(long, default_value = "60s", value_parser = parse_duration)]
+        #[arg(long, default_value = "60s", value_parser = parse_nonzero_duration)]
         rate_limit_window: Duration,
 
         /// Allow IP/subnet (can be repeated)
@@ -400,6 +400,17 @@ fn parse_duration(s: &str) -> Result<Duration, String> {
         return Ok(Duration::from_secs(secs));
     }
     humantime::parse_duration(s).map_err(|e| e.to_string())
+}
+
+/// Duration parser that rejects zero. For flags where zero is not a valid
+/// sentinel (e.g. `--rate-limit-window`, which would divide-by-zero the
+/// cleanup-task interval in `tokio::time::interval`).
+fn parse_nonzero_duration(s: &str) -> Result<Duration, String> {
+    let d = parse_duration(s)?;
+    if d.is_zero() {
+        return Err("Duration must be greater than 0".to_string());
+    }
+    Ok(d)
 }
 
 fn parse_test_duration(s: &str) -> Result<Duration, String> {
@@ -1858,6 +1869,30 @@ mod tests {
         assert!(parse_duration("abc").is_err());
         assert!(parse_duration("10q").is_err()); // unknown unit
         assert!(parse_duration("").is_err());
+    }
+
+    #[test]
+    fn test_parse_nonzero_duration_rejects_zero_variants() {
+        // Bare-integer 0 and any unit-suffixed zero must fail — the rate-limit
+        // cleanup task uses `window / 2` as a tokio::time::interval which
+        // panics on Duration::ZERO.
+        assert!(parse_nonzero_duration("0").is_err());
+        assert!(parse_nonzero_duration("0s").is_err());
+        assert!(parse_nonzero_duration("0ms").is_err());
+
+        // Non-zero values still parse the same as parse_duration.
+        assert_eq!(parse_nonzero_duration("1").unwrap(), Duration::from_secs(1));
+        assert_eq!(
+            parse_nonzero_duration("60s").unwrap(),
+            Duration::from_secs(60)
+        );
+        assert_eq!(
+            parse_nonzero_duration("500ms").unwrap(),
+            Duration::from_millis(500)
+        );
+
+        // Garbage still fails.
+        assert!(parse_nonzero_duration("abc").is_err());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -394,11 +394,16 @@ enum Commands {
 }
 
 fn parse_duration(s: &str) -> Result<Duration, String> {
+    // Accept bare integers as seconds (iperf-style muscle memory: `-t 10`).
+    // Fall back to humantime for unit-suffixed strings like "10s", "1min".
+    if let Ok(secs) = s.parse::<u64>() {
+        return Ok(Duration::from_secs(secs));
+    }
     humantime::parse_duration(s).map_err(|e| e.to_string())
 }
 
 fn parse_test_duration(s: &str) -> Result<Duration, String> {
-    let duration = humantime::parse_duration(s).map_err(|e| e.to_string())?;
+    let duration = parse_duration(s)?;
     // Allow 0 for infinite duration, otherwise require at least 1 second
     if duration == Duration::ZERO {
         return Ok(Duration::ZERO);
@@ -1824,6 +1829,35 @@ mod tests {
 
         // Sub-second (but not zero) should fail
         assert!(parse_test_duration("500ms").is_err());
+    }
+
+    #[test]
+    fn test_parse_duration_bare_integer_is_seconds() {
+        // iperf3 muscle memory: `-t 10` should mean 10 seconds.
+        assert_eq!(parse_duration("10").unwrap(), Duration::from_secs(10));
+        assert_eq!(parse_duration("1").unwrap(), Duration::from_secs(1));
+        assert_eq!(parse_duration("0").unwrap(), Duration::ZERO);
+        assert_eq!(parse_duration("3600").unwrap(), Duration::from_secs(3600));
+
+        // Unit-suffixed forms continue to work unchanged.
+        assert_eq!(parse_duration("10s").unwrap(), Duration::from_secs(10));
+        assert_eq!(parse_duration("1min").unwrap(), Duration::from_secs(60));
+        assert_eq!(parse_duration("500ms").unwrap(), Duration::from_millis(500));
+    }
+
+    #[test]
+    fn test_parse_test_duration_bare_integer_is_seconds() {
+        // Bare-int path must also apply the >= 1s minimum rule.
+        assert_eq!(parse_test_duration("10").unwrap(), Duration::from_secs(10));
+        assert_eq!(parse_test_duration("1").unwrap(), Duration::from_secs(1));
+        assert_eq!(parse_test_duration("0").unwrap(), Duration::ZERO);
+    }
+
+    #[test]
+    fn test_parse_duration_rejects_garbage() {
+        assert!(parse_duration("abc").is_err());
+        assert!(parse_duration("10q").is_err()); // unknown unit
+        assert!(parse_duration("").is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Addresses #61. `-t 10` now works and means 10 seconds (matching iperf3). Unit-suffixed forms (`10s`, `1min`, `500ms`) continue to work unchanged.

## Change

`parse_duration` tries `u64::from_str` first; on failure it falls back to `humantime::parse_duration`. `parse_test_duration` now wraps `parse_duration` so the existing `>= 1s` minimum-test-duration rule still fires for both forms (bare integer `1` = 1s; `0` = infinite; `500ms` still rejected).

Applies consistently to every duration-parsed flag: `-t`, `--max-duration`, `--rate-limit-window`, and `discover --timeout`.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-features --all-targets -- -D warnings`
- [x] `cargo test --all-features` (195 tests)
- [x] Three new unit tests: bare-int parsing, bare-int min-duration interaction, garbage rejection
- [x] Smoke test: `xfr 127.0.0.1 -t 3` (bare integer) ran 3s cleanly against a local server
- [x] Back-compat: `-t 10s`, `-t 1min`, `-t 500ms` still parse as before (tested explicitly)