### PR TITLE
Enable zero-copy TCP sends by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Zero-copy TCP sends are now on by default** (issue #33 follow-up) — `sendfile(2)` needs only Linux 3.17+ and every unsupported configuration (non-Linux, old kernels, old servers, sockets that reject `sendfile`) already falls back to regular writes, so there is no reason to make users opt in to the cheaper send path. `-Z`/`--zerocopy` is kept: passing it explicitly upgrades the silent fallback to a warning (non-Linux client sends, or a `-R`/`--bidir` server that doesn't advertise `zerocopy_v1`). New `--no-zerocopy` flag opts out. Payload semantics are unchanged, and on links where the sender isn't CPU-bound results are identical — where it is, throughput now reflects the network rather than the sender's copy overhead.
+
+### Library API (pre-1.0 break)
+- `client::ClientConfig.zerocopy` is now a `ZerocopyMode` enum (`Off` / `Auto` / `Requested`) instead of `bool`; `Default` is `Auto`. `Auto` and `Requested` behave identically except `Requested` warns on downgrade. `tcp::TcpConfig.zerocopy` stays `bool`.
+
 ## [0.9.16] - 2026-06-10
 
 > v0.9.15 was tagged but never released: its release CI failed on the aarch64-gnu cross build (glibc < 2.27 lacks the `memfd_create` wrapper; now invoked via raw syscall). All v0.9.15 changes ship here.

--- a/README.md
+++ b/README.md
@@ -453,7 +453,8 @@ See `examples/grafana-dashboard.json` for a sample Grafana dashboard.
 | `--mptcp` | | false | MPTCP mode (client-only, Linux 5.6+; server auto-enables) |
 | `--random` | | true | Use random payload data for client-sent TCP/UDP traffic (default) |
 | `--zeros` | | false | Use zero-filled payload data (client-sent traffic only) |
-| `--zerocopy` | `-Z` | false | Zero-copy TCP sends via sendfile(2), like iperf3 -Z (Linux; lowers sender CPU overhead) |
+| `--zerocopy` | `-Z` | true (TCP) | Zero-copy TCP sends via sendfile(2), like iperf3 -Z (Linux; lowers sender CPU overhead). On by default; explicit `-Z` warns when zero-copy can't take effect |
+| `--no-zerocopy` | | false | Disable zero-copy TCP sends (use regular buffered writes) |
 | `--json` | | false | JSON output |
 | `--json-stream` | | false | JSON per interval |
 | `--csv` | | false | CSV output |
@@ -569,7 +570,7 @@ Ensure the server is running and the port is not blocked by a firewall. TCP only
 - Try multiple parallel streams: `-P 4`
 - Disable Nagle's algorithm: `--tcp-nodelay`
 - Increase TCP socket buffer: `--window 4M`
-- On CPU-bound senders (embedded routers, SBCs), skip the per-write userspace copy: `--zerocopy` (TCP, Linux). Applies to client sends, and to server sends in `-R`/`--bidir` when the server supports it
+- On CPU-bound senders (embedded routers, SBCs), the per-write userspace copy is skipped by default via sendfile(2) (TCP, Linux). This applies to client sends, and to server sends in `-R`/`--bidir` when the server supports it; pass `-Z` to get a warning when zero-copy can't take effect, or `--no-zerocopy` to disable it
 
 ### UDP packet loss
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -145,6 +145,29 @@ pub enum PauseResult {
     NotReady,
 }
 
+/// How zero-copy TCP sends (sendfile(2), issue #33) were selected.
+///
+/// `Auto` and `Requested` are identical on the wire and the send path; they
+/// differ only in how loudly downgrades are reported. The default-on path
+/// stays quiet when zero-copy isn't available (non-Linux, old kernels, old
+/// servers), while an explicit `-Z` warns so the user knows their request
+/// didn't take effect.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ZerocopyMode {
+    /// Zero-copy disabled (`--no-zerocopy`, or non-TCP protocols).
+    Off,
+    /// On by default for TCP; downgrades are silent.
+    Auto,
+    /// Explicitly requested (`-Z`); downgrades warn.
+    Requested,
+}
+
+impl ZerocopyMode {
+    pub fn enabled(self) -> bool {
+        !matches!(self, ZerocopyMode::Off)
+    }
+}
+
 #[derive(Clone)]
 pub struct ClientConfig {
     pub host: String,
@@ -172,9 +195,9 @@ pub struct ClientConfig {
     pub random_payload: bool,
     /// Zero-copy TCP sends via sendfile(2) (Linux only, issue #33). Applies
     /// to client-sent traffic and is forwarded to the server for its sends
-    /// in download/bidir modes. Falls back to regular writes when
-    /// unsupported.
-    pub zerocopy: bool,
+    /// in download/bidir modes. On by default for TCP ([`ZerocopyMode::Auto`]);
+    /// falls back to regular writes when unsupported.
+    pub zerocopy: ZerocopyMode,
     /// DSCP/TOS value for IP_TOS socket option
     pub dscp: Option<u8>,
 }
@@ -198,7 +221,7 @@ impl Default for ClientConfig {
             sequential_ports: false,
             mptcp: false,
             random_payload: true,
-            zerocopy: false,
+            zerocopy: ZerocopyMode::Auto,
             dscp: None,
         }
     }
@@ -581,8 +604,9 @@ impl Client {
 
         // Zero-copy on the server's sends (download/bidir) rides on the
         // TestStart.zerocopy field; servers predating zerocopy_v1 silently
-        // ignore it, so tell the user their request won't take effect there.
-        if self.config.zerocopy
+        // ignore it. Only an explicit -Z warns about that — with the
+        // default-on mode the downgrade is invisible and harmless.
+        if self.config.zerocopy == ZerocopyMode::Requested
             && matches!(
                 self.config.direction,
                 Direction::Download | Direction::Bidir
@@ -614,7 +638,7 @@ impl Client {
             mptcp: self.config.mptcp,
             dscp: self.config.dscp,
             window_size: self.config.window_size.map(|w| w as u64),
-            zerocopy: self.config.zerocopy,
+            zerocopy: self.config.protocol == Protocol::Tcp && self.config.zerocopy.enabled(),
         };
         writer
             .write_all(format!("{}\n", test_start.serialize()?).as_bytes())
@@ -1078,7 +1102,7 @@ impl Client {
                 window_size: self.config.window_size,
                 congestion: self.config.tcp_congestion.clone(),
                 random_payload: self.config.random_payload,
-                zerocopy: self.config.zerocopy,
+                zerocopy: self.config.zerocopy.enabled(),
                 ..Default::default()
             };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,6 @@ pub mod udp;
 pub mod update;
 pub mod zerocopy;
 
-pub use client::{Client, ClientConfig};
+pub use client::{Client, ClientConfig, ZerocopyMode};
 pub use protocol::{ControlMessage, Direction, Protocol, TestResult};
 pub use serve::{Server, ServerConfig};

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ use tokio::sync::mpsc;
 use tracing::info;
 use tracing_subscriber::EnvFilter;
 
-use xfr::client::{Client, ClientConfig, TestProgress};
+use xfr::client::{Client, ClientConfig, TestProgress, ZerocopyMode};
 use xfr::config::Config;
 use xfr::diff::{DiffConfig, run_diff};
 use xfr::output::{output_csv, output_json, output_plain};
@@ -291,10 +291,15 @@ struct Cli {
     zeros: bool,
 
     /// Zero-copy TCP sends via sendfile(2), like iperf3 -Z (Linux only;
-    /// lowers sender CPU overhead). Falls back to regular writes when
-    /// unsupported.
+    /// lowers sender CPU overhead). On by default for TCP; passing -Z
+    /// explicitly warns when zero-copy cannot take effect instead of
+    /// silently falling back to regular writes.
     #[arg(short = 'Z', long, conflicts_with_all = ["udp", "quic"])]
     zerocopy: bool,
+
+    /// Disable zero-copy TCP sends (use regular buffered writes)
+    #[arg(long, conflicts_with = "zerocopy")]
+    no_zerocopy: bool,
 }
 
 #[derive(Subcommand)]
@@ -623,11 +628,27 @@ fn random_payload_notice(
     None
 }
 
-/// Warn when --zerocopy cannot take effect for client-sent traffic on this
-/// platform. Download mode is exempt: the client sends no bulk data there,
+/// Resolve the zero-copy mode from CLI flags. Zero-copy is on by default
+/// for TCP (issue #33 follow-up); an explicit -Z upgrades silent fallback
+/// to a warning, and --no-zerocopy opts out. Non-TCP protocols never use
+/// it (clap already rejects an explicit -Z with -u/-Q).
+fn effective_zerocopy(cli: &Cli, protocol: Protocol) -> ZerocopyMode {
+    debug_assert!(!(cli.zerocopy && cli.no_zerocopy));
+    if protocol != Protocol::Tcp || cli.no_zerocopy {
+        ZerocopyMode::Off
+    } else if cli.zerocopy {
+        ZerocopyMode::Requested
+    } else {
+        ZerocopyMode::Auto
+    }
+}
+
+/// Warn when zero-copy cannot take effect for client-sent traffic on this
+/// platform. Only an explicit -Z warns — the default-on mode falls back
+/// silently. Download mode is exempt: the client sends no bulk data there,
 /// and the (possibly Linux) server decides its own zero-copy support.
-fn zerocopy_notice(zerocopy: bool, direction: Direction) -> Option<&'static str> {
-    if !zerocopy || cfg!(target_os = "linux") {
+fn zerocopy_notice(zerocopy: ZerocopyMode, direction: Direction) -> Option<&'static str> {
+    if zerocopy != ZerocopyMode::Requested || cfg!(target_os = "linux") {
         return None;
     }
     match direction {
@@ -913,12 +934,13 @@ async fn main() -> Result<()> {
             };
 
             let random_payload = effective_random_payload(&cli);
+            let zerocopy = effective_zerocopy(&cli, protocol);
 
             if let Some(msg) = random_payload_notice(protocol, direction, random_payload) {
                 eprintln!("Warning: {msg}");
             }
 
-            if let Some(msg) = zerocopy_notice(cli.zerocopy, direction) {
+            if let Some(msg) = zerocopy_notice(zerocopy, direction) {
                 eprintln!("Warning: {msg}");
             }
 
@@ -1065,7 +1087,7 @@ async fn main() -> Result<()> {
                 sequential_ports: protocol != Protocol::Quic && cport.is_some() && streams > 1,
                 mptcp: cli.mptcp,
                 random_payload,
-                zerocopy: cli.zerocopy,
+                zerocopy,
                 dscp: cli
                     .dscp
                     .as_ref()
@@ -2050,18 +2072,37 @@ mod tests {
     fn test_cli_zerocopy_flag() {
         use clap::Parser;
 
+        // Bare invocation: neither flag set, mode resolves to Auto for TCP.
         let cli = Cli::try_parse_from(["xfr", "host"]).unwrap();
-        assert!(!cli.zerocopy, "zero-copy must be opt-in");
+        assert!(!cli.zerocopy);
+        assert!(!cli.no_zerocopy);
+        assert_eq!(effective_zerocopy(&cli, Protocol::Tcp), ZerocopyMode::Auto);
+        // Non-TCP protocols never use zero-copy, even in Auto mode.
+        assert_eq!(effective_zerocopy(&cli, Protocol::Udp), ZerocopyMode::Off);
+        assert_eq!(effective_zerocopy(&cli, Protocol::Quic), ZerocopyMode::Off);
 
         let cli = Cli::try_parse_from(["xfr", "host", "-Z"]).unwrap();
         assert!(cli.zerocopy);
+        assert_eq!(
+            effective_zerocopy(&cli, Protocol::Tcp),
+            ZerocopyMode::Requested
+        );
 
         let cli = Cli::try_parse_from(["xfr", "host", "--zerocopy"]).unwrap();
         assert!(cli.zerocopy);
 
-        // sendfile is a TCP-only mechanism: UDP and QUIC must conflict
+        let cli = Cli::try_parse_from(["xfr", "host", "--no-zerocopy"]).unwrap();
+        assert!(cli.no_zerocopy);
+        assert_eq!(effective_zerocopy(&cli, Protocol::Tcp), ZerocopyMode::Off);
+
+        // Opt-in and opt-out are mutually exclusive
+        assert!(Cli::try_parse_from(["xfr", "host", "-Z", "--no-zerocopy"]).is_err());
+
+        // sendfile is a TCP-only mechanism: explicit -Z with UDP/QUIC must
+        // conflict; --no-zerocopy with them is a harmless no-op.
         assert!(Cli::try_parse_from(["xfr", "host", "-Z", "-u"]).is_err());
         assert!(Cli::try_parse_from(["xfr", "host", "-Z", "-Q"]).is_err());
+        assert!(Cli::try_parse_from(["xfr", "host", "--no-zerocopy", "-u"]).is_ok());
 
         // MPTCP is allowed (sendfile goes through the regular splice path)
         assert!(Cli::try_parse_from(["xfr", "host", "-Z", "--mptcp"]).is_ok());
@@ -2069,21 +2110,24 @@ mod tests {
 
     #[test]
     fn test_zerocopy_notice() {
-        // No request, no warning — regardless of platform or direction.
-        assert!(zerocopy_notice(false, Direction::Upload).is_none());
-        assert!(zerocopy_notice(false, Direction::Download).is_none());
+        // Off and Auto never warn — default-on falls back silently.
+        for mode in [ZerocopyMode::Off, ZerocopyMode::Auto] {
+            assert!(zerocopy_notice(mode, Direction::Upload).is_none());
+            assert!(zerocopy_notice(mode, Direction::Bidir).is_none());
+            assert!(zerocopy_notice(mode, Direction::Download).is_none());
+        }
 
         if cfg!(target_os = "linux") {
             // Supported platform: never warn.
-            assert!(zerocopy_notice(true, Direction::Upload).is_none());
-            assert!(zerocopy_notice(true, Direction::Download).is_none());
-            assert!(zerocopy_notice(true, Direction::Bidir).is_none());
+            assert!(zerocopy_notice(ZerocopyMode::Requested, Direction::Upload).is_none());
+            assert!(zerocopy_notice(ZerocopyMode::Requested, Direction::Download).is_none());
+            assert!(zerocopy_notice(ZerocopyMode::Requested, Direction::Bidir).is_none());
         } else {
             // Unsupported platform: warn only when the client itself sends.
-            assert!(zerocopy_notice(true, Direction::Upload).is_some());
-            assert!(zerocopy_notice(true, Direction::Bidir).is_some());
+            assert!(zerocopy_notice(ZerocopyMode::Requested, Direction::Upload).is_some());
+            assert!(zerocopy_notice(ZerocopyMode::Requested, Direction::Bidir).is_some());
             // Download mode: the server decides its own zero-copy support.
-            assert!(zerocopy_notice(true, Direction::Download).is_none());
+            assert!(zerocopy_notice(ZerocopyMode::Requested, Direction::Download).is_none());
         }
     }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::{AtomicU16, Ordering};
 use std::time::Duration;
 use tokio::time::timeout;
 
-use xfr::client::{Client, ClientConfig};
+use xfr::client::{Client, ClientConfig, ZerocopyMode};
 use xfr::protocol::{Direction, Protocol};
 use xfr::serve::{Server, ServerConfig};
 
@@ -57,7 +57,9 @@ async fn test_tcp_single_stream() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
-        zerocopy: false,
+        // The default mode: exercises sendfile on Linux and the silent
+        // regular-write fallback elsewhere (macOS CI).
+        zerocopy: ZerocopyMode::Auto,
         dscp: None,
     };
 
@@ -109,7 +111,7 @@ async fn test_tcp_multi_stream() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
-        zerocopy: false,
+        zerocopy: ZerocopyMode::Off,
         dscp: None,
     };
 
@@ -143,7 +145,7 @@ async fn test_connection_refused() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
-        zerocopy: false,
+        zerocopy: ZerocopyMode::Off,
         dscp: None,
     };
 
@@ -177,7 +179,7 @@ async fn test_tcp_download() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
-        zerocopy: false,
+        zerocopy: ZerocopyMode::Off,
         dscp: None,
     };
 
@@ -216,7 +218,7 @@ async fn test_tcp_bidir() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
-        zerocopy: false,
+        zerocopy: ZerocopyMode::Off,
         dscp: None,
     };
 
@@ -273,7 +275,7 @@ async fn test_udp_upload() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
-        zerocopy: false,
+        zerocopy: ZerocopyMode::Off,
         dscp: None,
     };
 
@@ -313,7 +315,7 @@ async fn test_udp_download() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
-        zerocopy: false,
+        zerocopy: ZerocopyMode::Off,
         dscp: None,
     };
 
@@ -350,7 +352,7 @@ async fn test_udp_bidir() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
-        zerocopy: false,
+        zerocopy: ZerocopyMode::Off,
         dscp: None,
     };
 
@@ -389,7 +391,7 @@ async fn test_udp_multi_stream() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
-        zerocopy: false,
+        zerocopy: ZerocopyMode::Off,
         dscp: None,
     };
 
@@ -433,7 +435,7 @@ async fn test_multi_client_concurrent() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
-        zerocopy: false,
+        zerocopy: ZerocopyMode::Off,
         dscp: None,
     };
 
@@ -454,7 +456,7 @@ async fn test_multi_client_concurrent() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
-        zerocopy: false,
+        zerocopy: ZerocopyMode::Off,
         dscp: None,
     };
 
@@ -541,7 +543,7 @@ async fn test_psk_auth_success() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
-        zerocopy: false,
+        zerocopy: ZerocopyMode::Off,
         dscp: None,
     };
 
@@ -584,7 +586,7 @@ async fn test_psk_auth_failure() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
-        zerocopy: false,
+        zerocopy: ZerocopyMode::Off,
         dscp: None,
     };
 
@@ -627,7 +629,7 @@ async fn test_psk_auth_missing_client_key() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
-        zerocopy: false,
+        zerocopy: ZerocopyMode::Off,
         dscp: None,
     };
 
@@ -668,7 +670,7 @@ async fn test_acl_allow() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
-        zerocopy: false,
+        zerocopy: ZerocopyMode::Off,
         dscp: None,
     };
 
@@ -706,7 +708,7 @@ async fn test_rate_limit() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
-        zerocopy: false,
+        zerocopy: ZerocopyMode::Off,
         dscp: None,
     };
 
@@ -734,7 +736,7 @@ async fn test_rate_limit() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
-        zerocopy: false,
+        zerocopy: ZerocopyMode::Off,
         dscp: None,
     };
 
@@ -783,7 +785,7 @@ async fn test_quic_upload() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
-        zerocopy: false,
+        zerocopy: ZerocopyMode::Off,
         dscp: None,
     };
 
@@ -823,7 +825,7 @@ async fn test_quic_download() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
-        zerocopy: false,
+        zerocopy: ZerocopyMode::Off,
         dscp: None,
     };
 
@@ -862,7 +864,7 @@ async fn test_quic_multi_stream() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
-        zerocopy: false,
+        zerocopy: ZerocopyMode::Off,
         dscp: None,
     };
 
@@ -905,7 +907,7 @@ async fn test_quic_bidir() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
-        zerocopy: false,
+        zerocopy: ZerocopyMode::Off,
         dscp: None,
     };
 
@@ -945,7 +947,7 @@ async fn test_quic_with_psk() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
-        zerocopy: false,
+        zerocopy: ZerocopyMode::Off,
         dscp: None,
     };
 
@@ -987,7 +989,7 @@ async fn test_acl_deny() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
-        zerocopy: false,
+        zerocopy: ZerocopyMode::Off,
         dscp: None,
     };
 
@@ -1044,7 +1046,7 @@ async fn test_ipv6_localhost() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
-        zerocopy: false,
+        zerocopy: ZerocopyMode::Off,
         dscp: None,
     };
 
@@ -1088,7 +1090,7 @@ async fn test_tcp_infinite_duration_with_cancel() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
-        zerocopy: false,
+        zerocopy: ZerocopyMode::Off,
         dscp: None,
     };
 
@@ -1140,7 +1142,7 @@ async fn test_udp_infinite_duration_with_cancel() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
-        zerocopy: false,
+        zerocopy: ZerocopyMode::Off,
         dscp: None,
     };
 
@@ -1188,7 +1190,7 @@ async fn test_quic_infinite_duration_with_cancel() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
-        zerocopy: false,
+        zerocopy: ZerocopyMode::Off,
         dscp: None,
     };
 
@@ -1258,7 +1260,7 @@ async fn test_udp_ipv4_explicit() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
-        zerocopy: false,
+        zerocopy: ZerocopyMode::Off,
         dscp: None,
     };
 
@@ -1315,7 +1317,7 @@ async fn test_udp_ipv6_explicit() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
-        zerocopy: false,
+        zerocopy: ZerocopyMode::Off,
         dscp: None,
     };
 
@@ -1372,7 +1374,7 @@ async fn test_udp_cport_dualstack_ipv6_target() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
-        zerocopy: false,
+        zerocopy: ZerocopyMode::Off,
         dscp: None,
     };
 
@@ -1413,7 +1415,7 @@ async fn test_tcp_cport_single_stream() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
-        zerocopy: false,
+        zerocopy: ZerocopyMode::Off,
         dscp: None,
     };
 
@@ -1457,7 +1459,7 @@ async fn test_tcp_cport_multi_stream() {
         sequential_ports: true,
         mptcp: false,
         random_payload: false,
-        zerocopy: false,
+        zerocopy: ZerocopyMode::Off,
         dscp: None,
     };
 
@@ -1517,7 +1519,7 @@ async fn test_tcp_cport_dualstack_ipv6_target() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
-        zerocopy: false,
+        zerocopy: ZerocopyMode::Off,
         dscp: None,
     };
 
@@ -1573,7 +1575,7 @@ async fn test_quic_cport_dualstack_ipv6_target() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
-        zerocopy: false,
+        zerocopy: ZerocopyMode::Off,
         dscp: None,
     };
 
@@ -1614,7 +1616,7 @@ async fn test_udp_invalid_sequential_ports_config_fails() {
         sequential_ports: true,
         mptcp: false,
         random_payload: false,
-        zerocopy: false,
+        zerocopy: ZerocopyMode::Off,
         dscp: None,
     };
 
@@ -1662,7 +1664,7 @@ async fn test_udp_bitrate_underflow_regression() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
-        zerocopy: false,
+        zerocopy: ZerocopyMode::Off,
         dscp: None,
     };
 
@@ -1733,7 +1735,7 @@ async fn test_quic_ipv6() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
-        zerocopy: false,
+        zerocopy: ZerocopyMode::Off,
         dscp: None,
     };
 
@@ -1790,7 +1792,7 @@ async fn test_tcp_one_off_multi_stream() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
-        zerocopy: false,
+        zerocopy: ZerocopyMode::Off,
         dscp: None,
     };
 
@@ -1856,7 +1858,7 @@ async fn test_quic_one_off() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
-        zerocopy: false,
+        zerocopy: ZerocopyMode::Off,
         dscp: None,
     };
 
@@ -1901,7 +1903,7 @@ fn test_pause_not_ready_before_test_run() {
         sequential_ports: false,
         mptcp: false,
         random_payload: false,
-        zerocopy: false,
+        zerocopy: ZerocopyMode::Off,
         dscp: None,
     };
 
@@ -2164,7 +2166,7 @@ async fn test_serve_bind_ipv4_loopback() {
         direction: Direction::Upload,
         address_family: xfr::net::AddressFamily::V4Only,
         random_payload: false,
-        zerocopy: false,
+        zerocopy: ZerocopyMode::Off,
         ..Default::default()
     };
     let result = timeout(Duration::from_secs(10), Client::new(client_cfg).run(None)).await;
@@ -2207,7 +2209,7 @@ async fn test_serve_bind_ipv6_loopback() {
         direction: Direction::Upload,
         address_family: xfr::net::AddressFamily::V6Only,
         random_payload: false,
-        zerocopy: false,
+        zerocopy: ZerocopyMode::Off,
         ..Default::default()
     };
     let result = timeout(Duration::from_secs(10), Client::new(client_cfg).run(None)).await;
@@ -2242,7 +2244,7 @@ async fn test_serve_bind_ipv4_quic() {
         direction: Direction::Upload,
         address_family: xfr::net::AddressFamily::V4Only,
         random_payload: false,
-        zerocopy: false,
+        zerocopy: ZerocopyMode::Off,
         ..Default::default()
     };
     let result = timeout(Duration::from_secs(10), Client::new(client_cfg).run(None)).await;
@@ -2284,7 +2286,7 @@ async fn test_serve_bind_ipv6_quic() {
         direction: Direction::Upload,
         address_family: xfr::net::AddressFamily::V6Only,
         random_payload: false,
-        zerocopy: false,
+        zerocopy: ZerocopyMode::Off,
         ..Default::default()
     };
     let result = timeout(Duration::from_secs(10), Client::new(client_cfg).run(None)).await;
@@ -2402,7 +2404,7 @@ async fn test_serve_bind_ipv4_udp() {
         direction: Direction::Upload,
         address_family: xfr::net::AddressFamily::V4Only,
         random_payload: false,
-        zerocopy: false,
+        zerocopy: ZerocopyMode::Off,
         ..Default::default()
     };
     let result = timeout(Duration::from_secs(10), Client::new(client_cfg).run(None)).await;


### PR DESCRIPTION
Follow-up to #33 / #87, prompted by matttbe's question on #33: since the sendfile path only needs kernel 3.17+, why keep it opt-in?

There's no good reason to. Every unsupported configuration already falls back to regular writes — non-Linux platforms, kernels without `memfd_create`, servers predating `zerocopy_v1`, and sockets that reject `sendfile` mid-test. So zero-copy is now the default for TCP, same arc as the random-payload default in #34.

**Behavior:**
- Plain TCP tests use sendfile by default; unsupported setups fall back **silently**.
- Explicit `-Z` still works and now means "insist": downgrades that would be silent in auto mode warn instead (non-Linux client sends, `-R`/`--bidir` against a server that doesn't advertise `zerocopy_v1`).
- New `--no-zerocopy` opts out.
- `-Z -u` / `-Z -Q` still conflict at parse time; bare UDP/QUIC runs simply never use it.

**Implementation:** `ClientConfig.zerocopy` becomes a three-state `ZerocopyMode` (`Off`/`Auto`/`Requested`) so the warning sites can distinguish an explicit request from the default (pre-1.0 API break, noted in CHANGELOG). `TcpConfig.zerocopy` and the `TestStart.zerocopy` wire field stay `bool` — no wire change.

Verified with strace on loopback: a bare `xfr host` now makes ~28k sendfile calls per second of test, `--no-zerocopy` makes none, and payload semantics are unchanged.