### PR TITLE
Add pre-commit hooks for fmt/clippy/test

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,24 @@
+repos:
+  - repo: local
+    hooks:
+      - id: cargo-fmt
+        name: cargo fmt
+        entry: cargo fmt --all --
+        language: system
+        types: [rust]
+        pass_filenames: false
+
+      - id: cargo-clippy
+        name: cargo clippy
+        entry: cargo clippy --all-targets --all-features -- -D warnings
+        language: system
+        types: [rust]
+        pass_filenames: false
+
+      - id: cargo-test
+        name: cargo test
+        entry: cargo test --lib
+        language: system
+        types: [rust]
+        pass_filenames: false
+        stages: [pre-push]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,27 @@
 - Run `cargo clippy --all-features` and fix any warnings
 - Keep lines under 100 characters when possible
 
+### Pre-commit hooks
+
+We ship a `.pre-commit-config.yaml` that runs `cargo fmt` and `cargo clippy`
+on every commit and `cargo test --lib` on every push. Set it up once:
+
+```bash
+# Recommended: prek (fast Rust port, drop-in compatible)
+cargo install --locked prek
+prek install
+
+# Or via standalone installer (no Rust toolchain needed)
+curl -LsSf https://github.com/j178/prek/releases/latest/download/prek-installer.sh | sh
+
+# Or with the original Python pre-commit
+pipx install pre-commit
+pre-commit install --hook-type pre-commit --hook-type pre-push
+```
+
+After install, hooks run automatically. To run them manually against staged
+files: `prek run` (or `pre-commit run`).
+
 ## Testing
 
 ```bash


### PR DESCRIPTION
## Summary

Mirrors the `.pre-commit-config.yaml` pattern already used in [lance0/prefixd](https://github.com/lance0/prefixd/blob/master/.pre-commit-config.yaml) and [lance0/ttl](https://github.com/lance0/ttl/blob/master/.pre-commit-config.yaml). Local hooks only — no third-party hook-repo dependency.

- `cargo fmt --all --` and `cargo clippy --all-targets --all-features -- -D warnings` run on every commit
- `cargo test --lib` runs on every push (so commits stay fast)

Clippy flags match xfr's CI (`--all-features`, see `.github/workflows/ci.yml:40`) with the addition of `--all-targets` to lint test/example/bench code alongside the library — that stricter form is what the prefixd precedent uses and the codebase already passes it cleanly.

## CONTRIBUTING.md

Adds an install snippet under **Code Style** covering:
- [prek](https://github.com/j178/prek) (recommended, fast Rust port, drop-in compatible)
- Standalone installer (no Rust toolchain needed)
- Original Python `pre-commit` as a fallback

## Test plan

- [x] `cargo fmt --all -- --check` clean on master
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean on master
- [x] `cargo test --lib` passes (121 tests)

## Notes

- CI on Linux currently runs clippy with `--all-features` only (no `--all-targets`). The hook is stricter; if a future cross-platform contributor introduces test-only or example-only warnings on macOS/FreeBSD/Windows, the hook will catch them locally before they hit CI. Worth a follow-up to align CI to `--all-targets` if we want symmetric coverage, but out of scope for this PR.