### PR TITLE
Default to kernel TCP autotuning; add -w short alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Smoothed TUI jitter reading** (issue #48) — the UDP stats panel now shows jitter averaged over a 10-second rolling window rather than the raw per-second sample. The data pipeline is unchanged (samples still arrive every second from the server); only the aggregate display is smoothed. Per-stream jitter in the streams view continues to show the latest interval. While the test is running, the label shows `Jitter (10s):`; once completed, it reverts to `Jitter:` with the authoritative final value from the server's result.
 
 ### Fixed
-- **Default to kernel TCP autotuning** (issue #60) — xfr no longer forces `SO_SNDBUF`/`SO_RCVBUF` to 4 MB on either side by default; both ends let the kernel autotune unless the user passes `-w`/`--window`. When set, the client's value propagates to the server over the control protocol so both sides setsockopt symmetrically (matching iperf3). Loopback / intra-host benchmark numbers may decrease by roughly 10% as a result — this is expected; the previous numbers were inflated by the oversized app-applied buffer. Reported by @matttbe.
+- **Default to kernel TCP autotuning** (issue #60) — xfr no longer forces `SO_SNDBUF`/`SO_RCVBUF` to 4 MB on either side by default; both ends let the kernel autotune unless the user passes `-w`/`--window`. When set, the client's value propagates to the server over the control protocol so both sides apply the socket option symmetrically (matching iperf3). Reported by @matttbe.
+
+  Caveats:
+  - Loopback / intra-host benchmark numbers may decrease by roughly 10% — this is expected; the previous numbers were inflated by the oversized app-applied buffer.
+  - On high-RTT paths, very short tests (e.g. `-t 1s` at high bitrate) may now show ramp-up-limited throughput in the final summary because kernel autotune takes a handful of RTTs to grow the window. Use a longer `-t`, or pass an explicit `-w` to skip autotune. Note that `-O`/`--omit` only hides the early intervals from output — the server-side final summary is still computed over the full test duration.
+  - Explicit window sizes above `c_int::MAX` (≈2.1 GB on 64-bit) are now rejected with `InvalidInput` instead of silently wrapping before `setsockopt`.
 
 ## [0.9.8] - 2026-04-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **Max jitter and packet size in UDP summary** (issue #48 follow-up) — the final UDP summary now reports `Jitter Max` (peak of the RFC 3550 running estimate across the test) alongside the average, and `Packet Size` (UDP payload bytes). Surfaced in plain text and JSON. Requested by brettowe for NFS UDP packet-size tuning context.
+- **`-w` short alias for `--window`** (issue #60) — matches iperf3 muscle memory.
 
 ### Changed
 - **Smoothed TUI jitter reading** (issue #48) — the UDP stats panel now shows jitter averaged over a 10-second rolling window rather than the raw per-second sample. The data pipeline is unchanged (samples still arrive every second from the server); only the aggregate display is smoothed. Per-stream jitter in the streams view continues to show the latest interval. While the test is running, the label shows `Jitter (10s):`; once completed, it reverts to `Jitter:` with the authoritative final value from the server's result.
+
+### Fixed
+- **Default to kernel TCP autotuning** (issue #60) — xfr no longer forces `SO_SNDBUF`/`SO_RCVBUF` to 4 MB on either side by default; both ends let the kernel autotune unless the user passes `-w`/`--window`. When set, the client's value propagates to the server over the control protocol so both sides setsockopt symmetrically (matching iperf3). Loopback / intra-host benchmark numbers may decrease by roughly 10% as a result — this is expected; the previous numbers were inflated by the oversized app-applied buffer. Reported by @matttbe.
 
 ## [0.9.8] - 2026-04-17
 

--- a/README.md
+++ b/README.md
@@ -520,15 +520,15 @@ xfr <host> -Q --psk "secretkey"
 
 ### Server Resource Usage
 
-Each stream allocates 128KB-4MB for buffers depending on speed mode. Memory usage scales with concurrent clients:
+Each TCP stream allocates a 128 KB application read/write buffer. Kernel socket buffers are managed by TCP autotuning unless the client passes `-w`/`--window`, in which case the requested size is applied via `SO_SNDBUF`/`SO_RCVBUF` on both ends. Memory usage scales with concurrent clients:
 
-| Streams per client | Memory per client | 10 clients |
-|-------------------|-------------------|------------|
-| 1 (`-P 1`) | 128KB - 4MB | 1.3MB - 40MB |
-| 8 (`-P 8`) | 1MB - 32MB | 10MB - 320MB |
-| 128 (`-P 128`) | 16MB - 512MB | 160MB - 5GB |
+| Streams per client | App buffer per client | 10 clients (app buffers) |
+|-------------------|-----------------------|--------------------------|
+| 1 (`-P 1`) | 128 KB | 1.3 MB |
+| 8 (`-P 8`) | 1 MB | 10 MB |
+| 128 (`-P 128`) | 16 MB | 160 MB |
 
-The server limits concurrent handlers (default 100) to prevent resource exhaustion. Use `--rate-limit` to restrict tests per IP.
+On top of that, the kernel holds autotuned socket buffers (typically a few hundred KB per stream, capped by `net.ipv4.tcp_rmem[2]`/`tcp_wmem[2]`). When a client passes `-w N`, add roughly `N` bytes per stream on each side. The server limits concurrent handlers (default 100) to prevent resource exhaustion. Use `--rate-limit` to restrict tests per IP.
 
 ## Platform Support
 

--- a/benches/throughput.rs
+++ b/benches/throughput.rs
@@ -124,6 +124,7 @@ fn bench_protocol_serialize_test_start(c: &mut Criterion) {
         congestion: None,
         mptcp: false,
         dscp: None,
+        window_size: None,
     };
 
     c.bench_function("protocol_serialize_test_start", |b| {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -134,7 +134,7 @@ routing is needed since the port uniquely identifies the stream.
 
 ### Data Transfer
 
-**TCP**: Bulk send/receive with large buffers (128KB default, 4MB for high-speed mode). Supports optional bitrate pacing via `-b` using a byte-budget sleep approach with interruptible sleeps.
+**TCP**: Bulk send/receive with a 128 KB application read/write buffer. Kernel socket buffers (`SO_SNDBUF`/`SO_RCVBUF`) are left at kernel autotuning defaults unless the user passes `-w`/`--window`, in which case the value propagates to the server over the control protocol and both ends apply it symmetrically. Supports optional bitrate pacing via `-b` using a byte-budget sleep approach with interruptible sleeps.
 
 **UDP**: Paced sending with sequence numbers for loss detection:
 ```
@@ -335,19 +335,21 @@ The `--congestion` algorithm is validated early, before any streams are spawned:
 
 ### Socket Buffers
 
-Large buffers are used for high throughput:
+By default, xfr leaves kernel TCP autotuning in charge of `SO_SNDBUF`/`SO_RCVBUF`. The only buffer xfr allocates itself is a 128 KB application-level `Vec<u8>` used for each `read()`/`write()` syscall.
+
+If the user passes `-w`/`--window`, the value propagates over the control protocol and both client and server apply it via `setsockopt(SO_SNDBUF/SO_RCVBUF)`:
 
 ```rust
-// TCP (default, auto-bumps to 4MB when no bitrate limit set)
-socket.set_send_buffer_size(131072)?;   // 128KB
-socket.set_recv_buffer_size(131072)?;
+// Without -w: nothing applied; kernel autotune handles SNDBUF/RCVBUF.
 
-// UDP (larger for burst tolerance)
-socket.set_send_buffer_size(4194304)?;  // 4MB
-socket.set_recv_buffer_size(4194304)?;
+// With -w 256K: applied on both sides after connect/accept.
+setsockopt(fd, SOL_SOCKET, SO_SNDBUF, 262144)?;
+setsockopt(fd, SOL_SOCKET, SO_RCVBUF, 262144)?;
 ```
 
-**Memory footprint:** Each stream allocates 128KB-4MB for buffers. A test with `-P 8` uses ~1-32MB; 10 concurrent clients with 8 streams each could use 80-320MB.
+UDP does not apply any `SO_SNDBUF`/`SO_RCVBUF` override.
+
+**Memory footprint:** Each TCP stream allocates the 128 KB application buffer plus whatever the kernel decides for the socket buffer (typically a few hundred KB autotuned, more if the user set `-w`). A test with `-P 8` at default settings is on the order of ~2-8 MB; high-BDP paths where the user passes `-w 16M` will use proportionally more.
 
 ## Error Handling
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -312,6 +312,7 @@ impl Client {
             congestion: self.config.tcp_congestion.clone(),
             mptcp: self.config.mptcp,
             dscp: self.config.dscp,
+            window_size: self.config.window_size.map(|w| w as u64),
         };
         writer
             .write_all(format!("{}\n", test_start.serialize()?).as_bytes())
@@ -681,13 +682,13 @@ impl Client {
             let stream_index = i as u16;
             let handshake_limiter = handshake_limiter.clone();
 
-            let mut config = TcpConfig::with_auto_detect(
-                self.config.tcp_nodelay,
-                self.config.window_size,
-                self.config.bitrate,
-            );
-            config.congestion = self.config.tcp_congestion.clone();
-            config.random_payload = self.config.random_payload;
+            let config = TcpConfig {
+                nodelay: self.config.tcp_nodelay,
+                window_size: self.config.window_size,
+                congestion: self.config.tcp_congestion.clone(),
+                random_payload: self.config.random_payload,
+                ..Default::default()
+            };
 
             handles.push(tokio::spawn(async move {
                 // In single-port mode, limit concurrent connect+DataHello handshakes
@@ -1140,7 +1141,8 @@ impl Client {
             bitrate: self.config.bitrate,
             congestion: None,
             mptcp: false,
-            dscp: None, // QUIC manages its own TOS via the transport layer
+            dscp: None,        // QUIC manages its own TOS via the transport layer
+            window_size: None, // QUIC flow control is handled at the transport layer
         };
         ctrl_send
             .write_all(format!("{}\n", test_start.serialize()?).as_bytes())

--- a/src/main.rs
+++ b/src/main.rs
@@ -236,8 +236,8 @@ struct Cli {
     #[arg(long, value_name = "VALUE")]
     dscp: Option<String>,
 
-    /// TCP window size (e.g., 512K, 1M)
-    #[arg(long, value_parser = parse_size)]
+    /// TCP window size (e.g., 512K, 1M). When unset, the kernel autotunes.
+    #[arg(short = 'w', long, value_parser = parse_size)]
     window: Option<usize>,
 
     /// Timestamp format for interval output (relative, iso8601, unix)

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -105,6 +105,11 @@ pub enum ControlMessage {
         /// DSCP/TOS byte for QoS marking on server-side sockets (download/bidir)
         #[serde(default, skip_serializing_if = "Option::is_none")]
         dscp: Option<u8>,
+        /// SO_SNDBUF/SO_RCVBUF size requested by the client (iperf-style `-w`).
+        /// When absent, the server leaves kernel autotuning enabled. `u64` so
+        /// that large values like `-w 4G` round-trip without silent truncation.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        window_size: Option<u64>,
     },
     TestAck {
         id: String,
@@ -474,6 +479,7 @@ mod tests {
             congestion: None,
             mptcp: false,
             dscp: None,
+            window_size: None,
         };
         let json = msg.serialize().unwrap();
         let decoded = ControlMessage::deserialize(&json).unwrap();
@@ -485,6 +491,103 @@ mod tests {
             }
             _ => panic!("wrong message type"),
         }
+    }
+
+    #[test]
+    fn test_test_start_backward_compat_without_window_size() {
+        // Simulate an older client that doesn't know about window_size: the JSON
+        // omits the field entirely. The new server must deserialize it as None
+        // and fall back to kernel autotuning.
+        let json = r#"{"type":"test_start","id":"x","protocol":"tcp","streams":1,"duration_secs":5,"direction":"upload"}"#;
+        let decoded = ControlMessage::deserialize(json).unwrap();
+        match decoded {
+            ControlMessage::TestStart {
+                window_size, dscp, ..
+            } => {
+                assert!(
+                    window_size.is_none(),
+                    "absent field must deserialize to None"
+                );
+                assert!(dscp.is_none(), "sanity: dscp also absent");
+            }
+            _ => panic!("wrong message type"),
+        }
+    }
+
+    #[test]
+    fn test_test_start_roundtrip_with_window_size() {
+        let msg = ControlMessage::TestStart {
+            id: "x".to_string(),
+            protocol: Protocol::Tcp,
+            streams: 1,
+            duration_secs: 5,
+            direction: Direction::Upload,
+            bitrate: None,
+            congestion: None,
+            mptcp: false,
+            dscp: None,
+            window_size: Some(262_144),
+        };
+        let json = msg.serialize().unwrap();
+        assert!(json.contains("\"window_size\":262144"));
+        let decoded = ControlMessage::deserialize(&json).unwrap();
+        match decoded {
+            ControlMessage::TestStart { window_size, .. } => {
+                assert_eq!(window_size, Some(262_144));
+            }
+            _ => panic!("wrong message type"),
+        }
+    }
+
+    #[test]
+    fn test_test_start_window_size_above_u32_max_roundtrips() {
+        // u64 wire type must round-trip values that would silently truncate in
+        // u32 (e.g. `-w 4G` on a 64-bit client becomes 4_294_967_296 = u32::MAX+1).
+        let big = u32::MAX as u64 + 1;
+        let msg = ControlMessage::TestStart {
+            id: "x".to_string(),
+            protocol: Protocol::Tcp,
+            streams: 1,
+            duration_secs: 5,
+            direction: Direction::Upload,
+            bitrate: None,
+            congestion: None,
+            mptcp: false,
+            dscp: None,
+            window_size: Some(big),
+        };
+        let json = msg.serialize().unwrap();
+        let decoded = ControlMessage::deserialize(&json).unwrap();
+        match decoded {
+            ControlMessage::TestStart { window_size, .. } => {
+                assert_eq!(window_size, Some(big));
+            }
+            _ => panic!("wrong message type"),
+        }
+    }
+
+    #[test]
+    fn test_test_start_serialize_omits_none_window_size() {
+        // skip_serializing_if = Option::is_none must keep the field out of the
+        // JSON entirely when None, so older deserializers don't fail on it.
+        let msg = ControlMessage::TestStart {
+            id: "x".to_string(),
+            protocol: Protocol::Tcp,
+            streams: 1,
+            duration_secs: 5,
+            direction: Direction::Upload,
+            bitrate: None,
+            congestion: None,
+            mptcp: false,
+            dscp: None,
+            window_size: None,
+        };
+        let json = msg.serialize().unwrap();
+        assert!(
+            !json.contains("window_size"),
+            "None must be skipped in serialization, got: {}",
+            json
+        );
     }
 
     #[test]

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -1225,6 +1225,7 @@ async fn handle_test_request(
             congestion,
             mptcp,
             dscp,
+            window_size,
         } => {
             // Validate stream count
             if streams == 0 || streams > MAX_STREAMS {
@@ -1324,6 +1325,7 @@ async fn handle_test_request(
                 &security.push_gateway_url,
                 client_supports_single_port,
                 dscp,
+                window_size,
             )
             .await;
 
@@ -1702,6 +1704,7 @@ async fn run_test(
     push_gateway_url: &Option<String>,
     client_supports_single_port: bool,
     dscp: Option<u8>,
+    client_window_size: Option<u64>,
 ) -> anyhow::Result<(u64, u64, f64)> {
     let mut line = String::new();
 
@@ -1861,6 +1864,7 @@ async fn run_test(
                         bitrate,
                         pause_clone,
                         dscp,
+                        client_window_size,
                     )
                     .await
                 });
@@ -2122,6 +2126,7 @@ async fn spawn_tcp_handlers(
     congestion: Option<String>,
     bitrate: Option<u64>,
     pause: watch::Receiver<bool>,
+    client_window_size: Option<u64>,
 ) -> Vec<JoinHandle<()>> {
     let num_streams = listeners.len().max(1) as u64;
     let per_stream_bitrate = bitrate.map(|b| if b == 0 { 0 } else { (b / num_streams).max(1) });
@@ -2151,10 +2156,15 @@ async fn spawn_tcp_handlers(
                 }
             };
 
-            // Use high-speed config for server - we want maximum throughput
-            let mut config = TcpConfig::high_speed();
-            config.congestion = congestion.clone();
-            config.random_payload = true;
+            // Respect the client's window_size if they passed -w; otherwise leave
+            // kernel autotuning alone. Keep nodelay on to match historical behavior.
+            let config = TcpConfig {
+                nodelay: true,
+                window_size: client_window_size.map(|w| w as usize),
+                congestion: congestion.clone(),
+                random_payload: true,
+                ..Default::default()
+            };
 
             // Store fd for TCP_INFO interval polling
             #[cfg(unix)]
@@ -2277,6 +2287,7 @@ async fn spawn_tcp_stream_handlers(
     bitrate: Option<u64>,
     pause: watch::Receiver<bool>,
     dscp: Option<u8>,
+    client_window_size: Option<u64>,
 ) -> Vec<JoinHandle<()>> {
     let per_stream_bitrate = bitrate.map(|b| {
         if b == 0 {
@@ -2343,9 +2354,13 @@ async fn spawn_tcp_stream_handlers(
 
                 let congestion = congestion.clone();
                 let handle = tokio::spawn(async move {
-                    let mut config = TcpConfig::high_speed();
-                    config.congestion = congestion;
-                    config.random_payload = true;
+                    let config = TcpConfig {
+                        nodelay: true,
+                        window_size: client_window_size.map(|w| w as usize),
+                        congestion,
+                        random_payload: true,
+                        ..Default::default()
+                    };
 
                     // Store fd for TCP_INFO interval polling
                     #[cfg(unix)]

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -105,8 +105,28 @@ fn configure_socket_buffers(stream: &TcpStream, buffer_size: usize) -> std::io::
     use std::os::unix::io::AsRawFd;
     use tracing::debug;
 
+    // setsockopt SO_SNDBUF/SO_RCVBUF takes a `c_int`. On 64-bit Unix that's i32,
+    // so reject out-of-range requests up front — otherwise `as c_int` would wrap
+    // to garbage (or worse, a negative value) and the kernel would reject or
+    // misapply the request with only a debug-level log of the fallout.
+    let size = libc::c_int::try_from(buffer_size).map_err(|_| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!(
+                "window size {} exceeds platform maximum ({} bytes)",
+                buffer_size,
+                libc::c_int::MAX
+            ),
+        )
+    })?;
+    if size <= 0 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "window size must be greater than zero",
+        ));
+    }
+
     let fd = stream.as_raw_fd();
-    let size = buffer_size as libc::c_int;
 
     // SAFETY: fd is a valid file descriptor from stream.as_raw_fd(),
     // size is a valid c_int pointer, and size_of::<c_int>() is correct.
@@ -791,6 +811,34 @@ mod tests {
             config.window_size.is_none(),
             "default must not force SO_SNDBUF/SO_RCVBUF — leave it to the kernel"
         );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_configure_socket_buffers_rejects_values_above_c_int_max() {
+        // The wire protocol allows window_size up to u64::MAX. If a caller
+        // lets that value reach setsockopt, `as c_int` would wrap silently.
+        // Any value above c_int::MAX must surface as an InvalidInput error
+        // rather than being quietly misapplied.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let connect = tokio::net::TcpStream::connect(addr);
+        let accept = listener.accept();
+        let (client, _server) = tokio::join!(connect, accept);
+        let client = client.unwrap();
+
+        let huge = libc::c_int::MAX as usize + 1;
+        let err = configure_socket_buffers(&client, huge).expect_err("expected error");
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+        let msg = err.to_string();
+        assert!(
+            msg.contains("exceeds platform maximum"),
+            "unexpected error message: {msg}"
+        );
+
+        // Zero is not a sensible window either.
+        let err = configure_socket_buffers(&client, 0).expect_err("expected error");
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
     }
 
     #[test]

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -16,7 +16,6 @@ use crate::stats::StreamStats;
 use crate::tcp_info::get_tcp_info;
 
 const DEFAULT_BUFFER_SIZE: usize = 128 * 1024; // 128 KB
-const HIGH_SPEED_BUFFER: usize = 4 * 1024 * 1024; // 4 MB for 10G+
 const SEND_TEARDOWN_GRACE: Duration = Duration::from_millis(250);
 // Post-cancel read window: covers the race where our receive side signals
 // cancel and drops the socket before the peer's own cancel_tx has fired
@@ -97,53 +96,6 @@ impl Default for TcpConfig {
             window_size: None,
             congestion: None,
             random_payload: false,
-        }
-    }
-}
-
-/// Threshold for auto-selecting high-speed configuration (1 MB)
-const HIGH_SPEED_WINDOW_THRESHOLD: usize = 1_000_000;
-
-impl TcpConfig {
-    pub fn high_speed() -> Self {
-        Self {
-            buffer_size: HIGH_SPEED_BUFFER,
-            nodelay: true,
-            window_size: Some(HIGH_SPEED_BUFFER),
-            congestion: None,
-            random_payload: false,
-        }
-    }
-
-    /// Create a config with auto-detection for high-speed mode.
-    /// Selects high_speed() when window_size > 1MB or when there's no bitrate limit.
-    pub fn with_auto_detect(
-        nodelay: bool,
-        window_size: Option<usize>,
-        bitrate_limit: Option<u64>,
-    ) -> Self {
-        // Auto-select high-speed mode when:
-        // 1. Window size is explicitly set to > 1MB, or
-        // 2. No bitrate limit is set (unlimited speed, including explicit -b 0)
-        let use_high_speed = window_size
-            .map(|w| w > HIGH_SPEED_WINDOW_THRESHOLD)
-            .unwrap_or(false)
-            || !matches!(bitrate_limit, Some(bps) if bps > 0);
-
-        if use_high_speed && window_size.is_none() {
-            // Use full high-speed config with large buffers
-            let mut config = Self::high_speed();
-            config.nodelay = nodelay;
-            config
-        } else {
-            // Use user-specified or default settings
-            Self {
-                buffer_size: window_size.unwrap_or(DEFAULT_BUFFER_SIZE),
-                nodelay,
-                window_size,
-                congestion: None,
-                random_payload: false,
-            }
         }
     }
 }
@@ -831,17 +783,14 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_default_config() {
+    fn test_default_config_leaves_kernel_autotune_alone() {
         let config = TcpConfig::default();
         assert_eq!(config.buffer_size, DEFAULT_BUFFER_SIZE);
         assert!(!config.nodelay);
-    }
-
-    #[test]
-    fn test_high_speed_config() {
-        let config = TcpConfig::high_speed();
-        assert_eq!(config.buffer_size, HIGH_SPEED_BUFFER);
-        assert!(config.nodelay);
+        assert!(
+            config.window_size.is_none(),
+            "default must not force SO_SNDBUF/SO_RCVBUF — leave it to the kernel"
+        );
     }
 
     #[test]

--- a/tests/protocol.rs
+++ b/tests/protocol.rs
@@ -39,6 +39,7 @@ fn test_test_start_roundtrip() {
         congestion: Some("bbr".to_string()),
         mptcp: false,
         dscp: None,
+        window_size: None,
     };
 
     let json = msg.serialize().unwrap();
@@ -99,6 +100,7 @@ fn test_udp_test_start() {
         congestion: None,
         mptcp: false,
         dscp: None,
+        window_size: None,
     };
 
     let json = msg.serialize().unwrap();


### PR DESCRIPTION
## Summary

Addresses #60 (reported by @matttbe). xfr no longer silently forces `SO_SNDBUF`/`SO_RCVBUF` to 4 MB on either side. Both ends default to kernel autotuning; the client's `-w`/`--window` value is carried to the server over the control protocol and applied symmetrically (iperf3 parity).

## What changed

- **Client**: dropped `TcpConfig::with_auto_detect` (it silently forced 4 MB whenever `-b` was not set). Now builds `TcpConfig` directly from the user-supplied `window_size` (or `None`).
- **Server**: dropped the unconditional `TcpConfig::high_speed()`. Extracts `window_size` from the incoming `TestStart` (threaded through `run_test` → `spawn_tcp_handlers` / `spawn_tcp_stream_handlers`) and applies it only when the client requested one. Preserves `nodelay: true` to match historical behavior.
- **Protocol**: `TestStart` gains `window_size: Option<u64>` with `#[serde(default, skip_serializing_if = "Option::is_none")]` so mixed-version client/server pairs interoperate cleanly. `u64` (not `u32`) so `-w 4G` on a 64-bit client round-trips without truncating to 0.
- **CLI**: `--window` gets a `-w` short alias (iperf muscle memory).

## Back-compat

Serde default + skip_serializing_if = "Option::is_none" covers both directions:

- New client → old server: field ignored, old server keeps its prior unconditional 4 MB override (known, documented).
- Old client → new server: field absent, new server uses kernel autotune (intended).

## Tests

- 4 new protocol tests covering absent, present, omitted-on-None, and `> u32::MAX` roundtrip.
- Existing `test_default_config` extended to assert `window_size.is_none()`.
- Cross-version smoke (manual, pre-push): new↔old both directions, all work cleanly.
- Loopback throughput measured pre/post: ~48 Gbps (old, forced 4 MB) → ~43 Gbps (new, autotune). ~10% drop is expected and more honest — the previous numbers reflected app-applied buffer inflation, not the kernel's view. Documented in CHANGELOG.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-features --all-targets -- -D warnings`
- [x] `cargo test --all-features` (195 tests)
- [x] Smoke: `xfr -t 3s` (autotune), `xfr -t 3s -w 256K`, `xfr -t 3s -w 2M -P 4`
- [x] Cross-version: NEW server + OLD client, OLD server + NEW client, OLD server + NEW client with `-w`, all green

## Note to reviewers

- `TcpConfig::with_auto_detect` and `TcpConfig::high_speed` are deleted; pre-1.0 API break, no known external library consumers. If this matters to someone, we can restore deprecated constructors later.
- `src/serve.rs` has a dead `spawn_tcp_handlers` (the legacy multi-port path) — I threaded the new parameter through for consistency; removing it entirely is out of scope for this PR.