### PR TITLE
Add zero-copy TCP sends via sendfile (-Z/--zerocopy, issue #33)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Zero-copy TCP sends (`-Z`/`--zerocopy`, Linux)** (issue #33) — the send payload now lives in a `memfd_create` anonymous file and is pushed to the socket with `sendfile(2)`, skipping the userspace-to-kernel copy that `write(2)` performs on every 128 KB chunk. On CPU-bound senders (embedded routers, SBCs) the copy itself is often the throughput bottleneck — iperf3's equivalent `-Z` measured ~3x on a MIPS router. `sendfile` was chosen over `MSG_ZEROCOPY` for the first step because it works on old kernels, needs no error-queue completion reaping, and is MPTCP-compatible; `MSG_ZEROCOPY` remains on the roadmap under the same flag. Opt-in, TCP-only (conflicts with `-u`/`-Q` at parse time), and never fails a test: non-Linux platforms, kernels without `memfd_create`, and sockets that reject `sendfile` all fall back to regular writes with a warning. Payload semantics are unchanged (`--random` default / `--zeros` fill the memfd exactly as they fill the regular buffer).
+- **`zerocopy_v1` capability + `TestStart.zerocopy` field** — for `-R`/`--bidir`, the client forwards the zero-copy request in `TestStart` (wire-additive, absent = false) and the server applies it to its own send paths. Servers predating the field silently ignore it, so the client warns when the server doesn't advertise `zerocopy_v1`.
+
+### Library API (pre-1.0 break)
+- `tcp::TcpConfig` and `client::ClientConfig` gain `zerocopy: bool`. Struct-literal constructors must supply it (`Default` is `false`).
+- `protocol::ControlMessage::TestStart` gains `zerocopy: bool` (serde-default, omitted when false).
+- New module `zerocopy` with `ZerocopyPayload` (memfd construction + async sendfile chunk sends).
+
 ## [0.9.14] - 2026-05-03
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -445,6 +445,7 @@ See `examples/grafana-dashboard.json` for a sample Grafana dashboard.
 | `--mptcp` | | false | MPTCP mode (client-only, Linux 5.6+; server auto-enables) |
 | `--random` | | true | Use random payload data for client-sent TCP/UDP traffic (default) |
 | `--zeros` | | false | Use zero-filled payload data (client-sent traffic only) |
+| `--zerocopy` | `-Z` | false | Zero-copy TCP sends via sendfile(2), like iperf3 -Z (Linux; lowers sender CPU overhead) |
 | `--json` | | false | JSON output |
 | `--json-stream` | | false | JSON per interval |
 | `--csv` | | false | CSV output |
@@ -560,6 +561,7 @@ Ensure the server is running and the port is not blocked by a firewall. TCP only
 - Try multiple parallel streams: `-P 4`
 - Disable Nagle's algorithm: `--tcp-nodelay`
 - Increase TCP socket buffer: `--window 4M`
+- On CPU-bound senders (embedded routers, SBCs), skip the per-write userspace copy: `--zerocopy` (TCP, Linux). Applies to client sends, and to server sends in `-R`/`--bidir` when the server supports it
 
 ### UDP packet loss
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -307,8 +307,8 @@ Client behind strict firewall → which protocol?
 *Rationale: Simple socket-level change via socket2. Requested by kernel MPTCP co-maintainer (issue #24). Per-subflow stats via `MPTCP_FULL_INFO` would show multi-path behavior in the TUI.*
 
 ### IO Optimization / Zero-Copy (issue #33)
-- [ ] `sendfile()` + `mmap()` on the send path — create anonymous memory region via `mmap()` and pass fd to `sendfile()`, avoiding userspace buffer copies entirely. No temp file needed (iperf3 uses this approach). Lowest effort, biggest win on embedded/constrained devices (3x improvement measured on MIPS router: 30 → 100 Mbps)
-- [ ] `MSG_ZEROCOPY` on the send path — `setsockopt(SO_ZEROCOPY)` + `send()` with `MSG_ZEROCOPY` flag. Must be optional/flag-gated: MPTCP doesn't support it yet ([mptcp_net-next#578](https://github.com/multipath-tcp/mptcp_net-next/issues/578)). Linux 4.14+
+- [x] `sendfile()` on the TCP send path — shipped as `-Z`/`--zerocopy` (v0.9.15): payload lives in a `memfd_create` anonymous file and is pushed with `sendfile(2)`, skipping the per-write userspace copy. Forwarded to the server via `TestStart.zerocopy` for `-R`/`--bidir` (`zerocopy_v1` capability); MPTCP-compatible; falls back to regular writes when unsupported
+- [ ] `MSG_ZEROCOPY` on the send path — `setsockopt(SO_ZEROCOPY)` + `send()` with `MSG_ZEROCOPY` flag, picked automatically under the existing `--zerocopy` flag when supported and beneficial. Must stay optional: MPTCP doesn't support it yet ([mptcp_net-next#578](https://github.com/multipath-tcp/mptcp_net-next/issues/578)). Linux 4.14+, needs error-queue completion reaping
 - [ ] io_uring with fixed buffers — biggest win but requires different async runtime story (tokio-uring or glommio)
 - [ ] Multi-queue NIC support
 - [ ] AF_XDP kernel bypass

--- a/benches/throughput.rs
+++ b/benches/throughput.rs
@@ -125,6 +125,7 @@ fn bench_protocol_serialize_test_start(c: &mut Criterion) {
         mptcp: false,
         dscp: None,
         window_size: None,
+        zerocopy: false,
     };
 
     c.bench_function("protocol_serialize_test_start", |b| {

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -60,6 +60,15 @@ Both client and server use random payloads by default for TCP and UDP, avoiding 
 - `--zeros` only affects client-sent traffic; the server always sends random. Payload mode is not negotiated over the wire (future enhancement).
 - QUIC payloads are ignored since QUIC encrypts all traffic via TLS 1.3.
 
+### Zero-Copy Sends (`--zerocopy`, Linux)
+
+TCP sends can skip the per-write userspace-to-kernel copy with `-Z`/`--zerocopy` (issue #33), which serves the payload from an anonymous in-memory file via `sendfile(2)` — the same mechanism as iperf3's `-Z`. On constrained CPUs (embedded routers, SBCs) the copy itself is often the bottleneck, so this raises the throughput ceiling and lowers CPU load at any given rate.
+
+- Client-sent traffic uses zero-copy directly; for `-R`/`--bidir`, the request is forwarded in `TestStart` and servers that advertise the `zerocopy_v1` capability apply it to their sends (older servers ignore it, and the client warns).
+- Works with MPTCP (`sendfile` goes through the regular splice path, unlike `MSG_ZEROCOPY`).
+- Falls back to regular writes — with a warning, never a failed test — on non-Linux platforms, kernels without `memfd_create`, or sockets that reject `sendfile`.
+- Payload semantics are unchanged: the in-memory file is filled once with the same random (or `--zeros`) pattern the regular path uses.
+
 ### QUIC
 
 Encrypted transport over UDP using TLS 1.3:
@@ -569,6 +578,7 @@ See `xfr --help` for complete CLI documentation.
 | `--mptcp` | | false | MPTCP mode (Multi-Path TCP, Linux 5.6+) |
 | `--random` | | true | Use random payload data for client-sent TCP/UDP traffic (default) |
 | `--zeros` | | false | Use zero-filled payload data (client-sent traffic only) |
+| `--zerocopy` | `-Z` | false | Zero-copy TCP sends via sendfile(2) (Linux; lowers sender CPU overhead) |
 
 ### Server-Specific Flags
 

--- a/docs/xfr.1
+++ b/docs/xfr.1
@@ -119,6 +119,9 @@ Use random payload data (default for TCP/UDP client\-sent traffic)
 .B \-\-zeros
 Use zero\-filled payload data instead of random bytes
 .TP
+.B \-Z ", " \-\-zerocopy
+Zero\-copy TCP sends via sendfile(2), like iperf3 \-Z (Linux only; lowers sender CPU overhead). Applies to client\-sent traffic, and is forwarded to servers that support it for \-R/\-\-bidir. Falls back to regular writes when unsupported
+.TP
 .BI \-\-completions " SHELL"
 Generate shell completions: bash, zsh, fish, powershell, elvish
 .SH SERVER OPTIONS

--- a/src/client.rs
+++ b/src/client.rs
@@ -90,6 +90,11 @@ pub struct ClientConfig {
     pub mptcp: bool,
     /// Use random payload data for client-sent traffic
     pub random_payload: bool,
+    /// Zero-copy TCP sends via sendfile(2) (Linux only, issue #33). Applies
+    /// to client-sent traffic and is forwarded to the server for its sends
+    /// in download/bidir modes. Falls back to regular writes when
+    /// unsupported.
+    pub zerocopy: bool,
     /// DSCP/TOS value for IP_TOS socket option
     pub dscp: Option<u8>,
 }
@@ -113,6 +118,7 @@ impl Default for ClientConfig {
             sequential_ports: false,
             mptcp: false,
             random_payload: true,
+            zerocopy: false,
             dscp: None,
         }
     }
@@ -493,6 +499,19 @@ impl Client {
         let server_supports_udp_feedback =
             crate::protocol::capability_advertised(&server_capabilities, "udp_feedback_v1");
 
+        // Zero-copy on the server's sends (download/bidir) rides on the
+        // TestStart.zerocopy field; servers predating zerocopy_v1 silently
+        // ignore it, so tell the user their request won't take effect there.
+        if self.config.zerocopy
+            && matches!(
+                self.config.direction,
+                Direction::Download | Direction::Bidir
+            )
+            && !crate::protocol::capability_advertised(&server_capabilities, "zerocopy_v1")
+        {
+            warn!("Server does not support zero-copy; server-sent traffic will use regular writes");
+        }
+
         // Validate congestion algorithm before starting test (TCP only)
         if self.config.protocol == Protocol::Tcp
             && let Some(ref algo) = self.config.tcp_congestion
@@ -515,6 +534,7 @@ impl Client {
             mptcp: self.config.mptcp,
             dscp: self.config.dscp,
             window_size: self.config.window_size.map(|w| w as u64),
+            zerocopy: self.config.zerocopy,
         };
         writer
             .write_all(format!("{}\n", test_start.serialize()?).as_bytes())
@@ -927,6 +947,7 @@ impl Client {
                 window_size: self.config.window_size,
                 congestion: self.config.tcp_congestion.clone(),
                 random_payload: self.config.random_payload,
+                zerocopy: self.config.zerocopy,
                 ..Default::default()
             };
 
@@ -1039,6 +1060,7 @@ impl Client {
                                     window_size: config.window_size,
                                     congestion: config.congestion.clone(),
                                     random_payload: config.random_payload,
+                                    zerocopy: config.zerocopy,
                                 };
                                 let recv_config = config;
 
@@ -1456,6 +1478,7 @@ impl Client {
             mptcp: false,
             dscp: None,        // QUIC manages its own TOS via the transport layer
             window_size: None, // QUIC flow control is handled at the transport layer
+            zerocopy: false,   // sendfile is incompatible with QUIC's userspace encryption
         };
         ctrl_send
             .write_all(format!("{}\n", test_start.serialize()?).as_bytes())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,7 @@ pub mod tcp_info;
 pub mod tui;
 pub mod udp;
 pub mod update;
+pub mod zerocopy;
 
 pub use client::{Client, ClientConfig};
 pub use protocol::{ControlMessage, Direction, Protocol, TestResult};

--- a/src/main.rs
+++ b/src/main.rs
@@ -289,6 +289,12 @@ struct Cli {
     /// Use zero-filled payload data instead of random bytes
     #[arg(long, conflicts_with = "random")]
     zeros: bool,
+
+    /// Zero-copy TCP sends via sendfile(2), like iperf3 -Z (Linux only;
+    /// lowers sender CPU overhead). Falls back to regular writes when
+    /// unsupported.
+    #[arg(short = 'Z', long, conflicts_with_all = ["udp", "quic"])]
+    zerocopy: bool,
 }
 
 #[derive(Subcommand)]
@@ -617,6 +623,21 @@ fn random_payload_notice(
     None
 }
 
+/// Warn when --zerocopy cannot take effect for client-sent traffic on this
+/// platform. Download mode is exempt: the client sends no bulk data there,
+/// and the (possibly Linux) server decides its own zero-copy support.
+fn zerocopy_notice(zerocopy: bool, direction: Direction) -> Option<&'static str> {
+    if !zerocopy || cfg!(target_os = "linux") {
+        return None;
+    }
+    match direction {
+        Direction::Download => None,
+        Direction::Upload | Direction::Bidir => Some(
+            "--zerocopy requires Linux sendfile(2); client-sent traffic will use regular writes",
+        ),
+    }
+}
+
 fn generate_completions(shell: &str) {
     use clap::CommandFactory;
     use clap_complete::{Shell, generate};
@@ -897,6 +918,10 @@ async fn main() -> Result<()> {
                 eprintln!("Warning: {msg}");
             }
 
+            if let Some(msg) = zerocopy_notice(cli.zerocopy, direction) {
+                eprintln!("Warning: {msg}");
+            }
+
             if cli.dscp.is_some() && protocol == xfr::protocol::Protocol::Quic {
                 eprintln!("Warning: --dscp is ignored with QUIC (QUIC manages its own socket)");
             }
@@ -1040,6 +1065,7 @@ async fn main() -> Result<()> {
                 sequential_ports: protocol != Protocol::Quic && cport.is_some() && streams > 1,
                 mptcp: cli.mptcp,
                 random_payload,
+                zerocopy: cli.zerocopy,
                 dscp: cli
                     .dscp
                     .as_ref()
@@ -2018,6 +2044,47 @@ mod tests {
 
         let cli = Cli::try_parse_from(["xfr", "host", "--zeros"]).unwrap();
         assert!(!effective_random_payload(&cli));
+    }
+
+    #[test]
+    fn test_cli_zerocopy_flag() {
+        use clap::Parser;
+
+        let cli = Cli::try_parse_from(["xfr", "host"]).unwrap();
+        assert!(!cli.zerocopy, "zero-copy must be opt-in");
+
+        let cli = Cli::try_parse_from(["xfr", "host", "-Z"]).unwrap();
+        assert!(cli.zerocopy);
+
+        let cli = Cli::try_parse_from(["xfr", "host", "--zerocopy"]).unwrap();
+        assert!(cli.zerocopy);
+
+        // sendfile is a TCP-only mechanism: UDP and QUIC must conflict
+        assert!(Cli::try_parse_from(["xfr", "host", "-Z", "-u"]).is_err());
+        assert!(Cli::try_parse_from(["xfr", "host", "-Z", "-Q"]).is_err());
+
+        // MPTCP is allowed (sendfile goes through the regular splice path)
+        assert!(Cli::try_parse_from(["xfr", "host", "-Z", "--mptcp"]).is_ok());
+    }
+
+    #[test]
+    fn test_zerocopy_notice() {
+        // No request, no warning — regardless of platform or direction.
+        assert!(zerocopy_notice(false, Direction::Upload).is_none());
+        assert!(zerocopy_notice(false, Direction::Download).is_none());
+
+        if cfg!(target_os = "linux") {
+            // Supported platform: never warn.
+            assert!(zerocopy_notice(true, Direction::Upload).is_none());
+            assert!(zerocopy_notice(true, Direction::Download).is_none());
+            assert!(zerocopy_notice(true, Direction::Bidir).is_none());
+        } else {
+            // Unsupported platform: warn only when the client itself sends.
+            assert!(zerocopy_notice(true, Direction::Upload).is_some());
+            assert!(zerocopy_notice(true, Direction::Bidir).is_some());
+            // Download mode: the server decides its own zero-copy support.
+            assert!(zerocopy_notice(true, Direction::Download).is_none());
+        }
     }
 
     #[test]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -119,6 +119,12 @@ pub enum ControlMessage {
         /// that large values like `-w 4G` round-trip without silent truncation.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         window_size: Option<u64>,
+        /// Request zero-copy (sendfile) sends on the server side for
+        /// download/bidir TCP (`--zerocopy`, issue #33). Wire-additive:
+        /// absent means false, and older servers ignore the field — the
+        /// client warns via the `zerocopy_v1` capability when that happens.
+        #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+        zerocopy: bool,
     },
     TestAck {
         id: String,
@@ -433,6 +439,10 @@ pub const SUPPORTED_CAPABILITIES: &[&str] = &[
     // UDP at 2 Hz when both peers advertise this. Sidesteps TCP control
     // for live UDP-loss visibility under upload-mode saturation.
     "udp_feedback_v1",
+    // v0.9.15: server honors TestStart.zerocopy (sendfile-based sends for
+    // download/bidir TCP, issue #33). Advertised so clients can warn when
+    // a `-R --zerocopy` request lands on a server that will ignore it.
+    "zerocopy_v1",
 ];
 
 fn supported_capabilities() -> Vec<String> {
@@ -535,6 +545,7 @@ mod tests {
             mptcp: false,
             dscp: None,
             window_size: None,
+            zerocopy: false,
         };
         let json = msg.serialize().unwrap();
         let decoded = ControlMessage::deserialize(&json).unwrap();
@@ -582,6 +593,7 @@ mod tests {
             mptcp: false,
             dscp: None,
             window_size: Some(262_144),
+            zerocopy: false,
         };
         let json = msg.serialize().unwrap();
         assert!(json.contains("\"window_size\":262144"));
@@ -610,6 +622,7 @@ mod tests {
             mptcp: false,
             dscp: None,
             window_size: Some(big),
+            zerocopy: false,
         };
         let json = msg.serialize().unwrap();
         let decoded = ControlMessage::deserialize(&json).unwrap();
@@ -636,6 +649,7 @@ mod tests {
             mptcp: false,
             dscp: None,
             window_size: None,
+            zerocopy: false,
         };
         let json = msg.serialize().unwrap();
         assert!(
@@ -643,6 +657,50 @@ mod tests {
             "None must be skipped in serialization, got: {}",
             json
         );
+        assert!(
+            !json.contains("zerocopy"),
+            "false zerocopy must be skipped in serialization, got: {}",
+            json
+        );
+    }
+
+    #[test]
+    fn test_test_start_backward_compat_without_zerocopy() {
+        // Older peers don't send the zerocopy field; it must default to false.
+        let json = r#"{"type":"test_start","id":"x","protocol":"tcp","streams":1,"duration_secs":5,"direction":"download"}"#;
+        let decoded = ControlMessage::deserialize(json).unwrap();
+        match decoded {
+            ControlMessage::TestStart { zerocopy, .. } => {
+                assert!(!zerocopy, "absent field must deserialize to false");
+            }
+            _ => panic!("wrong message type"),
+        }
+    }
+
+    #[test]
+    fn test_test_start_roundtrip_with_zerocopy() {
+        let msg = ControlMessage::TestStart {
+            id: "x".to_string(),
+            protocol: Protocol::Tcp,
+            streams: 1,
+            duration_secs: 5,
+            direction: Direction::Download,
+            bitrate: None,
+            congestion: None,
+            mptcp: false,
+            dscp: None,
+            window_size: None,
+            zerocopy: true,
+        };
+        let json = msg.serialize().unwrap();
+        assert!(json.contains("\"zerocopy\":true"));
+        let decoded = ControlMessage::deserialize(&json).unwrap();
+        match decoded {
+            ControlMessage::TestStart { zerocopy, .. } => {
+                assert!(zerocopy);
+            }
+            _ => panic!("wrong message type"),
+        }
     }
 
     #[test]

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -1258,6 +1258,7 @@ async fn handle_test_request(
             mptcp,
             dscp,
             window_size,
+            zerocopy,
         } => {
             // Validate stream count
             if streams == 0 || streams > MAX_STREAMS {
@@ -1359,6 +1360,7 @@ async fn handle_test_request(
                 client_supports_udp_feedback,
                 dscp,
                 window_size,
+                zerocopy,
             )
             .await;
 
@@ -1746,6 +1748,7 @@ async fn run_test(
     client_supports_udp_feedback: bool,
     dscp: Option<u8>,
     client_window_size: Option<u64>,
+    zerocopy: bool,
 ) -> anyhow::Result<(u64, u64, f64)> {
     let mut line = String::new();
 
@@ -1916,6 +1919,7 @@ async fn run_test(
                         pause_clone,
                         dscp,
                         client_window_size,
+                        zerocopy,
                     )
                     .await
                 });
@@ -2282,6 +2286,7 @@ async fn spawn_tcp_handlers(
                         window_size: config.window_size,
                         congestion: config.congestion.clone(),
                         random_payload: true,
+                        zerocopy: config.zerocopy,
                     };
                     let recv_config = config;
 
@@ -2341,6 +2346,7 @@ async fn spawn_tcp_stream_handlers(
     pause: watch::Receiver<bool>,
     dscp: Option<u8>,
     client_window_size: Option<u64>,
+    zerocopy: bool,
 ) -> Vec<JoinHandle<()>> {
     let per_stream_bitrate = bitrate.map(|b| {
         if b == 0 {
@@ -2412,6 +2418,7 @@ async fn spawn_tcp_stream_handlers(
                         window_size: client_window_to_host(client_window_size),
                         congestion,
                         random_payload: true,
+                        zerocopy,
                         ..Default::default()
                     };
 

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -6,7 +6,11 @@
 use std::io;
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
+use tokio::io::{AsyncRead, AsyncReadExt};
+// Only the non-Linux teardown path calls shutdown(); Linux relies on
+// SO_LINGER=0 + drop. write()/flush() are no longer used — see write_chunk.
+#[cfg(not(target_os = "linux"))]
+use tokio::io::AsyncWriteExt;
 use tokio::net::TcpStream;
 use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
 use tokio::sync::watch;
@@ -14,6 +18,7 @@ use tracing::{debug, error, warn};
 
 use crate::stats::StreamStats;
 use crate::tcp_info::get_tcp_info;
+use crate::zerocopy::ZerocopyPayload;
 
 const DEFAULT_BUFFER_SIZE: usize = 128 * 1024; // 128 KB
 const SEND_TEARDOWN_GRACE: Duration = Duration::from_millis(250);
@@ -86,6 +91,10 @@ pub struct TcpConfig {
     pub window_size: Option<usize>,
     pub congestion: Option<String>,
     pub random_payload: bool,
+    /// Send via sendfile(2) from a memfd instead of write(2), skipping the
+    /// per-chunk userspace-to-kernel copy (issue #33). Linux-only; falls
+    /// back to regular writes elsewhere or when setup fails.
+    pub zerocopy: bool,
 }
 
 impl Default for TcpConfig {
@@ -96,6 +105,7 @@ impl Default for TcpConfig {
             window_size: None,
             congestion: None,
             random_payload: false,
+            zerocopy: false,
         }
     }
 }
@@ -329,10 +339,61 @@ pub fn configure_control_stream(stream: &TcpStream) -> std::io::Result<()> {
     stream.set_nodelay(true)
 }
 
+/// Write one payload chunk to the socket: sendfile(2) from the memfd when
+/// zero-copy is active, otherwise a regular write. The readiness-then-try_write
+/// loop is the same mechanism `AsyncWriteExt::write` uses internally, so the
+/// regular path is behaviorally unchanged; both paths return bytes queued with
+/// partial-write semantics. Cancel-safe: dropping the future mid-await queues
+/// nothing.
+async fn write_chunk(
+    stream: &TcpStream,
+    buffer: &[u8],
+    zerocopy: Option<&ZerocopyPayload>,
+) -> io::Result<usize> {
+    if let Some(payload) = zerocopy {
+        return payload.send_chunk(stream).await;
+    }
+    loop {
+        stream.writable().await?;
+        match stream.try_write(buffer) {
+            Ok(n) => return Ok(n),
+            Err(e) if e.kind() == io::ErrorKind::WouldBlock => continue,
+            Err(e) => return Err(e),
+        }
+    }
+}
+
+/// Build the zero-copy payload from the already-filled send buffer when
+/// requested, logging (not failing) on setup errors so the caller can fall
+/// back to regular writes — e.g. non-Linux platforms or kernels without
+/// memfd_create.
+fn setup_zerocopy(config: &TcpConfig, buffer: &[u8], stream_id: u8) -> Option<ZerocopyPayload> {
+    if !config.zerocopy {
+        return None;
+    }
+    match ZerocopyPayload::new(buffer) {
+        Ok(payload) => {
+            debug!(
+                "Stream {}: zero-copy enabled ({}B sendfile chunks)",
+                stream_id,
+                payload.len()
+            );
+            Some(payload)
+        }
+        Err(e) => {
+            warn!(
+                "Stream {}: zero-copy unavailable ({}); using regular writes",
+                stream_id, e
+            );
+            None
+        }
+    }
+}
+
 /// Send data as fast as possible for the given duration
 /// Returns the final TCP_INFO snapshot (for RTT, retransmits, cwnd)
 pub async fn send_data(
-    mut stream: TcpStream,
+    stream: TcpStream,
     stats: Arc<StreamStats>,
     duration: Duration,
     config: TcpConfig,
@@ -375,6 +436,7 @@ pub async fn send_data(
     if config.random_payload {
         rand::RngExt::fill(&mut rand::rng(), buffer.as_mut_slice());
     }
+    let mut zerocopy = setup_zerocopy(&config, &buffer, stats.stream_id);
     let start = tokio::time::Instant::now();
     let deadline = start + duration;
     let is_infinite = duration == Duration::ZERO;
@@ -431,7 +493,7 @@ pub async fn send_data(
                 debug!("Deadline reached during write for stream {}", stats.stream_id);
                 break;
             }
-            r = stream.write(&buffer) => r,
+            r = write_chunk(&stream, &buffer, zerocopy.as_ref()) => r,
         };
 
         match write_result {
@@ -462,6 +524,22 @@ pub async fn send_data(
                         }
                     }
                 }
+            }
+            // sendfile rejected by this socket/kernel combo (e.g. MPTCP before
+            // splice support): demote to regular writes and keep the test
+            // running rather than failing it.
+            Err(e)
+                if zerocopy.is_some()
+                    && matches!(
+                        e.kind(),
+                        io::ErrorKind::Unsupported | io::ErrorKind::InvalidInput
+                    ) =>
+            {
+                warn!(
+                    "Stream {}: sendfile failed ({}); falling back to regular writes",
+                    stats.stream_id, e
+                );
+                zerocopy = None;
             }
             Err(e) => {
                 let now = tokio::time::Instant::now();
@@ -508,6 +586,8 @@ pub async fn send_data(
     // On Linux, SO_LINGER=0 was set earlier; drop alone triggers RST (skipping drain).
     // On other platforms, call shutdown() for graceful FIN — slower but preserves
     // accounting accuracy since we don't have bytes_acked to clamp overcount.
+    #[cfg(not(target_os = "linux"))]
+    let mut stream = stream;
     #[cfg(not(target_os = "linux"))]
     if let Err(e) = stream.shutdown().await {
         if *cancel.borrow() || is_peer_closed_error(&e) {
@@ -630,7 +710,7 @@ pub fn get_stream_tcp_info(stream: &TcpStream) -> Option<crate::protocol::TcpInf
 /// post-reunite, since a second read would see a later (larger) `bytes_acked`
 /// that could exceed the clamped `bytes_sent`.
 pub async fn send_data_half(
-    mut write_half: OwnedWriteHalf,
+    write_half: OwnedWriteHalf,
     stats: Arc<StreamStats>,
     duration: Duration,
     config: TcpConfig,
@@ -668,6 +748,7 @@ pub async fn send_data_half(
     if config.random_payload {
         rand::RngExt::fill(&mut rand::rng(), buffer.as_mut_slice());
     }
+    let mut zerocopy = setup_zerocopy(&config, &buffer, stats.stream_id);
     let start = tokio::time::Instant::now();
     let deadline = start + duration;
     let is_infinite = duration == Duration::ZERO;
@@ -718,7 +799,7 @@ pub async fn send_data_half(
                 debug!("Deadline reached during write for stream {}", stats.stream_id);
                 break;
             }
-            r = write_half.write(&buffer) => r,
+            r = write_chunk(write_half.as_ref(), &buffer, zerocopy.as_ref()) => r,
         };
 
         match write_result {
@@ -748,6 +829,21 @@ pub async fn send_data_half(
                         }
                     }
                 }
+            }
+            // sendfile rejected by this socket/kernel combo: demote to regular
+            // writes and keep the test running. See send_data for rationale.
+            Err(e)
+                if zerocopy.is_some()
+                    && matches!(
+                        e.kind(),
+                        io::ErrorKind::Unsupported | io::ErrorKind::InvalidInput
+                    ) =>
+            {
+                warn!(
+                    "Stream {}: sendfile failed ({}); falling back to regular writes",
+                    stats.stream_id, e
+                );
+                zerocopy = None;
             }
             Err(e) => {
                 let now = tokio::time::Instant::now();
@@ -791,6 +887,8 @@ pub async fn send_data_half(
 
     // On Linux, SO_LINGER=0 was set earlier; drop alone triggers RST.
     // On other platforms, do graceful shutdown to preserve accounting accuracy.
+    #[cfg(not(target_os = "linux"))]
+    let mut write_half = write_half;
     #[cfg(not(target_os = "linux"))]
     let _ = write_half.shutdown().await;
 
@@ -893,6 +991,63 @@ mod tests {
             config.window_size.is_none(),
             "default must not force SO_SNDBUF/SO_RCVBUF — leave it to the kernel"
         );
+        assert!(!config.zerocopy, "zero-copy must be opt-in");
+    }
+
+    /// End-to-end: send_data with zerocopy enabled pushes real bytes through
+    /// the sendfile path and records them in stats, over a finite test
+    /// duration. Linux-only — elsewhere setup falls back to regular writes,
+    /// which the other tests already cover.
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn send_data_zerocopy_delivers_bytes_and_counts_them() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let connect = tokio::net::TcpStream::connect(addr);
+        let accept = listener.accept();
+        let (client, server) = tokio::join!(connect, accept);
+        let client = client.unwrap();
+        let (mut server, _) = server.unwrap();
+
+        let stats = Arc::new(StreamStats::new(0));
+        let config = TcpConfig {
+            zerocopy: true,
+            random_payload: true,
+            ..Default::default()
+        };
+        let (_cancel_tx, cancel_rx) = watch::channel(false);
+        let (_pause_tx, pause_rx) = watch::channel(false);
+
+        // Drain continuously so the sender isn't stalled on a full buffer.
+        // Read errors are expected at the end: SO_LINGER=0 teardown RSTs.
+        let recv_task = tokio::spawn(async move {
+            let mut buf = vec![0u8; 256 * 1024];
+            let mut total = 0u64;
+            loop {
+                match server.read(&mut buf).await {
+                    Ok(0) | Err(_) => break,
+                    Ok(n) => total += n as u64,
+                }
+            }
+            total
+        });
+
+        send_data(
+            client,
+            stats.clone(),
+            Duration::from_millis(300),
+            config,
+            cancel_rx,
+            None,
+            pause_rx,
+        )
+        .await
+        .expect("zerocopy send_data should succeed on Linux");
+
+        let received = recv_task.await.unwrap();
+        let sent = stats.bytes_sent.load(std::sync::atomic::Ordering::Relaxed);
+        assert!(sent > 0, "sendfile path must record bytes_sent");
+        assert!(received > 0, "receiver must observe sendfile-pushed bytes");
     }
 
     #[tokio::test]

--- a/src/zerocopy.rs
+++ b/src/zerocopy.rs
@@ -1,0 +1,214 @@
+//! Zero-copy TCP send support (issue #33)
+//!
+//! Implements iperf3-style `--zerocopy`: the payload lives in an anonymous
+//! memory file (`memfd_create`) and is pushed to the socket with
+//! `sendfile(2)`, skipping the userspace-to-kernel copy that `write(2)`
+//! performs on every chunk. On constrained CPUs (embedded routers) the copy
+//! itself is often the throughput bottleneck, so eliding it raises the
+//! ceiling and lowers CPU load at any given rate.
+//!
+//! `sendfile` is used rather than `MSG_ZEROCOPY` because it works on old
+//! kernels (the embedded systems motivating this feature), needs no
+//! error-queue completion reaping, and is supported by MPTCP.
+//!
+//! Linux-only. On other platforms [`ZerocopyPayload::new`] returns
+//! `ErrorKind::Unsupported` and callers fall back to regular writes.
+
+use std::io;
+use tokio::net::TcpStream;
+
+/// A fixed payload backed by a memfd, sent repeatedly with `sendfile(2)`.
+///
+/// The payload contents are written once at construction (random or zeros,
+/// matching the regular send path) and never change, so every
+/// [`send_chunk`](Self::send_chunk) transmits the same bytes — the same
+/// semantics as the regular path's reused userspace buffer.
+#[derive(Debug)]
+pub struct ZerocopyPayload {
+    #[cfg(target_os = "linux")]
+    file: std::fs::File,
+    len: usize,
+}
+
+impl ZerocopyPayload {
+    /// Create a payload fd containing `payload`.
+    ///
+    /// Fails with `ErrorKind::Unsupported` on non-Linux platforms or when
+    /// `memfd_create` is unavailable (kernel < 3.17, seccomp); callers
+    /// should fall back to regular writes.
+    #[cfg(target_os = "linux")]
+    pub fn new(payload: &[u8]) -> io::Result<Self> {
+        use std::io::Write;
+        use std::os::unix::io::FromRawFd;
+
+        if payload.is_empty() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "zero-copy payload must not be empty",
+            ));
+        }
+
+        // CStr literal avoids a CString allocation; name is debug-only
+        // (shows up in /proc/<pid>/fd).
+        let name = c"xfr-zerocopy";
+        let fd = unsafe { libc::memfd_create(name.as_ptr(), libc::MFD_CLOEXEC) };
+        if fd < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        let mut file = unsafe { std::fs::File::from_raw_fd(fd) };
+        file.write_all(payload)?;
+
+        Ok(Self {
+            file,
+            len: payload.len(),
+        })
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    pub fn new(_payload: &[u8]) -> io::Result<Self> {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "zero-copy sends require Linux sendfile(2)",
+        ))
+    }
+
+    /// Payload size in bytes (the chunk size of each `send_chunk`).
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// One non-blocking `sendfile(2)` of the payload from offset 0.
+    /// Partial sends are fine — the caller counts whatever was queued,
+    /// matching `write(2)` semantics on the regular path.
+    #[cfg(target_os = "linux")]
+    fn sendfile_once(&self, socket_fd: std::os::unix::io::RawFd) -> io::Result<usize> {
+        use std::os::unix::io::AsRawFd;
+
+        let mut offset: libc::off_t = 0;
+        let n = unsafe { libc::sendfile(socket_fd, self.file.as_raw_fd(), &mut offset, self.len) };
+        if n < 0 {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(n as usize)
+        }
+    }
+
+    /// Send one payload chunk on `stream` via sendfile, awaiting socket
+    /// writability. Cancel-safe: dropping the future mid-await sends
+    /// nothing; a completed sendfile returns synchronously.
+    #[cfg(target_os = "linux")]
+    pub async fn send_chunk(&self, stream: &TcpStream) -> io::Result<usize> {
+        use std::os::unix::io::AsRawFd;
+        use tokio::io::Interest;
+
+        let socket_fd = stream.as_raw_fd();
+        loop {
+            stream.writable().await?;
+            match stream.try_io(Interest::WRITABLE, || self.sendfile_once(socket_fd)) {
+                Ok(n) => return Ok(n),
+                // Spurious readiness or send buffer refilled between
+                // writable() and sendfile — wait again.
+                Err(e) if e.kind() == io::ErrorKind::WouldBlock => continue,
+                Err(e) => return Err(e),
+            }
+        }
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    pub async fn send_chunk(&self, _stream: &TcpStream) -> io::Result<usize> {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "zero-copy sends require Linux sendfile(2)",
+        ))
+    }
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use super::*;
+    use tokio::io::AsyncReadExt;
+
+    #[test]
+    fn new_rejects_empty_payload() {
+        let err = ZerocopyPayload::new(&[]).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    }
+
+    #[test]
+    fn new_creates_payload_of_requested_len() {
+        let payload = ZerocopyPayload::new(&[0xAB; 4096]).unwrap();
+        assert_eq!(payload.len(), 4096);
+        assert!(!payload.is_empty());
+    }
+
+    /// sendfile path delivers exactly the payload bytes over a real TCP
+    /// loopback connection, repeatedly, from a stable offset-0 chunk.
+    #[tokio::test]
+    async fn send_chunk_delivers_payload_bytes() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let pattern: Vec<u8> = (0..1024u32).map(|i| (i % 251) as u8).collect();
+        let payload = ZerocopyPayload::new(&pattern).unwrap();
+
+        let sender = tokio::net::TcpStream::connect(addr).await.unwrap();
+        let (mut receiver, _) = listener.accept().await.unwrap();
+
+        // Send the chunk twice to verify the offset resets per call.
+        let mut queued = 0usize;
+        while queued < pattern.len() * 2 {
+            queued += payload.send_chunk(&sender).await.unwrap();
+        }
+        drop(sender);
+
+        let mut received = Vec::new();
+        receiver.read_to_end(&mut received).await.unwrap();
+        assert_eq!(received.len(), pattern.len() * 2);
+        assert_eq!(&received[..pattern.len()], pattern.as_slice());
+        assert_eq!(&received[pattern.len()..], pattern.as_slice());
+    }
+
+    /// EAGAIN handling: a small payload sent in a tight loop against a
+    /// receiver that drains slowly must eventually push every byte through
+    /// the writable()/WouldBlock retry path without error.
+    #[tokio::test]
+    async fn send_chunk_handles_full_send_buffer() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let pattern = vec![0x5A; 64 * 1024];
+        let payload = ZerocopyPayload::new(&pattern).unwrap();
+
+        let sender = tokio::net::TcpStream::connect(addr).await.unwrap();
+        let (mut receiver, _) = listener.accept().await.unwrap();
+
+        const TARGET: usize = 8 * 1024 * 1024; // well past any send buffer
+        let send_task = tokio::spawn(async move {
+            let mut queued = 0usize;
+            while queued < TARGET {
+                queued += payload.send_chunk(&sender).await.unwrap();
+            }
+            queued
+        });
+
+        let mut drained = 0usize;
+        let mut buf = vec![0u8; 256 * 1024];
+        let sent = loop {
+            if send_task.is_finished() && drained > 0 {
+                // Sender done; drain whatever remains in flight.
+                let sent = send_task.await.unwrap();
+                while drained < sent {
+                    drained += receiver.read(&mut buf).await.unwrap();
+                }
+                break sent;
+            }
+            drained += receiver.read(&mut buf).await.unwrap();
+        };
+        assert!(sent >= TARGET);
+        assert!(drained >= sent);
+    }
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -57,6 +57,7 @@ async fn test_tcp_single_stream() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
+        zerocopy: false,
         dscp: None,
     };
 
@@ -108,6 +109,7 @@ async fn test_tcp_multi_stream() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
+        zerocopy: false,
         dscp: None,
     };
 
@@ -141,6 +143,7 @@ async fn test_connection_refused() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
+        zerocopy: false,
         dscp: None,
     };
 
@@ -174,6 +177,7 @@ async fn test_tcp_download() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
+        zerocopy: false,
         dscp: None,
     };
 
@@ -212,6 +216,7 @@ async fn test_tcp_bidir() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
+        zerocopy: false,
         dscp: None,
     };
 
@@ -268,6 +273,7 @@ async fn test_udp_upload() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
+        zerocopy: false,
         dscp: None,
     };
 
@@ -307,6 +313,7 @@ async fn test_udp_download() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
+        zerocopy: false,
         dscp: None,
     };
 
@@ -343,6 +350,7 @@ async fn test_udp_bidir() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
+        zerocopy: false,
         dscp: None,
     };
 
@@ -381,6 +389,7 @@ async fn test_udp_multi_stream() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
+        zerocopy: false,
         dscp: None,
     };
 
@@ -424,6 +433,7 @@ async fn test_multi_client_concurrent() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
+        zerocopy: false,
         dscp: None,
     };
 
@@ -444,6 +454,7 @@ async fn test_multi_client_concurrent() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
+        zerocopy: false,
         dscp: None,
     };
 
@@ -530,6 +541,7 @@ async fn test_psk_auth_success() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
+        zerocopy: false,
         dscp: None,
     };
 
@@ -572,6 +584,7 @@ async fn test_psk_auth_failure() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
+        zerocopy: false,
         dscp: None,
     };
 
@@ -614,6 +627,7 @@ async fn test_psk_auth_missing_client_key() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
+        zerocopy: false,
         dscp: None,
     };
 
@@ -654,6 +668,7 @@ async fn test_acl_allow() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
+        zerocopy: false,
         dscp: None,
     };
 
@@ -691,6 +706,7 @@ async fn test_rate_limit() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
+        zerocopy: false,
         dscp: None,
     };
 
@@ -718,6 +734,7 @@ async fn test_rate_limit() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
+        zerocopy: false,
         dscp: None,
     };
 
@@ -766,6 +783,7 @@ async fn test_quic_upload() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
+        zerocopy: false,
         dscp: None,
     };
 
@@ -805,6 +823,7 @@ async fn test_quic_download() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
+        zerocopy: false,
         dscp: None,
     };
 
@@ -843,6 +862,7 @@ async fn test_quic_multi_stream() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
+        zerocopy: false,
         dscp: None,
     };
 
@@ -885,6 +905,7 @@ async fn test_quic_bidir() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
+        zerocopy: false,
         dscp: None,
     };
 
@@ -924,6 +945,7 @@ async fn test_quic_with_psk() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
+        zerocopy: false,
         dscp: None,
     };
 
@@ -965,6 +987,7 @@ async fn test_acl_deny() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
+        zerocopy: false,
         dscp: None,
     };
 
@@ -1021,6 +1044,7 @@ async fn test_ipv6_localhost() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
+        zerocopy: false,
         dscp: None,
     };
 
@@ -1064,6 +1088,7 @@ async fn test_tcp_infinite_duration_with_cancel() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
+        zerocopy: false,
         dscp: None,
     };
 
@@ -1115,6 +1140,7 @@ async fn test_udp_infinite_duration_with_cancel() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
+        zerocopy: false,
         dscp: None,
     };
 
@@ -1162,6 +1188,7 @@ async fn test_quic_infinite_duration_with_cancel() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
+        zerocopy: false,
         dscp: None,
     };
 
@@ -1231,6 +1258,7 @@ async fn test_udp_ipv4_explicit() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
+        zerocopy: false,
         dscp: None,
     };
 
@@ -1287,6 +1315,7 @@ async fn test_udp_ipv6_explicit() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
+        zerocopy: false,
         dscp: None,
     };
 
@@ -1343,6 +1372,7 @@ async fn test_udp_cport_dualstack_ipv6_target() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
+        zerocopy: false,
         dscp: None,
     };
 
@@ -1383,6 +1413,7 @@ async fn test_tcp_cport_single_stream() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
+        zerocopy: false,
         dscp: None,
     };
 
@@ -1426,6 +1457,7 @@ async fn test_tcp_cport_multi_stream() {
         sequential_ports: true,
         mptcp: false,
         random_payload: false,
+        zerocopy: false,
         dscp: None,
     };
 
@@ -1485,6 +1517,7 @@ async fn test_tcp_cport_dualstack_ipv6_target() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
+        zerocopy: false,
         dscp: None,
     };
 
@@ -1540,6 +1573,7 @@ async fn test_quic_cport_dualstack_ipv6_target() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
+        zerocopy: false,
         dscp: None,
     };
 
@@ -1580,6 +1614,7 @@ async fn test_udp_invalid_sequential_ports_config_fails() {
         sequential_ports: true,
         mptcp: false,
         random_payload: false,
+        zerocopy: false,
         dscp: None,
     };
 
@@ -1627,6 +1662,7 @@ async fn test_udp_bitrate_underflow_regression() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
+        zerocopy: false,
         dscp: None,
     };
 
@@ -1697,6 +1733,7 @@ async fn test_quic_ipv6() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
+        zerocopy: false,
         dscp: None,
     };
 
@@ -1753,6 +1790,7 @@ async fn test_tcp_one_off_multi_stream() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
+        zerocopy: false,
         dscp: None,
     };
 
@@ -1818,6 +1856,7 @@ async fn test_quic_one_off() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
+        zerocopy: false,
         dscp: None,
     };
 
@@ -1862,6 +1901,7 @@ fn test_pause_not_ready_before_test_run() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
+        zerocopy: false,
         dscp: None,
     };
 
@@ -2124,6 +2164,7 @@ async fn test_serve_bind_ipv4_loopback() {
         direction: Direction::Upload,
         address_family: xfr::net::AddressFamily::V4Only,
         random_payload: false,
+        zerocopy: false,
         ..Default::default()
     };
     let result = timeout(Duration::from_secs(10), Client::new(client_cfg).run(None)).await;
@@ -2166,6 +2207,7 @@ async fn test_serve_bind_ipv6_loopback() {
         direction: Direction::Upload,
         address_family: xfr::net::AddressFamily::V6Only,
         random_payload: false,
+        zerocopy: false,
         ..Default::default()
     };
     let result = timeout(Duration::from_secs(10), Client::new(client_cfg).run(None)).await;
@@ -2200,6 +2242,7 @@ async fn test_serve_bind_ipv4_quic() {
         direction: Direction::Upload,
         address_family: xfr::net::AddressFamily::V4Only,
         random_payload: false,
+        zerocopy: false,
         ..Default::default()
     };
     let result = timeout(Duration::from_secs(10), Client::new(client_cfg).run(None)).await;
@@ -2241,6 +2284,7 @@ async fn test_serve_bind_ipv6_quic() {
         direction: Direction::Upload,
         address_family: xfr::net::AddressFamily::V6Only,
         random_payload: false,
+        zerocopy: false,
         ..Default::default()
     };
     let result = timeout(Duration::from_secs(10), Client::new(client_cfg).run(None)).await;
@@ -2358,6 +2402,7 @@ async fn test_serve_bind_ipv4_udp() {
         direction: Direction::Upload,
         address_family: xfr::net::AddressFamily::V4Only,
         random_payload: false,
+        zerocopy: false,
         ..Default::default()
     };
     let result = timeout(Duration::from_secs(10), Client::new(client_cfg).run(None)).await;

--- a/tests/protocol.rs
+++ b/tests/protocol.rs
@@ -40,6 +40,7 @@ fn test_test_start_roundtrip() {
         mptcp: false,
         dscp: None,
         window_size: None,
+        zerocopy: false,
     };
 
     let json = msg.serialize().unwrap();
@@ -101,6 +102,7 @@ fn test_udp_test_start() {
         mptcp: false,
         dscp: None,
         window_size: None,
+        zerocopy: false,
     };
 
     let json = msg.serialize().unwrap();


### PR DESCRIPTION
## Summary

First step for #33: `-Z`/`--zerocopy` sends TCP payload with `sendfile(2)` from a `memfd_create` anonymous file, skipping the userspace-to-kernel copy that `write(2)` performs on every 128 KB chunk. This is the same mechanism as iperf3's `-Z`.

sendfile was chosen over `MSG_ZEROCOPY` for the first step because it works on old kernels (the embedded systems motivating the issue), needs no error-queue completion reaping, and is MPTCP-compatible. `MSG_ZEROCOPY` stays on the roadmap as a future automatic upgrade under the same flag.

## Implementation

- **New `zerocopy` module** — `ZerocopyPayload` owns the memfd (filled once with the same random/`--zeros` pattern as the regular buffer) and sends chunks through `TcpStream::writable()` + `try_io`, cancel-safe inside the existing select-based deadline race.
- **`tcp::write_chunk`** centralizes the per-chunk write for both `send_data` and `send_data_half`. The regular path now uses readiness + `try_write` — the same mechanism `AsyncWriteExt::write` uses internally — so non-zerocopy behavior is unchanged.
- **Never fails a test**: non-Linux platforms and kernels without `memfd_create` fall back at setup; a runtime `EINVAL`/`EOPNOTSUPP` from sendfile (e.g. MPTCP before splice support) demotes to regular writes with a warning.
- **Reverse/bidir**: `TestStart` gains a wire-additive `zerocopy` field (absent = false, same pattern as `window_size`/`mptcp`) so the server applies sendfile to its own sends. New `zerocopy_v1` capability lets the client warn when an older server will ignore the request.
- **TCP-only by construction**: `-Z` conflicts with `-u`/`-Q` at parse time. MPTCP is allowed.

## Verification

- strace: one `memfd_create` + ~48k × 128 KB `sendfile` calls on the client in upload mode and on the **server** in `-R` (propagation verified); zero sendfile calls without `-Z`.
- Release-build loopback A/B (3 runs each): ~42.7 Gbps at 100% client CPU baseline → 58–78 Gbps at 81–93% CPU with `-Z`. Bidir total 33 → 60 Gbps.
- New tests: memfd/sendfile unit tests (byte accuracy across repeated chunks, EAGAIN retry path), end-to-end `send_data` zerocopy test, TestStart serde backward-compat (absent field → false, false omitted from JSON), CLI conflict tests.
- 254 tests pass; `cargo clippy --all-features --all-targets -- -D warnings` clean.

Loopback numbers measure the copy elision, not real NIC behavior — the interesting validation is matttbe's embedded hardware, where iperf3's `-Z` measured ~3x.

Closes nothing yet; #33 stays open for reporter validation and the MSG_ZEROCOPY/io_uring follow-ups.