### PR TITLE
Set TCP_NODELAY on the control connection

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -230,6 +230,9 @@ impl Client {
         // prior peer's string forward into the TUI display.
         *self.server_version.lock() = None;
 
+        if let Err(e) = tcp::configure_control_stream(&stream) {
+            warn!("Failed to set TCP_NODELAY on control stream: {}", e);
+        }
         let (reader, mut writer) = stream.into_split();
         let mut reader = BufReader::new(reader);
         let mut line = String::new();

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -994,6 +994,9 @@ async fn handle_client_with_first_message(
     security: &SecurityContext,
     first_msg: ControlMessage,
 ) -> anyhow::Result<()> {
+    if let Err(e) = tcp::configure_control_stream(&stream) {
+        warn!("Failed to set TCP_NODELAY on control stream: {}", e);
+    }
     let (reader, mut writer) = stream.into_split();
     let mut reader = BufReader::new(reader);
     let mut line = String::new();
@@ -1103,6 +1106,9 @@ async fn handle_client_with_auth(
     server_max_duration: Option<Duration>,
     security: &SecurityContext,
 ) -> anyhow::Result<()> {
+    if let Err(e) = tcp::configure_control_stream(&stream) {
+        warn!("Failed to set TCP_NODELAY on control stream: {}", e);
+    }
     let (reader, mut writer) = stream.into_split();
     let mut reader = BufReader::new(reader);
     let mut line = String::new();

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -306,6 +306,29 @@ pub fn configure_stream(stream: &TcpStream, config: &TcpConfig) -> std::io::Resu
     Ok(())
 }
 
+/// Configure the control-channel TCP stream.
+///
+/// Control writes are tiny (~150-byte newline-delimited JSON messages) and
+/// emitted at low cadence (~1 Hz for periodic Interval updates, plus
+/// asynchronous control messages like Cancel/Pause/Hello/Result). With the
+/// kernel's default Nagle behavior, those writes get coalesced waiting for
+/// either an MSS-sized payload (which never arrives) or a delayed ACK from
+/// the peer. Under heavy parallel data load on a saturated link — Wi-Fi,
+/// any rate-limited path, even a busy LAN — the ACK turnaround climbs and
+/// Nagle holds the small writes for the duration of the test, then flushes
+/// every queued segment in a single burst at end-of-test. The resulting
+/// bunched timestamps on the receiving side made the v0.9.11 live UDP loss
+/// counter appear permanently stuck at 0.0% on real-world networks even
+/// though the data path was working correctly (#70 follow-up).
+///
+/// Setting `TCP_NODELAY` defeats this. iperf3 does the same on its control
+/// channel for the same reason. Data-stream sockets are configured
+/// separately via [`configure_stream`] using the user-facing
+/// `--tcp-nodelay` flag.
+pub fn configure_control_stream(stream: &TcpStream) -> std::io::Result<()> {
+    stream.set_nodelay(true)
+}
+
 /// Send data as fast as possible for the given duration
 /// Returns the final TCP_INFO snapshot (for RTT, retransmits, cwnd)
 pub async fn send_data(
@@ -869,6 +892,32 @@ mod tests {
         assert!(
             config.window_size.is_none(),
             "default must not force SO_SNDBUF/SO_RCVBUF — leave it to the kernel"
+        );
+    }
+
+    #[tokio::test]
+    async fn configure_control_stream_sets_tcp_nodelay() {
+        // Pin the contract that the control channel disables Nagle. Without
+        // this, ~150-byte interval messages get coalesced waiting for an
+        // ACK, and on a saturated link the ACK turnaround stretches such
+        // that the entire test's worth of progress messages flush in one
+        // burst at end-of-test (#70 follow-up). Reproducible on any link
+        // type, not just Wi-Fi.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let connect = tokio::net::TcpStream::connect(addr);
+        let accept = listener.accept();
+        let (client, _server) = tokio::join!(connect, accept);
+        let client = client.unwrap();
+
+        // Default Tokio TCP streams inherit kernel default (Nagle on);
+        // configure_control_stream must flip it.
+        configure_control_stream(&client).expect("set_nodelay should succeed");
+        assert!(
+            client
+                .nodelay()
+                .expect("getsockopt(TCP_NODELAY) should succeed"),
+            "control stream must have TCP_NODELAY enabled after configure_control_stream"
         );
     }
 


### PR DESCRIPTION
## Summary

Fixes the actual root cause of #70's "live UDP loss counter stuck at 0%" — turns out it had nothing to do with kernel UDP buffer sizing (#70 follow-up to v0.9.12 which addressed the adjacent receive-buffer issue).

## The diagnosis

@brettowe ran \`xfr -u -t 10 192.168.1.141 --no-tui --json-stream\` and the output showed all 9 per-second interval lines bunched at the same client-side timestamp (\~11.5s, after the 10s test ended), each carrying its correct \`elapsed_ms\` field of 1..9. Server was generating per-interval messages on schedule but they only reached the client at end-of-test in a single burst.

Code audit found that \`configure_stream\` (which sets \`TCP_NODELAY\` and other socket options) was being called for every DATA stream but **never on the CONTROL stream**. The control TcpStream was split into reader/writer immediately after accept/connect with no socket configuration at all.

The kernel's default Nagle behavior holds ~150-byte interval writes waiting for either an MSS-sized payload (which never arrives — control messages are tiny and 1 Hz) or an ACK from the peer. Under heavy parallel data load on the same path, ACK turnaround stretches such that every queued segment is held for the duration of the test, then flushes in a single burst when the data flow stops. The bunched-timestamp pattern matches this exactly.

Independent of link type — observable on wired, Wi-Fi, anything rate-limited. Loopback hides it because ACK turnaround is sub-ms. iperf3 [explicitly sets \`TCP_NODELAY\` on its control channel](https://software.es.net/iperf/faq.html) for the same reason.

## Changes

- New \`tcp::configure_control_stream(&TcpStream) -> io::Result<()>\` helper that sets only \`TCP_NODELAY\` (no window, no congestion — control is tiny, kernel defaults are right otherwise).
- Applied at three sites that own the control TcpStream:
  - \`src/serve.rs::handle_client_with_first_message\` (the active live server path)
  - \`src/serve.rs::handle_client_with_auth\` (currently \`#[allow(dead_code)]\`, configured for symmetry)
  - \`src/client.rs::Client::run_test\`
- Failures log a \`warn!\` and the test continues — \`TCP_NODELAY\` rejection is essentially impossible on a freshly-accepted/connected socket, but we don't want a setsockopt rejection to abort an otherwise-healthy test.

## Tests

- \`configure_control_stream_sets_tcp_nodelay\` (new, in \`src/tcp.rs::tests\`): connects a real TCP socket pair, calls the helper, asserts \`nodelay()\` reads back \`true\`. Default Tokio TCP streams inherit the kernel default (Nagle on); without the helper this would fail.
- \`cargo test --all-features\`: 232 tests pass (+1 new)
- \`cargo fmt --check\` clean
- \`cargo clippy --all-features --all-targets -- -D warnings\` clean

## Why earlier hypotheses were wrong

I went down two wrong paths before getting to this one — worth recording:

1. **"The TUI's \`udp_progress\` plumbing is broken."** It isn't; v0.9.11's plumbing is correct. The data path was just blocked at the wire.
2. **"Wi-Fi airtime contention starves TCP control."** I asserted this confidently, the user pushed back, and a web search disproved the magnitude — the literature consistently shows Wi-Fi airtime contention produces hundreds of ms of latency, not seconds. The bunching pattern (9 small writes at 1Hz, all delivered in one ~25ms burst at end-of-test) is the textbook signature of Nagle + delayed-ACK + TCP Small Queues, not radio-level starvation. iperf3 documents the same fix for the same reason.

## Test plan

- [x] Unit test pins \`TCP_NODELAY\` on configured control streams
- [x] Build/lint/test green locally
- [ ] Confirmation from @brettowe that on a release with this fix, the live counter tracks loss in real time during the test rather than jumping at quit