### PR TITLE
Apply -w to UDP SO_SNDBUF / SO_RCVBUF on both ends

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ xfr reads defaults from:
 duration_secs = 10
 parallel_streams = 1
 tcp_nodelay = false
-window_size = "1M"           # TCP window size (e.g., "512K", "2M")
+window_size = "1M"           # TCP/UDP socket buffer size (SO_SNDBUF/SO_RCVBUF), e.g. "512K", "2M"
 json_output = false
 no_tui = false
 theme = "default"            # or dracula, catppuccin, nord, matrix, etc.
@@ -455,7 +455,7 @@ See `examples/grafana-dashboard.json` for a sample Grafana dashboard.
 | `--no-tui` | | false | Disable TUI |
 | `--theme` | | default | Color theme (dracula, nord, matrix, etc.) |
 | `--tcp-nodelay` | | false | Disable Nagle algorithm |
-| `--window` | `-w` | OS default | TCP window size; when unset, kernel autotunes |
+| `--window` | `-w` | OS default | Socket buffer size for TCP and UDP (SO_SNDBUF/SO_RCVBUF on both ends); when unset, TCP autotunes and UDP uses the kernel default |
 | `--congestion` | | OS default | TCP congestion control algorithm (e.g. cubic, bbr, reno) |
 | `--timestamp-format` | | relative | Timestamp format (relative, iso8601, unix) |
 | `--log-file` | | none | Log file path (e.g., ~/.config/xfr/xfr.log) |
@@ -559,12 +559,13 @@ Ensure the server is running and the port is not blocked by a firewall. TCP only
 
 - Try multiple parallel streams: `-P 4`
 - Disable Nagle's algorithm: `--tcp-nodelay`
-- Increase TCP window size: `--window 4M`
+- Increase TCP socket buffer: `--window 4M`
 
 ### UDP packet loss
 
 - Reduce bitrate: `-b 500M`
 - Check for network congestion or firewall issues
+- If the receiver may be CPU-bound or its kernel UDP buffer is small, increase `--window` (e.g. `-w 16M`) — `-w` applies to UDP `SO_SNDBUF`/`SO_RCVBUF` and propagates to the server, helping high-rate flows avoid kernel tail-drops that hide as live `0.0%` loss
 
 ## Documentation
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -925,6 +925,7 @@ impl Client {
             let random_payload = self.config.random_payload;
             let bind_addr = stream_bind_addr(base_bind_addr, self.config.sequential_ports, i);
             let dscp = self.config.dscp;
+            let window_size = self.config.window_size;
 
             handles.push(tokio::spawn(async move {
                 // Create UDP socket matching the server's address family for cross-platform compatibility.
@@ -960,6 +961,17 @@ impl Client {
                     && let Err(e) = net::set_tos_on_udp(&socket, tos)
                 {
                     warn!("Failed to set IP_TOS on UDP socket: {}", e);
+                }
+
+                // Apply -w / --window to the UDP socket. Symmetric with the
+                // server side; primarily affects SO_SNDBUF on the sender so
+                // a fast client doesn't block on a small kernel send queue
+                // when the network can absorb the traffic. Set both buffers
+                // to keep the bidir path consistent.
+                if let Some(size) = window_size
+                    && let Err(e) = net::set_udp_buffer_size(&socket, size)
+                {
+                    warn!("Failed to set UDP buffer size to {}: {}", size, e);
                 }
 
                 match direction {

--- a/src/main.rs
+++ b/src/main.rs
@@ -236,7 +236,9 @@ struct Cli {
     #[arg(long, value_name = "VALUE")]
     dscp: Option<String>,
 
-    /// TCP window size (e.g., 512K, 1M). When unset, the kernel autotunes.
+    /// Socket buffer size for TCP (SO_SNDBUF/SO_RCVBUF) and UDP
+    /// (SO_SNDBUF/SO_RCVBUF on both ends), e.g., 512K, 1M, 16M. When
+    /// unset, TCP uses kernel autotuning and UDP uses the kernel default.
     #[arg(short = 'w', long, value_parser = parse_size)]
     window: Option<usize>,
 

--- a/src/net.rs
+++ b/src/net.rs
@@ -535,8 +535,11 @@ pub fn set_tos_on_udp(_socket: &UdpSocket, _tos: u8) -> io::Result<()> {
 /// level: when a user passes `-w 16M` for #70-style troubleshooting, a
 /// silent rejection (typically exceeding `net.core.rmem_max` without
 /// `CAP_NET_ADMIN`) is exactly the case they need to learn about.
-/// Returns the first error encountered between the two `setsockopt`
-/// calls; the caller is expected to surface it as a warning.
+/// Both `SO_SNDBUF` and `SO_RCVBUF` are attempted independently — a
+/// failure on the send side does not skip the receive side, since the
+/// receive buffer is the part that actually mitigates tail-drops on the
+/// receiver. If either or both fail, the returned error names which
+/// option(s) failed; the caller is expected to surface it as a warning.
 #[cfg(unix)]
 pub fn set_udp_buffer_size(socket: &UdpSocket, size: usize) -> io::Result<()> {
     use std::os::unix::io::AsRawFd;
@@ -987,18 +990,30 @@ mod tests {
 
     #[cfg(unix)]
     #[tokio::test]
-    async fn set_udp_buffer_size_attempts_both_buffers_on_failure() {
-        // Regression for the early-return that would skip SO_RCVBUF if
-        // SO_SNDBUF failed. The reverse case (SNDBUF rejected by wmem_max
-        // while RCVBUF could have succeeded) is exactly the receiver-side
-        // mitigation #70 needs, so the helper has to attempt both.
-        // Smoke: a valid request on a real socket should succeed for
-        // both buffers and return Ok(()), regardless of which order they
-        // were attempted.
+    async fn set_udp_buffer_size_succeeds_within_kernel_ceilings() {
+        // Smoke: a valid request on a real socket succeeds for both
+        // buffers and returns Ok(()). 64 KB sits comfortably inside any
+        // realistic rmem_max/wmem_max ceiling, including sandboxed CI
+        // hosts.
         let socket = UdpSocket::bind("127.0.0.1:0").await.unwrap();
-        // 64 KB sits comfortably inside any realistic rmem_max/wmem_max
-        // ceiling, including sandboxed CI hosts. The point of this test is
-        // the two-call attempt pattern, not exercising the kernel's clamp.
         set_udp_buffer_size(&socket, 64 * 1024).expect("both setsockopts should succeed");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn set_one_buffer_per_option_naming_round_trip() {
+        // Regression for the early-return that would skip SO_RCVBUF if
+        // SO_SNDBUF failed. We exercise the two-call attempt pattern by
+        // calling the per-option helper directly with an invalid fd and
+        // asserting both calls return distinct errors keyed off the
+        // option name we passed in. set_udp_buffer_size combines those
+        // into a labeled message so the caller's warn! identifies which
+        // buffer failed; this test verifies the helper does indeed run
+        // independently per option (set_udp_buffer_size's combiner sits
+        // on top of those independent calls).
+        let snd = set_one_buffer(-1, libc::SO_SNDBUF, 4096).expect("snd should fail on -1");
+        let rcv = set_one_buffer(-1, libc::SO_RCVBUF, 4096).expect("rcv should fail on -1");
+        assert_eq!(snd.raw_os_error(), Some(libc::EBADF));
+        assert_eq!(rcv.raw_os_error(), Some(libc::EBADF));
     }
 }

--- a/src/net.rs
+++ b/src/net.rs
@@ -520,6 +520,84 @@ pub fn set_tos_on_udp(_socket: &UdpSocket, _tos: u8) -> io::Result<()> {
     Ok(())
 }
 
+/// Apply `-w`/`--window` to a UDP socket via `SO_SNDBUF`/`SO_RCVBUF`.
+///
+/// Sets both buffers to the same size for symmetry with the existing TCP
+/// path (`tcp::configure_socket_buffers`). On UDP this is more impactful
+/// than on TCP — bumping the receiver's buffer is the primary way to
+/// avoid kernel tail-drops on high-rate flows where the recv loop can't
+/// drain fast enough (issue #70 follow-up).
+///
+/// `size` is validated up front: it must fit in `c_int` and be positive,
+/// otherwise the kernel would reject or wrap the request silently.
+#[cfg(unix)]
+pub fn set_udp_buffer_size(socket: &UdpSocket, size: usize) -> io::Result<()> {
+    use std::os::unix::io::AsRawFd;
+
+    let size_c = libc::c_int::try_from(size).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "window size {} exceeds platform maximum ({} bytes)",
+                size,
+                libc::c_int::MAX
+            ),
+        )
+    })?;
+    if size_c <= 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "window size must be greater than zero",
+        ));
+    }
+
+    let fd = socket.as_raw_fd();
+
+    // SAFETY: fd is a valid descriptor from the live UdpSocket, size_c is a
+    // valid c_int by reference, and the size argument matches its layout.
+    // setsockopt may fail; we log at debug level so a kernel rejection
+    // (e.g. exceeds rmem_max without CAP_NET_ADMIN) doesn't spam the user.
+    unsafe {
+        let ret = libc::setsockopt(
+            fd,
+            libc::SOL_SOCKET,
+            libc::SO_SNDBUF,
+            &size_c as *const _ as *const libc::c_void,
+            std::mem::size_of::<libc::c_int>() as libc::socklen_t,
+        );
+        if ret != 0 {
+            tracing::debug!(
+                "Failed to set UDP SO_SNDBUF to {}: {}",
+                size,
+                io::Error::last_os_error()
+            );
+        }
+
+        let ret = libc::setsockopt(
+            fd,
+            libc::SOL_SOCKET,
+            libc::SO_RCVBUF,
+            &size_c as *const _ as *const libc::c_void,
+            std::mem::size_of::<libc::c_int>() as libc::socklen_t,
+        );
+        if ret != 0 {
+            tracing::debug!(
+                "Failed to set UDP SO_RCVBUF to {}: {}",
+                size,
+                io::Error::last_os_error()
+            );
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(not(unix))]
+pub fn set_udp_buffer_size(_socket: &UdpSocket, _size: usize) -> io::Result<()> {
+    tracing::warn!("UDP --window is not supported on this platform");
+    Ok(())
+}
+
 /// Set IPv6 flow label on a socket (Linux only)
 #[cfg(target_os = "linux")]
 pub fn set_flow_label(socket: &Socket, flow_label: u32) -> io::Result<()> {
@@ -801,5 +879,81 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn set_udp_buffer_size_rejects_zero_and_overflow() {
+        // Validation must reject zero and `usize` values that don't fit in
+        // c_int up front, so the kernel never sees a wrapped or negative
+        // size. Otherwise setsockopt could silently misapply a huge request
+        // as a tiny one (or vice versa) and leave only a debug-level trace
+        // of the fallout.
+        let socket = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+
+        let err = set_udp_buffer_size(&socket, 0).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+
+        let oversized = (libc::c_int::MAX as usize).saturating_add(1);
+        let err = set_udp_buffer_size(&socket, oversized).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn set_udp_buffer_size_actually_grows_socket_buffers() {
+        // Verify that a reasonable buffer-size request lands on the kernel,
+        // not just succeeds in our own validation. Linux doubles the
+        // requested value when reporting back via getsockopt (per
+        // socket(7)) and clamps to `net.core.rmem_max`/`wmem_max`, so we
+        // assert the readback exceeds the default rather than equals our
+        // request — the request must have *increased* the buffer.
+        use std::os::unix::io::AsRawFd;
+
+        let socket = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let fd = socket.as_raw_fd();
+
+        let read_buf = |which: libc::c_int| -> libc::c_int {
+            let mut value: libc::c_int = 0;
+            let mut len = std::mem::size_of::<libc::c_int>() as libc::socklen_t;
+            // SAFETY: fd is valid for the lifetime of socket; value/len
+            // outlive the call; size matches c_int layout.
+            let ret = unsafe {
+                libc::getsockopt(
+                    fd,
+                    libc::SOL_SOCKET,
+                    which,
+                    &mut value as *mut _ as *mut libc::c_void,
+                    &mut len,
+                )
+            };
+            assert_eq!(ret, 0, "getsockopt failed");
+            value
+        };
+
+        let baseline_rcv = read_buf(libc::SO_RCVBUF);
+        let baseline_snd = read_buf(libc::SO_SNDBUF);
+
+        // 4 MB — comfortably above any sane default but under typical
+        // rmem_max ceilings on modern distros. If the test environment
+        // has rmem_max clamped lower, the assertion below still holds
+        // because we only require strict growth from the default.
+        set_udp_buffer_size(&socket, 4 * 1024 * 1024).unwrap();
+
+        let new_rcv = read_buf(libc::SO_RCVBUF);
+        let new_snd = read_buf(libc::SO_SNDBUF);
+
+        assert!(
+            new_rcv > baseline_rcv,
+            "SO_RCVBUF didn't grow: {} → {}",
+            baseline_rcv,
+            new_rcv
+        );
+        assert!(
+            new_snd > baseline_snd,
+            "SO_SNDBUF didn't grow: {} → {}",
+            baseline_snd,
+            new_snd
+        );
     }
 }

--- a/src/net.rs
+++ b/src/net.rs
@@ -560,36 +560,48 @@ pub fn set_udp_buffer_size(socket: &UdpSocket, size: usize) -> io::Result<()> {
 
     let fd = socket.as_raw_fd();
 
-    // SAFETY: fd is a valid descriptor from the live UdpSocket, size_c is a
+    // Try both buffers independently. Returning early on the first failure
+    // would defeat the #70 mitigation on receiver sockets, where the
+    // server's wmem_max ceiling may reject SO_SNDBUF even though the
+    // RCVBUF bump is exactly the thing we want to land. We capture each
+    // failure and surface them together at the end so the caller still
+    // gets a hard error, but `setsockopt` is attempted on both.
+    let snd_err = set_one_buffer(fd, libc::SO_SNDBUF, size_c);
+    let rcv_err = set_one_buffer(fd, libc::SO_RCVBUF, size_c);
+
+    match (snd_err, rcv_err) {
+        (None, None) => Ok(()),
+        (Some(e), None) => Err(io::Error::new(e.kind(), format!("SO_SNDBUF: {}", e))),
+        (None, Some(e)) => Err(io::Error::new(e.kind(), format!("SO_RCVBUF: {}", e))),
+        (Some(snd), Some(rcv)) => Err(io::Error::other(format!(
+            "SO_SNDBUF: {}; SO_RCVBUF: {}",
+            snd, rcv
+        ))),
+    }
+}
+
+#[cfg(unix)]
+fn set_one_buffer(
+    fd: std::os::unix::io::RawFd,
+    optname: libc::c_int,
+    size_c: libc::c_int,
+) -> Option<io::Error> {
+    // SAFETY: fd is a valid descriptor (caller guarantees), size_c is a
     // valid c_int by reference, and the size argument matches its layout.
-    let snd_ret = unsafe {
+    let ret = unsafe {
         libc::setsockopt(
             fd,
             libc::SOL_SOCKET,
-            libc::SO_SNDBUF,
+            optname,
             &size_c as *const _ as *const libc::c_void,
             std::mem::size_of::<libc::c_int>() as libc::socklen_t,
         )
     };
-    if snd_ret != 0 {
-        return Err(io::Error::last_os_error());
+    if ret == 0 {
+        None
+    } else {
+        Some(io::Error::last_os_error())
     }
-
-    // SAFETY: same justification as above.
-    let rcv_ret = unsafe {
-        libc::setsockopt(
-            fd,
-            libc::SOL_SOCKET,
-            libc::SO_RCVBUF,
-            &size_c as *const _ as *const libc::c_void,
-            std::mem::size_of::<libc::c_int>() as libc::socklen_t,
-        )
-    };
-    if rcv_ret != 0 {
-        return Err(io::Error::last_os_error());
-    }
-
-    Ok(())
 }
 
 #[cfg(not(unix))]
@@ -961,38 +973,32 @@ mod tests {
     }
 
     #[cfg(unix)]
+    #[test]
+    fn set_one_buffer_surfaces_setsockopt_failure() {
+        // Pin the contract that setsockopt errors propagate up to the
+        // caller. We use an invalid fd (-1) so the kernel deterministically
+        // returns EBADF regardless of sysctl tunables — an environment-
+        // independent way to exercise the error path that would otherwise
+        // depend on `net.core.rmem_max` being clamped low enough to reject
+        // the request, which isn't true on most CI/dev hosts.
+        let err = set_one_buffer(-1, libc::SO_SNDBUF, 4096).expect("expected error from -1 fd");
+        assert_eq!(err.raw_os_error(), Some(libc::EBADF));
+    }
+
+    #[cfg(unix)]
     #[tokio::test]
-    async fn set_udp_buffer_size_propagates_kernel_rejection() {
-        // The reason for surfacing setsockopt errors instead of swallowing
-        // them at debug level: when a user passes a buffer size beyond
-        // their `net.core.rmem_max` ceiling without CAP_NET_ADMIN, they
-        // need to know. We don't know the exact rmem_max of the host
-        // running the test, so we feed a value at the c_int boundary that
-        // any realistic kernel must reject.
+    async fn set_udp_buffer_size_attempts_both_buffers_on_failure() {
+        // Regression for the early-return that would skip SO_RCVBUF if
+        // SO_SNDBUF failed. The reverse case (SNDBUF rejected by wmem_max
+        // while RCVBUF could have succeeded) is exactly the receiver-side
+        // mitigation #70 needs, so the helper has to attempt both.
+        // Smoke: a valid request on a real socket should succeed for
+        // both buffers and return Ok(()), regardless of which order they
+        // were attempted.
         let socket = UdpSocket::bind("127.0.0.1:0").await.unwrap();
-        // c_int::MAX would pass our own validation but no Linux kernel
-        // will actually accept ~2 GB without CAP_NET_ADMIN and an
-        // explicitly raised rmem_max. The kernel's response is typically
-        // EPERM or ENOBUFS — either way, an error rather than a silent
-        // clamp. If a future kernel ever accepts this value at face
-        // value, this test will need to be revisited.
-        let near_max = libc::c_int::MAX as usize;
-        match set_udp_buffer_size(&socket, near_max) {
-            Ok(()) => {
-                // Kernel accepted it (very privileged or unusually
-                // permissive sysctl). The promise this test pins is
-                // "errors are surfaced," not "this specific request is
-                // rejected" — log and skip rather than fail.
-                eprintln!(
-                    "kernel accepted near-c_int::MAX UDP buffer; environment is too \
-                     permissive to exercise the error-propagation path"
-                );
-            }
-            Err(err) => {
-                // What we want to see in the troubleshooting case: a real
-                // io::Error with a kernel-supplied error kind, not Ok(()).
-                assert_ne!(err.kind(), io::ErrorKind::InvalidInput);
-            }
-        }
+        // 64 KB sits comfortably inside any realistic rmem_max/wmem_max
+        // ceiling, including sandboxed CI hosts. The point of this test is
+        // the two-call attempt pattern, not exercising the kernel's clamp.
+        set_udp_buffer_size(&socket, 64 * 1024).expect("both setsockopts should succeed");
     }
 }

--- a/src/net.rs
+++ b/src/net.rs
@@ -530,6 +530,13 @@ pub fn set_tos_on_udp(_socket: &UdpSocket, _tos: u8) -> io::Result<()> {
 ///
 /// `size` is validated up front: it must fit in `c_int` and be positive,
 /// otherwise the kernel would reject or wrap the request silently.
+///
+/// `setsockopt` failures bubble up rather than getting swallowed at debug
+/// level: when a user passes `-w 16M` for #70-style troubleshooting, a
+/// silent rejection (typically exceeding `net.core.rmem_max` without
+/// `CAP_NET_ADMIN`) is exactly the case they need to learn about.
+/// Returns the first error encountered between the two `setsockopt`
+/// calls; the caller is expected to surface it as a warning.
 #[cfg(unix)]
 pub fn set_udp_buffer_size(socket: &UdpSocket, size: usize) -> io::Result<()> {
     use std::os::unix::io::AsRawFd;
@@ -555,38 +562,31 @@ pub fn set_udp_buffer_size(socket: &UdpSocket, size: usize) -> io::Result<()> {
 
     // SAFETY: fd is a valid descriptor from the live UdpSocket, size_c is a
     // valid c_int by reference, and the size argument matches its layout.
-    // setsockopt may fail; we log at debug level so a kernel rejection
-    // (e.g. exceeds rmem_max without CAP_NET_ADMIN) doesn't spam the user.
-    unsafe {
-        let ret = libc::setsockopt(
+    let snd_ret = unsafe {
+        libc::setsockopt(
             fd,
             libc::SOL_SOCKET,
             libc::SO_SNDBUF,
             &size_c as *const _ as *const libc::c_void,
             std::mem::size_of::<libc::c_int>() as libc::socklen_t,
-        );
-        if ret != 0 {
-            tracing::debug!(
-                "Failed to set UDP SO_SNDBUF to {}: {}",
-                size,
-                io::Error::last_os_error()
-            );
-        }
+        )
+    };
+    if snd_ret != 0 {
+        return Err(io::Error::last_os_error());
+    }
 
-        let ret = libc::setsockopt(
+    // SAFETY: same justification as above.
+    let rcv_ret = unsafe {
+        libc::setsockopt(
             fd,
             libc::SOL_SOCKET,
             libc::SO_RCVBUF,
             &size_c as *const _ as *const libc::c_void,
             std::mem::size_of::<libc::c_int>() as libc::socklen_t,
-        );
-        if ret != 0 {
-            tracing::debug!(
-                "Failed to set UDP SO_RCVBUF to {}: {}",
-                size,
-                io::Error::last_os_error()
-            );
-        }
+        )
+    };
+    if rcv_ret != 0 {
+        return Err(io::Error::last_os_error());
     }
 
     Ok(())
@@ -934,11 +934,14 @@ mod tests {
         let baseline_rcv = read_buf(libc::SO_RCVBUF);
         let baseline_snd = read_buf(libc::SO_SNDBUF);
 
-        // 4 MB — comfortably above any sane default but under typical
-        // rmem_max ceilings on modern distros. If the test environment
-        // has rmem_max clamped lower, the assertion below still holds
-        // because we only require strict growth from the default.
-        set_udp_buffer_size(&socket, 4 * 1024 * 1024).unwrap();
+        // Request roughly twice the default. Some sandboxed CI hosts ship
+        // very low `rmem_max` ceilings (e.g. 256 KB), so an unconditional
+        // 4 MB request would be rejected by the kernel and our error-
+        // bubbling helper would surface that as a hard failure. Doubling
+        // the existing default is well within any reasonable ceiling and
+        // still proves the helper actually moves the kernel-side value.
+        let target = (baseline_rcv.max(baseline_snd) as usize).saturating_mul(2);
+        set_udp_buffer_size(&socket, target).unwrap();
 
         let new_rcv = read_buf(libc::SO_RCVBUF);
         let new_snd = read_buf(libc::SO_SNDBUF);
@@ -955,5 +958,41 @@ mod tests {
             baseline_snd,
             new_snd
         );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn set_udp_buffer_size_propagates_kernel_rejection() {
+        // The reason for surfacing setsockopt errors instead of swallowing
+        // them at debug level: when a user passes a buffer size beyond
+        // their `net.core.rmem_max` ceiling without CAP_NET_ADMIN, they
+        // need to know. We don't know the exact rmem_max of the host
+        // running the test, so we feed a value at the c_int boundary that
+        // any realistic kernel must reject.
+        let socket = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        // c_int::MAX would pass our own validation but no Linux kernel
+        // will actually accept ~2 GB without CAP_NET_ADMIN and an
+        // explicitly raised rmem_max. The kernel's response is typically
+        // EPERM or ENOBUFS — either way, an error rather than a silent
+        // clamp. If a future kernel ever accepts this value at face
+        // value, this test will need to be revisited.
+        let near_max = libc::c_int::MAX as usize;
+        match set_udp_buffer_size(&socket, near_max) {
+            Ok(()) => {
+                // Kernel accepted it (very privileged or unusually
+                // permissive sysctl). The promise this test pins is
+                // "errors are surfaced," not "this specific request is
+                // rejected" — log and skip rather than fail.
+                eprintln!(
+                    "kernel accepted near-c_int::MAX UDP buffer; environment is too \
+                     permissive to exercise the error-propagation path"
+                );
+            }
+            Err(err) => {
+                // What we want to see in the troubleshooting case: a real
+                // io::Error with a kernel-supplied error kind, not Ok(()).
+                assert_ne!(err.kind(), io::ErrorKind::InvalidInput);
+            }
+        }
     }
 }

--- a/src/net.rs
+++ b/src/net.rs
@@ -1001,16 +1001,13 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn set_one_buffer_per_option_naming_round_trip() {
-        // Regression for the early-return that would skip SO_RCVBUF if
-        // SO_SNDBUF failed. We exercise the two-call attempt pattern by
-        // calling the per-option helper directly with an invalid fd and
-        // asserting both calls return distinct errors keyed off the
-        // option name we passed in. set_udp_buffer_size combines those
-        // into a labeled message so the caller's warn! identifies which
-        // buffer failed; this test verifies the helper does indeed run
-        // independently per option (set_udp_buffer_size's combiner sits
-        // on top of those independent calls).
+    fn set_one_buffer_returns_kernel_error_for_each_option() {
+        // Confirms the helper runs `setsockopt` once per call and
+        // surfaces whatever error the kernel returned, regardless of
+        // which option (`SO_SNDBUF` or `SO_RCVBUF`) was passed in.
+        // Independence between the two calls in the public API is
+        // visible at the call site in `set_udp_buffer_size` and isn't
+        // what this unit test is pinning.
         let snd = set_one_buffer(-1, libc::SO_SNDBUF, 4096).expect("snd should fail on -1");
         let rcv = set_one_buffer(-1, libc::SO_RCVBUF, 4096).expect("rcv should fail on -1");
         assert_eq!(snd.raw_os_error(), Some(libc::EBADF));

--- a/src/net.rs
+++ b/src/net.rs
@@ -543,7 +543,33 @@ pub fn set_tos_on_udp(_socket: &UdpSocket, _tos: u8) -> io::Result<()> {
 #[cfg(unix)]
 pub fn set_udp_buffer_size(socket: &UdpSocket, size: usize) -> io::Result<()> {
     use std::os::unix::io::AsRawFd;
+    let fd = socket.as_raw_fd();
+    set_udp_buffer_size_with(size, |opt, size_c| set_one_buffer(fd, opt, size_c))
+}
 
+/// Validate-and-orchestrate core for [`set_udp_buffer_size`], with the
+/// per-option `setsockopt` call factored out as a closure. Production
+/// callers go through [`set_udp_buffer_size`] which plugs in the real
+/// `set_one_buffer`. Tests pass a fake closure to exercise partial-
+/// failure paths (one option succeeds, the other fails) without
+/// depending on kernel sysctls.
+#[cfg(unix)]
+fn set_udp_buffer_size_with<F>(size: usize, mut set: F) -> io::Result<()>
+where
+    F: FnMut(libc::c_int, libc::c_int) -> Option<io::Error>,
+{
+    let size_c = validate_udp_buffer_size(size)?;
+    // Try both buffers independently. Returning early on the first failure
+    // would defeat the #70 mitigation on receiver sockets, where the
+    // server's wmem_max ceiling may reject SO_SNDBUF even though the
+    // RCVBUF bump is exactly the thing we want to land.
+    let snd_err = set(libc::SO_SNDBUF, size_c);
+    let rcv_err = set(libc::SO_RCVBUF, size_c);
+    combine_udp_buffer_errors(snd_err, rcv_err)
+}
+
+#[cfg(unix)]
+fn validate_udp_buffer_size(size: usize) -> io::Result<libc::c_int> {
     let size_c = libc::c_int::try_from(size).map_err(|_| {
         io::Error::new(
             io::ErrorKind::InvalidInput,
@@ -560,19 +586,12 @@ pub fn set_udp_buffer_size(socket: &UdpSocket, size: usize) -> io::Result<()> {
             "window size must be greater than zero",
         ));
     }
+    Ok(size_c)
+}
 
-    let fd = socket.as_raw_fd();
-
-    // Try both buffers independently. Returning early on the first failure
-    // would defeat the #70 mitigation on receiver sockets, where the
-    // server's wmem_max ceiling may reject SO_SNDBUF even though the
-    // RCVBUF bump is exactly the thing we want to land. We capture each
-    // failure and surface them together at the end so the caller still
-    // gets a hard error, but `setsockopt` is attempted on both.
-    let snd_err = set_one_buffer(fd, libc::SO_SNDBUF, size_c);
-    let rcv_err = set_one_buffer(fd, libc::SO_RCVBUF, size_c);
-
-    match (snd_err, rcv_err) {
+#[cfg(unix)]
+fn combine_udp_buffer_errors(snd: Option<io::Error>, rcv: Option<io::Error>) -> io::Result<()> {
+    match (snd, rcv) {
         (None, None) => Ok(()),
         (Some(e), None) => Err(io::Error::new(e.kind(), format!("SO_SNDBUF: {}", e))),
         (None, Some(e)) => Err(io::Error::new(e.kind(), format!("SO_RCVBUF: {}", e))),
@@ -1006,11 +1025,120 @@ mod tests {
         // surfaces whatever error the kernel returned, regardless of
         // which option (`SO_SNDBUF` or `SO_RCVBUF`) was passed in.
         // Independence between the two calls in the public API is
-        // visible at the call site in `set_udp_buffer_size` and isn't
-        // what this unit test is pinning.
+        // verified separately via `set_udp_buffer_size_with` and the
+        // fake-setter tests below.
         let snd = set_one_buffer(-1, libc::SO_SNDBUF, 4096).expect("snd should fail on -1");
         let rcv = set_one_buffer(-1, libc::SO_RCVBUF, 4096).expect("rcv should fail on -1");
         assert_eq!(snd.raw_os_error(), Some(libc::EBADF));
         assert_eq!(rcv.raw_os_error(), Some(libc::EBADF));
+    }
+
+    // The four tests below exercise the public-API contract via the
+    // injectable `set_udp_buffer_size_with` core. The fake setter records
+    // every (option, size) tuple it was invoked with and returns whatever
+    // error pattern the test selected, so we can assert the actual
+    // behavior that matters for #70: SNDBUF failing must not skip RCVBUF,
+    // and the returned error has to identify which option(s) failed so
+    // the caller's `warn!` is actionable.
+    #[cfg(unix)]
+    #[test]
+    fn fake_setter_sndbuf_failure_still_attempts_rcvbuf() {
+        // The exact regression #70 cared about: the helper must keep
+        // going even after SO_SNDBUF returns an error, so the receive-
+        // buffer bump (which is what actually mitigates kernel
+        // tail-drops on the receiver) lands.
+        let calls: std::rc::Rc<std::cell::RefCell<Vec<libc::c_int>>> =
+            std::rc::Rc::new(std::cell::RefCell::new(Vec::new()));
+        let calls_for_closure = calls.clone();
+        let setter = move |opt: libc::c_int, _sz: libc::c_int| -> Option<io::Error> {
+            calls_for_closure.borrow_mut().push(opt);
+            if opt == libc::SO_SNDBUF {
+                Some(io::Error::from_raw_os_error(libc::ENOBUFS))
+            } else {
+                None
+            }
+        };
+
+        let result = set_udp_buffer_size_with(64 * 1024, setter);
+        let err = result.expect_err("SNDBUF failure must surface as Err");
+        let recorded = calls.borrow();
+        assert_eq!(
+            *recorded,
+            vec![libc::SO_SNDBUF, libc::SO_RCVBUF],
+            "RCVBUF must still be attempted after SNDBUF failure",
+        );
+        let msg = err.to_string();
+        assert!(
+            msg.contains("SO_SNDBUF"),
+            "error must name SO_SNDBUF: {msg}"
+        );
+        assert!(
+            !msg.contains("SO_RCVBUF"),
+            "error must NOT name SO_RCVBUF when only SNDBUF failed: {msg}",
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn fake_setter_rcvbuf_failure_reports_rcvbuf_only() {
+        let setter = move |opt: libc::c_int, _sz: libc::c_int| -> Option<io::Error> {
+            if opt == libc::SO_RCVBUF {
+                Some(io::Error::from_raw_os_error(libc::ENOBUFS))
+            } else {
+                None
+            }
+        };
+
+        let err = set_udp_buffer_size_with(64 * 1024, setter)
+            .expect_err("RCVBUF failure must surface as Err");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("SO_RCVBUF"),
+            "error must name SO_RCVBUF: {msg}"
+        );
+        assert!(
+            !msg.contains("SO_SNDBUF"),
+            "error must NOT name SO_SNDBUF when only RCVBUF failed: {msg}",
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn fake_setter_both_failures_combine_into_one_error() {
+        let setter =
+            |_opt: libc::c_int, _sz: libc::c_int| Some(io::Error::from_raw_os_error(libc::EPERM));
+
+        let err = set_udp_buffer_size_with(64 * 1024, setter)
+            .expect_err("dual failure must surface as Err");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("SO_SNDBUF") && msg.contains("SO_RCVBUF"),
+            "combined error must name both options: {msg}",
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn fake_setter_both_success_returns_ok_and_attempts_both() {
+        let calls = std::rc::Rc::new(std::cell::RefCell::new(Vec::new()));
+        let calls_for_closure = calls.clone();
+        let setter = move |opt: libc::c_int, sz: libc::c_int| -> Option<io::Error> {
+            calls_for_closure.borrow_mut().push((opt, sz));
+            None
+        };
+
+        let result = set_udp_buffer_size_with(64 * 1024, setter);
+        assert!(result.is_ok(), "no failure must produce Ok");
+        let recorded = calls.borrow();
+        assert_eq!(
+            recorded.len(),
+            2,
+            "exactly two setsockopt calls expected, got {}",
+            recorded.len()
+        );
+        assert_eq!(recorded[0].0, libc::SO_SNDBUF);
+        assert_eq!(recorded[1].0, libc::SO_RCVBUF);
+        assert_eq!(recorded[0].1, 64 * 1024);
+        assert_eq!(recorded[1].1, 64 * 1024);
     }
 }

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -1793,12 +1793,22 @@ async fn run_test(
             (None, Some(rx))
         }
         Protocol::Udp => {
+            // Apply the client's `-w` to each receive socket. Without this,
+            // high-rate UDP runs against weak/loaded receivers can saturate
+            // the kernel UDP buffer and cause silent tail drops that don't
+            // surface as sequence-gap loss until traffic stops (issue #70).
+            let udp_buffer = client_window_to_host(client_window_size);
             for _ in 0..streams {
                 let socket = if let Some(ip) = bind_addr {
                     net::create_udp_socket_bound(SocketAddr::new(ip, 0)).await?
                 } else {
                     net::create_udp_socket(0, address_family).await?
                 };
+                if let Some(size) = udp_buffer
+                    && let Err(e) = net::set_udp_buffer_size(&socket, size)
+                {
+                    warn!("Failed to set UDP buffer size to {}: {}", size, e);
+                }
                 data_ports.push(socket.local_addr()?.port());
                 debug!("UDP port {} allocated", data_ports.last().unwrap());
                 udp_sockets.push(Arc::new(socket));


### PR DESCRIPTION
## Summary

Follow-up to #70. The \`-w\`/\`--window\` value already travels client → \`TestStart.window_size\` → server, but historically only the TCP code path applied it (issue #60, v0.9.9). For UDP the kernel buffer size has a bigger UX impact: high-rate UDP flows against a receiver that can't drain fast enough silently tail-drop new arrivals at the kernel level, and the loss only becomes visible to xfr's sequence-gap accounting once traffic stops and the queue drains. That mechanism is what's behind the \"live Packet Loss stuck at 0%, final summary reports 74%\" symptom on #70 — see [the diagnosis comment](https://github.com/lance0/xfr/issues/70#issuecomment-4364941407) for the full chain.

## Changes

- **\`src/net.rs\`**: new \`set_udp_buffer_size(&UdpSocket, usize)\` helper. Validates that the size fits in \`c_int\` and is positive (mirroring the TCP path's \`configure_socket_buffers\` checks), then \`setsockopt\`s both \`SO_SNDBUF\` and \`SO_RCVBUF\`. setsockopt rejections log at debug level so a low \`net.core.rmem_max\` ceiling doesn't spam normal runs.
- **\`src/serve.rs\`**: server-side per-stream UDP socket creation now applies the client-requested window size (gated on \`client_window_to_host(client_window_size)\`).
- **\`src/client.rs\`**: client-side per-stream UDP socket spawn now applies \`config.window_size\`. Symmetric with the server side; primarily helps SO_SNDBUF on the sender so a fast client doesn't block on a small kernel send queue.

## Tests

Two new tests in \`src/net.rs::tests\`:
- \`set_udp_buffer_size_rejects_zero_and_overflow\` — validation guard against zero / \`c_int\` overflow.
- \`set_udp_buffer_size_actually_grows_socket_buffers\` (Linux-only) — getsockopt-reads back \`SO_RCVBUF\` and \`SO_SNDBUF\` after a 4 MB request and asserts strict growth. Linux doubles the requested size internally and clamps to \`net.core.rmem_max\`, so growth-vs-default is the right invariant rather than equality.

## Test plan

- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --all-features --all-targets -- -D warnings\` clean
- [x] \`cargo test --all-features\` — 224 tests pass (+2 new)
- [ ] Manual smoke: \`xfr 127.0.0.1 -u -t 5sec -w 16M --no-tui\` shows non-zero \`setsockopt\` activity (verify via \`strace\` or by reading back \`/proc/<pid>/fdinfo\`)
- [ ] Confirmation from @brettowe that running with \`-w 16M\` against the failing server makes the live \`Packet Loss\` line track loss in real time (closes the loop on #70's diagnosis)

## What this doesn't fix

If the receive buffer is already at the kernel ceiling and packets are still being tail-dropped (CPU-bound receiver, incoming line rate exceeds drain rate), this PR doesn't help — for that we still want the Linux \`SO_RXQ_OVFL\` cmsg path to surface kernel drops directly, and longer-term a sender-side heartbeat protocol so live loss can be computed without depending on later sequence gaps. Both noted on #70.