### PR TITLE
Add path-MTU probe mode: --probe-mtu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,18 @@ jobs:
       - name: Check MSRV
         run: cargo check --all-features
 
+  mtu-probe:
+    name: MTU probe (#64 netns)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Build release binary
+        run: cargo build --release
+      - name: Probe through a constrained middle hop
+        run: sudo ./test-mtu-probe-ns.sh --ci
+
   # The release workflow cross-compiles aarch64-unknown-linux-gnu with an
   # old-glibc toolchain that the ubuntu/macos test jobs never exercise.
   # v0.9.15 died at release time on a glibc symbol (memfd_create, glibc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Path-MTU probe: `--probe-mtu`** (issue #64) — discovers the largest UDP payload that survives the path in each direction, instead of running a throughput test. The client walks a ladder of common wire MTUs (576, 1280, 1492, 1500, 4352, 9000, 9216) and binary-searches the gap, RFC 8899 style, with the IP don't-fragment flag set so middleboxes must drop oversized packets rather than quietly fragment them. Each probe gets two replies from the server: a small ack (proves the client→server direction) and a same-size echo (proves server→client), so an asymmetric path shows up as ack-without-echo — per-direction attribution was brettowe's suggestion on the issue. Output is a per-size table plus the largest surviving payload and derived path MTU per direction; `--json` carries the full report. Requires a server advertising the new `mtu_probe_v1` capability (the client refuses old servers up front, since they'd silently swallow probes). Validated in a netns harness with a 1500-byte middle hop on a jumbo-framed client (`test-mtu-probe-ns.sh`, now a CI job).
+
 ### Changed
 - **Zero-copy TCP sends are now on by default** (issue #33 follow-up) — `sendfile(2)` needs only Linux 3.17+ and every unsupported configuration (non-Linux, old kernels, old servers, sockets that reject `sendfile`) already falls back to regular writes, so there is no reason to make users opt in to the cheaper send path. `-Z`/`--zerocopy` is kept: passing it explicitly upgrades the silent fallback to a warning (non-Linux client sends, or a `-R`/`--bidir` server that doesn't advertise `zerocopy_v1`). New `--no-zerocopy` flag opts out. Payload semantics are unchanged, and on links where the sender isn't CPU-bound results are identical — where it is, throughput now reflects the network rather than the sender's copy overhead.
 
@@ -15,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Library API (pre-1.0 break)
 - `client::ClientConfig.zerocopy` is now a `ZerocopyMode` enum (`Off` / `Auto` / `Requested`) instead of `bool`; `Default` is `Auto`. `Auto` and `Requested` behave identically except `Requested` warns on downgrade. `tcp::TcpConfig.zerocopy` stays `bool`.
+- New public module `probe` (`ProbePacket`, `SizeSearch`, `MtuProbeReport`, `run_probe`); `client::ClientConfig` gains `mtu_probe: bool`; `protocol::ControlMessage::TestStart` gains `mtu_probe: bool` and `protocol::TestResult` gains `mtu_probe: Option<MtuProbeReport>` (both serde-default, wire-additive); `udp::respond_mtu_probes` and `net::set_dont_fragment` are new.
 
 ## [0.9.16] - 2026-06-10
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,14 @@ Test UDP at your expected rate to detect packet loss:
 xfr <host> -u -b 500M -t 60s    # Watch for loss percentage in TUI
 ```
 
+### Path MTU Discovery
+Find the largest UDP payload that survives the path — per direction, with
+the don't-fragment flag set so middleboxes can't hide the limit by
+fragmenting (useful for NFS-over-UDP and VPN/tunnel tuning):
+```bash
+xfr <host> --probe-mtu
+```
+
 ### Before/After Comparison
 Quantify the impact of network changes:
 ```bash
@@ -455,6 +463,7 @@ See `examples/grafana-dashboard.json` for a sample Grafana dashboard.
 | `--zeros` | | false | Use zero-filled payload data (client-sent traffic only) |
 | `--zerocopy` | `-Z` | true (TCP) | Zero-copy TCP sends via sendfile(2), like iperf3 -Z (Linux; lowers sender CPU overhead). On by default; explicit `-Z` warns when zero-copy can't take effect |
 | `--no-zerocopy` | | false | Disable zero-copy TCP sends (use regular buffered writes) |
+| `--probe-mtu` | | false | Probe the path MTU per direction instead of running a throughput test (UDP + DF bit; needs server ≥ this version) |
 | `--json` | | false | JSON output |
 | `--json-stream` | | false | JSON per interval |
 | `--csv` | | false | CSV output |

--- a/src/client.rs
+++ b/src/client.rs
@@ -228,6 +228,10 @@ pub struct ClientConfig {
     pub zerocopy: ZerocopyMode,
     /// DSCP/TOS value for IP_TOS socket option
     pub dscp: Option<u8>,
+    /// Run a path-MTU probe instead of a throughput test (issue #64,
+    /// `--probe-mtu`). UDP only; requires a server advertising
+    /// `mtu_probe_v1`.
+    pub mtu_probe: bool,
 }
 
 impl Default for ClientConfig {
@@ -251,6 +255,7 @@ impl Default for ClientConfig {
             random_payload: true,
             zerocopy: ZerocopyMode::Auto,
             dscp: None,
+            mtu_probe: false,
         }
     }
 }
@@ -644,6 +649,19 @@ impl Client {
             warn!("Server does not support zero-copy; server-sent traffic will use regular writes");
         }
 
+        // MTU probing needs active server cooperation (ack + echo per
+        // probe); an old server would silently count probes as junk
+        // data and the search would read as "everything blocked".
+        // Refuse up front instead.
+        if self.config.mtu_probe
+            && !crate::protocol::capability_advertised(&server_capabilities, "mtu_probe_v1")
+        {
+            return Err(anyhow::anyhow!(
+                "Server does not support MTU probing (mtu_probe_v1 capability missing); \
+                 upgrade the server to use --probe-mtu"
+            ));
+        }
+
         // Validate congestion algorithm before starting test (TCP only)
         if self.config.protocol == Protocol::Tcp
             && let Some(ref algo) = self.config.tcp_congestion
@@ -667,6 +685,7 @@ impl Client {
             dscp: self.config.dscp,
             window_size: self.config.window_size.map(|w| w as u64),
             zerocopy: self.config.protocol == Protocol::Tcp && self.config.zerocopy.enabled(),
+            mtu_probe: self.config.mtu_probe,
         };
         writer
             .write_all(format!("{}\n", test_start.serialize()?).as_bytes())
@@ -702,6 +721,15 @@ impl Client {
                     The server may be an older version that is incompatible with this client."
                 ));
             }
+        }
+
+        // --probe-mtu: the handshake above is shared with throughput
+        // tests, but from here probe mode runs its own exchange on the
+        // data socket instead of bulk streams, then cancels the test.
+        if self.config.mtu_probe {
+            return self
+                .run_mtu_probe_exchange(&mut reader, &mut writer, &test_id, server_ip, &data_ports)
+                .await;
         }
 
         // Create stats
@@ -1344,6 +1372,78 @@ impl Client {
         Ok(handles)
     }
 
+    /// The `--probe-mtu` data exchange (issue #64): walk payload sizes
+    /// against the server's probe responder on the (single) UDP data
+    /// socket, then cancel the test on the control channel and wait for
+    /// the server's Result so the connection closes out the normal way.
+    /// The probe report rides home on the result's `mtu_probe` field.
+    async fn run_mtu_probe_exchange(
+        &self,
+        reader: &mut BufReader<tokio::net::tcp::OwnedReadHalf>,
+        writer: &mut tokio::net::tcp::OwnedWriteHalf,
+        test_id: &str,
+        server_ip: SocketAddr,
+        data_ports: &[u16],
+    ) -> anyhow::Result<TestResult> {
+        let port = data_ports
+            .first()
+            .copied()
+            .ok_or_else(|| anyhow::anyhow!("Server allocated no UDP port for the MTU probe"))?;
+        let server_addr = SocketAddr::new(server_ip.ip(), port);
+
+        let socket = net::create_udp_socket_for_remote(server_addr).await?;
+        socket.connect(server_addr).await?;
+        let ipv6 = socket.local_addr().map(|a| a.is_ipv6()).unwrap_or(false);
+        // Without DF the kernel fragments oversized probes and every
+        // size "passes" — the forward results would be meaningless.
+        // Reverse stays valid (the server sets DF on its echoes), so
+        // degrade with a warning rather than refuse.
+        if let Err(e) = net::set_dont_fragment(&socket, ipv6) {
+            warn!(
+                "Could not set don't-fragment on probe socket: {} \
+                 (client-to-server results may overstate the path)",
+                e
+            );
+        }
+
+        let report = crate::probe::run_probe(&socket, ipv6).await?;
+
+        // The probe converged well before the test duration; cancel so
+        // the server sends its Result now instead of at the deadline.
+        let cancel_msg = ControlMessage::Cancel {
+            id: test_id.to_string(),
+            reason: "MTU probe complete".to_string(),
+        };
+        writer
+            .write_all(format!("{}\n", cancel_msg.serialize()?).as_bytes())
+            .await?;
+
+        // Drain control messages (Intervals that accumulated during the
+        // probe, the Cancelled ack) until the Result lands. If the test
+        // deadline beat our cancel, the Result may already be queued.
+        let mut line = String::new();
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+        let mut result = loop {
+            line.clear();
+            let n = tokio::time::timeout_at(deadline, read_bounded_line(reader, &mut line))
+                .await
+                .map_err(|_| anyhow::anyhow!("Timeout waiting for probe result"))??;
+            if n == 0 {
+                return Err(anyhow::anyhow!("Connection closed before probe result"));
+            }
+            match ControlMessage::deserialize(line.trim())? {
+                ControlMessage::Result(result) => break result,
+                ControlMessage::Error { message } => {
+                    return Err(anyhow::anyhow!("Server error: {}", message));
+                }
+                _ => continue,
+            }
+        };
+
+        result.mtu_probe = Some(report);
+        Ok(result)
+    }
+
     #[allow(clippy::too_many_arguments)]
     async fn spawn_udp_streams(
         &self,
@@ -1709,6 +1809,7 @@ impl Client {
             dscp: None,        // QUIC manages its own TOS via the transport layer
             window_size: None, // QUIC flow control is handled at the transport layer
             zerocopy: false,   // sendfile is incompatible with QUIC's userspace encryption
+            mtu_probe: false,  // probe mode is UDP-only
         };
         ctrl_send
             .write_all(format!("{}\n", test_start.serialize()?).as_bytes())
@@ -2214,6 +2315,7 @@ mod tests {
             bytes_received: None,
             throughput_send_mbps: None,
             throughput_recv_mbps: None,
+            mtu_probe: None,
         };
 
         overlay_udp_download_result(&mut result, &stats);
@@ -2243,6 +2345,7 @@ mod tests {
             bytes_received: None,
             throughput_send_mbps: None,
             throughput_recv_mbps: None,
+            mtu_probe: None,
         };
         overlay_udp_download_result(&mut result, &stats);
         assert_eq!(result.bytes_total, 1_000);
@@ -2271,6 +2374,7 @@ mod tests {
             bytes_received: Some(300_000_000),
             throughput_send_mbps: Some(160.0),
             throughput_recv_mbps: Some(2_400.0),
+            mtu_probe: None,
         };
 
         overlay_udp_bidir_result(&mut result, &stats);
@@ -2306,6 +2410,7 @@ mod tests {
             bytes_received: None,
             throughput_send_mbps: None,
             throughput_recv_mbps: None,
+            mtu_probe: None,
         };
 
         overlay_udp_bidir_result(&mut result, &stats);

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -161,6 +161,7 @@ mod tests {
             bytes_received: None,
             throughput_send_mbps: None,
             throughput_recv_mbps: None,
+            mtu_probe: None,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,7 @@ pub mod net;
 pub mod output;
 mod pause;
 pub mod prefs;
+pub mod probe;
 pub mod protocol;
 pub mod quic;
 pub mod rate_limit;

--- a/src/main.rs
+++ b/src/main.rs
@@ -300,6 +300,17 @@ struct Cli {
     /// Disable zero-copy TCP sends (use regular buffered writes)
     #[arg(long, conflicts_with = "zerocopy")]
     no_zerocopy: bool,
+
+    /// Probe the path MTU instead of running a throughput test: walks
+    /// UDP payload sizes with the don't-fragment flag set and reports
+    /// the largest size surviving in each direction (issue #64).
+    /// Implies UDP (a redundant -u is accepted); requires a server with
+    /// mtu_probe_v1 support.
+    #[arg(
+        long,
+        conflicts_with_all = ["quic", "reverse", "bidir", "bitrate", "parallel", "zerocopy", "zeros"]
+    )]
+    probe_mtu: bool,
 }
 
 #[derive(Subcommand)]
@@ -927,7 +938,7 @@ async fn main() -> Result<()> {
 
             let protocol = if cli.quic {
                 Protocol::Quic
-            } else if cli.udp {
+            } else if cli.udp || cli.probe_mtu {
                 Protocol::Udp
             } else {
                 Protocol::Tcp
@@ -960,6 +971,12 @@ async fn main() -> Result<()> {
             // Apply config file defaults where CLI didn't override
             let duration = if cli.time != Duration::from_secs(10) {
                 cli.time
+            } else if cli.probe_mtu {
+                // Probe mode: the duration is only a server-side safety
+                // deadline (the client cancels as soon as the search
+                // converges, normally within seconds). The 10s default
+                // could truncate a slow search, so give it headroom.
+                Duration::from_secs(60)
             } else {
                 file_config
                     .client
@@ -1088,6 +1105,7 @@ async fn main() -> Result<()> {
                 mptcp: cli.mptcp,
                 random_payload,
                 zerocopy,
+                mtu_probe: cli.probe_mtu,
                 dscp: cli
                     .dscp
                     .as_ref()
@@ -1108,7 +1126,10 @@ async fn main() -> Result<()> {
                 timestamp_format,
             };
 
-            if no_tui || json_output || cli.json_stream || cli.csv || cli.quiet {
+            // Probe mode always uses plain output: there is no live
+            // throughput to graph, the run lasts seconds, and the
+            // deliverable is the per-size table.
+            if no_tui || json_output || cli.json_stream || cli.csv || cli.quiet || cli.probe_mtu {
                 // Plain/JSON/CSV mode
                 run_client_plain(config, output_opts, cli.output).await?;
             } else {
@@ -1416,6 +1437,7 @@ fn build_fallback_result(cumulative_bytes: u64, elapsed_ms: u64) -> xfr::protoco
         bytes_received: None,
         throughput_send_mbps: None,
         throughput_recv_mbps: None,
+        mtu_probe: None,
     }
 }
 
@@ -2106,6 +2128,27 @@ mod tests {
 
         // MPTCP is allowed (sendfile goes through the regular splice path)
         assert!(Cli::try_parse_from(["xfr", "host", "-Z", "--mptcp"]).is_ok());
+    }
+
+    #[test]
+    fn test_cli_probe_mtu_flag() {
+        use clap::Parser;
+
+        let cli = Cli::try_parse_from(["xfr", "host", "--probe-mtu"]).unwrap();
+        assert!(cli.probe_mtu);
+
+        // Redundant -u is accepted (probe implies UDP anyway)
+        assert!(Cli::try_parse_from(["xfr", "host", "--probe-mtu", "-u"]).is_ok());
+
+        // A diagnostic mode: throughput-test knobs conflict
+        for forbidden in ["-Q", "-R", "--bidir", "-Z", "--zeros"] {
+            assert!(
+                Cli::try_parse_from(["xfr", "host", "--probe-mtu", forbidden]).is_err(),
+                "--probe-mtu must conflict with {forbidden}"
+            );
+        }
+        assert!(Cli::try_parse_from(["xfr", "host", "--probe-mtu", "-b", "1G"]).is_err());
+        assert!(Cli::try_parse_from(["xfr", "host", "--probe-mtu", "-P", "4"]).is_err());
     }
 
     #[test]

--- a/src/net.rs
+++ b/src/net.rs
@@ -520,6 +520,81 @@ pub fn set_tos_on_udp(_socket: &UdpSocket, _tos: u8) -> io::Result<()> {
     Ok(())
 }
 
+/// Set the IP don't-fragment behavior on a UDP socket so oversized
+/// MTU-probe packets are dropped (surfacing EMSGSIZE locally, or dying
+/// at the constraining hop) instead of being fragmented — fragmentation
+/// would hide exactly the path limit `--probe-mtu` measures (issue #64).
+///
+/// Linux exposes this as `IP_MTU_DISCOVER = IP_PMTUDISC_DO` (and the
+/// IPv6 twin); macOS/BSD use the boolean `IP_DONTFRAG`/`IPV6_DONTFRAG`.
+#[cfg(target_os = "linux")]
+pub fn set_dont_fragment(socket: &UdpSocket, ipv6: bool) -> io::Result<()> {
+    use std::os::unix::io::AsRawFd;
+    let (level, optname, value) = if ipv6 {
+        (
+            libc::IPPROTO_IPV6,
+            libc::IPV6_MTU_DISCOVER,
+            libc::IPV6_PMTUDISC_DO,
+        )
+    } else {
+        (
+            libc::IPPROTO_IP,
+            libc::IP_MTU_DISCOVER,
+            libc::IP_PMTUDISC_DO,
+        )
+    };
+    let value = value as libc::c_int;
+    // SAFETY: fd is a valid descriptor, value is a c_int on the stack.
+    let ret = unsafe {
+        libc::setsockopt(
+            socket.as_raw_fd(),
+            level,
+            optname,
+            &value as *const libc::c_int as *const libc::c_void,
+            std::mem::size_of::<libc::c_int>() as libc::socklen_t,
+        )
+    };
+    if ret != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+#[cfg(any(target_os = "macos", target_os = "freebsd"))]
+pub fn set_dont_fragment(socket: &UdpSocket, ipv6: bool) -> io::Result<()> {
+    use std::os::unix::io::AsRawFd;
+    let (level, optname) = if ipv6 {
+        (libc::IPPROTO_IPV6, libc::IPV6_DONTFRAG)
+    } else {
+        (libc::IPPROTO_IP, libc::IP_DONTFRAG)
+    };
+    let value: libc::c_int = 1;
+    // SAFETY: fd is a valid descriptor, value is a c_int on the stack.
+    let ret = unsafe {
+        libc::setsockopt(
+            socket.as_raw_fd(),
+            level,
+            optname,
+            &value as *const libc::c_int as *const libc::c_void,
+            std::mem::size_of::<libc::c_int>() as libc::socklen_t,
+        )
+    };
+    if ret != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+// Only platforms with a verified DONTFRAG constant get the real call;
+// guessing option numbers risks setting an unrelated IP option.
+#[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "freebsd")))]
+pub fn set_dont_fragment(_socket: &UdpSocket, _ipv6: bool) -> io::Result<()> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "don't-fragment control is not supported on this platform",
+    ))
+}
+
 /// Apply `-w`/`--window` to a UDP socket via `SO_SNDBUF`/`SO_RCVBUF`.
 ///
 /// Sets both buffers to the same size for symmetry with the existing TCP

--- a/src/output/plain.rs
+++ b/src/output/plain.rs
@@ -1,9 +1,15 @@
 //! Plain text output
 
+use crate::probe::{MtuProbeReport, SizeVerdict};
 use crate::protocol::TestResult;
 use crate::stats::{bytes_to_human, mbps_to_human};
 
 pub fn output_plain(result: &TestResult, mptcp: bool) -> String {
+    // A probe run carries no meaningful throughput numbers; the
+    // per-size table IS the result.
+    if let Some(ref probe) = result.mtu_probe {
+        return format_mtu_probe(probe);
+    }
     let mut output = String::new();
 
     output.push_str("─".repeat(60).as_str());
@@ -124,6 +130,67 @@ pub fn output_plain(result: &TestResult, mptcp: bool) -> String {
     output
 }
 
+/// Render a `--probe-mtu` report (issue #64): the per-size walk, then
+/// the largest surviving payload and derived path MTU per direction.
+fn format_mtu_probe(probe: &MtuProbeReport) -> String {
+    let mut output = String::new();
+
+    output.push_str("─".repeat(60).as_str());
+    output.push('\n');
+    output.push_str("  xfr Path MTU Probe\n");
+    output.push_str("─".repeat(60).as_str());
+    output.push_str("\n\n");
+
+    output.push_str(&format!(
+        "  Address family: {} ({} bytes IP+UDP overhead)\n\n",
+        if probe.ipv6 { "IPv6" } else { "IPv4" },
+        crate::probe::ip_overhead(probe.ipv6)
+    ));
+
+    output.push_str("  Payload      client → server    server → client\n");
+    for size in &probe.sizes {
+        output.push_str(&format!(
+            "  {:>7}      {:<18} {}\n",
+            size.payload,
+            format_verdict(size.forward, size.forward_ok, size.attempts),
+            format_verdict(size.reverse, size.reverse_ok, size.attempts),
+        ));
+    }
+    output.push('\n');
+
+    match (probe.forward_max_payload, probe.forward_path_mtu) {
+        (Some(payload), Some(mtu)) => output.push_str(&format!(
+            "  Largest payload client → server: {} bytes  (path MTU ≈ {})\n",
+            payload, mtu
+        )),
+        _ => output.push_str("  Largest payload client → server: none survived\n"),
+    }
+    match (probe.reverse_max_payload, probe.reverse_path_mtu) {
+        (Some(payload), Some(mtu)) => output.push_str(&format!(
+            "  Largest payload server → client: {} bytes  (path MTU ≈ {})\n",
+            payload, mtu
+        )),
+        _ => output.push_str("  Largest payload server → client: none observed\n"),
+    }
+    // The echo can only ever be as large as the probe that triggered
+    // it, so a wider reverse path is invisible from this side.
+    output.push_str("  (server → client is a lower bound, capped by the client → server path)\n");
+
+    output.push_str("─".repeat(60).as_str());
+    output.push('\n');
+
+    output
+}
+
+fn format_verdict(verdict: SizeVerdict, ok: u8, attempts: u8) -> String {
+    match verdict {
+        SizeVerdict::Pass => format!("pass ({}/{})", ok, attempts),
+        SizeVerdict::Fail => format!("BLOCKED (0/{})", attempts),
+        SizeVerdict::LocalLimit => "local MTU limit".to_string(),
+        SizeVerdict::Untested => "untested".to_string(),
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn output_interval_plain(
     timestamp: &str,
@@ -192,6 +259,7 @@ mod tests {
             bytes_received: None,
             throughput_send_mbps: None,
             throughput_recv_mbps: None,
+            mtu_probe: None,
         }
     }
 

--- a/src/probe.rs
+++ b/src/probe.rs
@@ -1,0 +1,703 @@
+//! UDP path-MTU probe (`--probe-mtu`, issue #64).
+//!
+//! Discovers the largest UDP payload that survives the path in each
+//! direction, in the spirit of DPLPMTUD (RFC 8899): walk a ladder of
+//! common MTU sizes, then binary-search the gap between the largest
+//! passing and smallest failing size. Every probe is sent with the IP
+//! don't-fragment flag set so middleboxes must drop oversized packets
+//! rather than fragment them — fragmentation would hide exactly the
+//! limit we're measuring.
+//!
+//! Direction attribution uses a three-packet exchange per probe
+//! (suggested by brettowe on the issue): the client sends a `Probe` of
+//! the trial size; the server answers with a small fixed-size `Ack`
+//! (which survives almost any path, proving the forward direction) and
+//! a full-size `Echo` padded to the same trial size (proving the
+//! reverse direction). Ack-without-echo therefore means the reverse
+//! path blocks the size even though the forward path carried it.
+//!
+//! Wire framing shares the data socket with regular UDP test traffic
+//! and the `XFRF` feedback lane; the `XFRP` magic plus a `kind` byte is
+//! the discriminator. Probe mode never runs concurrently with bulk
+//! traffic, but the magic keeps stray packets from being misparsed.
+
+use serde::{Deserialize, Serialize};
+
+/// Magic prefix on every probe-lane packet. Distinct from `XFRF`
+/// (feedback) and from data-packet sequence prefixes (high bits of a
+/// u64 counter starting at zero).
+pub const PROBE_MAGIC: [u8; 4] = *b"XFRP";
+/// Currently-supported probe packet protocol version.
+pub const PROBE_VERSION: u8 = 1;
+/// Header bytes preceding the padding in `Probe`/`Echo` packets; also
+/// the full size of an `Ack`. Must stay below `MIN_PROBE_PAYLOAD`.
+pub const PROBE_HEADER_SIZE: usize = 16;
+/// Smallest trial payload. 576 is the classic IPv4 minimum-reassembly
+/// datagram; nothing real blocks below this, and the header has to fit.
+pub const MIN_PROBE_PAYLOAD: usize = 548; // 576 wire - 28 IPv4/UDP overhead
+/// Largest trial payload: 9216-byte jumbo wire MTU minus IPv4 overhead.
+pub const MAX_PROBE_PAYLOAD: usize = 9188;
+
+/// Packet kinds on the probe lane.
+pub const PROBE_KIND_PROBE: u8 = 1;
+pub const PROBE_KIND_ACK: u8 = 2;
+pub const PROBE_KIND_ECHO: u8 = 3;
+
+/// Per-IP-version overhead between UDP payload size and wire MTU:
+/// 20 (IPv4) or 40 (IPv6) IP header + 8 UDP header.
+pub fn ip_overhead(is_ipv6: bool) -> usize {
+    if is_ipv6 { 48 } else { 28 }
+}
+
+/// A probe-lane packet.
+///
+/// Wire layout, all multi-byte fields big-endian:
+/// ```text
+/// offset  size  field
+///   0      4    magic = b"XFRP"
+///   4      1    version = 1
+///   5      1    kind (1 = probe, 2 = ack, 3 = echo)
+///   6      2    flags = 0 (reserved)
+///   8      4    seq (u32)
+///  12      2    declared_size (u16) — full payload size of the Probe
+///               this packet belongs to (Acks carry it so the client
+///               can attribute them without trusting datagram length)
+///  14      2    reserved = 0
+///  16      —    padding to declared_size (Probe/Echo only)
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProbePacket {
+    pub kind: u8,
+    pub seq: u32,
+    pub declared_size: u16,
+}
+
+impl ProbePacket {
+    /// Encode into `buffer`, returning the number of bytes to send:
+    /// `declared_size` for Probe/Echo (header + padding), or
+    /// `PROBE_HEADER_SIZE` for Ack. Returns `None` when the buffer is
+    /// too small or `declared_size` is below the header size for a
+    /// padded kind.
+    pub fn encode(&self, buffer: &mut [u8]) -> Option<usize> {
+        let wire_len = match self.kind {
+            PROBE_KIND_ACK => PROBE_HEADER_SIZE,
+            _ => usize::from(self.declared_size),
+        };
+        if wire_len < PROBE_HEADER_SIZE || buffer.len() < wire_len {
+            return None;
+        }
+        buffer[0..4].copy_from_slice(&PROBE_MAGIC);
+        buffer[4] = PROBE_VERSION;
+        buffer[5] = self.kind;
+        buffer[6..8].copy_from_slice(&0u16.to_be_bytes()); // flags
+        buffer[8..12].copy_from_slice(&self.seq.to_be_bytes());
+        buffer[12..14].copy_from_slice(&self.declared_size.to_be_bytes());
+        buffer[14..16].copy_from_slice(&0u16.to_be_bytes()); // reserved
+        Some(wire_len)
+    }
+
+    /// Decode a probe-lane packet. Returns `None` for wrong magic,
+    /// version, unknown kind, or a padded kind whose datagram is
+    /// shorter than its header. Padding content is ignored.
+    pub fn decode(buffer: &[u8]) -> Option<Self> {
+        if buffer.len() < PROBE_HEADER_SIZE || buffer[0..4] != PROBE_MAGIC {
+            return None;
+        }
+        if buffer[4] != PROBE_VERSION {
+            return None;
+        }
+        let kind = buffer[5];
+        if !matches!(kind, PROBE_KIND_PROBE | PROBE_KIND_ACK | PROBE_KIND_ECHO) {
+            return None;
+        }
+        let seq = u32::from_be_bytes(buffer[8..12].try_into().ok()?);
+        let declared_size = u16::from_be_bytes(buffer[12..14].try_into().ok()?);
+        Some(Self {
+            kind,
+            seq,
+            declared_size,
+        })
+    }
+}
+
+/// Outcome of probing one payload size in one direction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SizeVerdict {
+    /// At least one probe of this size made it through.
+    Pass,
+    /// Every attempt was lost.
+    Fail,
+    /// The local kernel refused the send (EMSGSIZE with DF set) —
+    /// the local interface MTU is below this size.
+    LocalLimit,
+    /// Never exercised: the reverse direction is only tested by the
+    /// echo a successful forward probe triggers, so a size whose
+    /// forward probes all died leaves the reverse path unknown.
+    Untested,
+}
+
+/// Per-size probe record, kept for the final report table.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SizeResult {
+    pub payload: usize,
+    /// Probes acked by the server (forward direction successes).
+    pub forward_ok: u8,
+    /// Full-size echoes received back (reverse direction successes).
+    pub reverse_ok: u8,
+    /// Probes attempted at this size.
+    pub attempts: u8,
+    pub forward: SizeVerdict,
+    pub reverse: SizeVerdict,
+}
+
+/// Final probe report, attached to the client-side `TestResult`
+/// (wire-additive; the server never populates it).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MtuProbeReport {
+    /// Largest payload that passed client→server, if any size did.
+    pub forward_max_payload: Option<usize>,
+    /// Largest payload that passed server→client, if any size did.
+    pub reverse_max_payload: Option<usize>,
+    /// `forward_max_payload` + IP/UDP overhead for the address family
+    /// used — the conventional "path MTU" number.
+    pub forward_path_mtu: Option<usize>,
+    pub reverse_path_mtu: Option<usize>,
+    /// True when the address family was IPv6 (48-byte overhead).
+    pub ipv6: bool,
+    /// Every size tried, in probe order.
+    pub sizes: Vec<SizeResult>,
+}
+
+/// The ladder of payload sizes tried before binary search, derived
+/// from wire MTUs seen in the wild: IPv4 minimum (576), IPv6 minimum
+/// (1280), PPPoE (1492), Ethernet (1500), FDDI (4352), jumbo (9000,
+/// 9216). Clamped to the valid probe range and deduplicated; always
+/// ends at `MAX_PROBE_PAYLOAD` so the search space is fully bracketed.
+pub fn size_ladder(is_ipv6: bool) -> Vec<usize> {
+    let overhead = ip_overhead(is_ipv6);
+    let mut ladder: Vec<usize> = [576usize, 1280, 1492, 1500, 4352, 9000, 9216]
+        .iter()
+        .map(|wire| wire.saturating_sub(overhead))
+        .filter(|&p| (MIN_PROBE_PAYLOAD..=MAX_PROBE_PAYLOAD).contains(&p))
+        .collect();
+    if ladder.first() != Some(&MIN_PROBE_PAYLOAD) {
+        ladder.insert(0, MIN_PROBE_PAYLOAD);
+    }
+    if ladder.last() != Some(&MAX_PROBE_PAYLOAD) {
+        ladder.push(MAX_PROBE_PAYLOAD);
+    }
+    ladder.dedup();
+    ladder
+}
+
+/// Driver for the size-search state machine, kept free of socket IO so
+/// the search logic is unit-testable. Call `next_size()` to get the
+/// next payload to probe; report the outcome with `record()`; repeat
+/// until `next_size()` returns `None`. Ladder phase first, then binary
+/// search between the bracketing pass/fail pair.
+///
+/// The search key is the *forward* verdict: that is the direction the
+/// prober controls the send size of directly. Reverse outcomes are
+/// recorded per size for the report but do not steer the search — the
+/// echo is always the same size as the probe, so reverse data arrives
+/// for free at every step.
+#[derive(Debug)]
+pub struct SizeSearch {
+    ladder: Vec<usize>,
+    ladder_idx: usize,
+    /// Largest size with a forward pass so far.
+    low: Option<usize>,
+    /// Smallest size with a forward fail so far.
+    high: Option<usize>,
+    in_binary: bool,
+    pending: Option<usize>,
+}
+
+impl SizeSearch {
+    pub fn new(is_ipv6: bool) -> Self {
+        Self {
+            ladder: size_ladder(is_ipv6),
+            ladder_idx: 0,
+            low: None,
+            high: None,
+            in_binary: false,
+            pending: None,
+        }
+    }
+
+    /// Next payload size to probe, or `None` when the search has
+    /// converged (bracket closed to <= 1 byte or ladder exhausted with
+    /// no failures).
+    pub fn next_size(&mut self) -> Option<usize> {
+        if let Some(p) = self.pending {
+            return Some(p);
+        }
+        let next = if !self.in_binary {
+            loop {
+                match self.ladder.get(self.ladder_idx) {
+                    // A ladder rung above a known failure is pointless;
+                    // skip ahead (failures bracket from above).
+                    Some(&size) if self.high.is_some_and(|h| size >= h) => {
+                        self.ladder_idx += 1;
+                    }
+                    Some(&size) => break Some(size),
+                    None => {
+                        self.in_binary = true;
+                        break self.binary_midpoint();
+                    }
+                }
+            }
+        } else {
+            self.binary_midpoint()
+        };
+        self.pending = next;
+        next
+    }
+
+    fn binary_midpoint(&self) -> Option<usize> {
+        let low = self.low?;
+        let high = self.high?;
+        if high - low <= 1 {
+            return None;
+        }
+        Some(low + (high - low) / 2)
+    }
+
+    /// Record the forward verdict for the size most recently returned
+    /// by `next_size()`.
+    pub fn record(&mut self, size: usize, forward: SizeVerdict) {
+        self.pending = None;
+        if !self.in_binary {
+            self.ladder_idx += 1;
+        }
+        match forward {
+            SizeVerdict::Pass => {
+                if self.low.is_none_or(|l| size > l) {
+                    self.low = Some(size);
+                }
+            }
+            // LocalLimit brackets exactly like a path failure: the
+            // search should converge below it either way.
+            SizeVerdict::Fail | SizeVerdict::LocalLimit => {
+                if self.high.is_none_or(|h| size < h) {
+                    self.high = Some(size);
+                }
+            }
+            // Reverse-only verdict; the search keys on forward outcomes
+            // and a forward probe is always either sent or refused.
+            SizeVerdict::Untested => {
+                debug_assert!(false, "Untested is never a forward verdict");
+            }
+        }
+    }
+
+    /// Largest forward-passing size found, if any.
+    pub fn forward_max(&self) -> Option<usize> {
+        self.low
+    }
+}
+
+/// Attempts per trial size. The first attempt that proves both
+/// directions short-circuits, so the cost is paid only on lossy or
+/// blocked sizes.
+pub const PROBES_PER_SIZE: u8 = 3;
+/// How long to wait for the ack/echo pair after each probe send.
+pub const PROBE_REPLY_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(250);
+
+/// Client-side probe driver: run the size search against a connected
+/// UDP socket whose peer is a `mtu_probe_v1` server, and assemble the
+/// report. The caller is responsible for having set don't-fragment on
+/// the socket — without it the forward direction overstates the path.
+///
+/// Reverse-direction results are a lower bound capped by the forward
+/// path: echoes are only triggered by probes that arrived, so a reverse
+/// path *wider* than the forward one can't be observed from this side.
+pub async fn run_probe(
+    socket: &tokio::net::UdpSocket,
+    is_ipv6: bool,
+) -> std::io::Result<MtuProbeReport> {
+    let mut search = SizeSearch::new(is_ipv6);
+    let mut sizes = Vec::new();
+    let mut send_buf = vec![0u8; MAX_PROBE_PAYLOAD];
+    let mut recv_buf = vec![0u8; MAX_PROBE_PAYLOAD + 100];
+    let mut seq: u32 = 0;
+    let mut reverse_max: Option<usize> = None;
+
+    while let Some(size) = search.next_size() {
+        let mut forward_ok: u8 = 0;
+        let mut reverse_ok: u8 = 0;
+        let mut attempts: u8 = 0;
+        let mut local_limit = false;
+
+        for _ in 0..PROBES_PER_SIZE {
+            attempts += 1;
+            seq = seq.wrapping_add(1);
+            let pkt = ProbePacket {
+                kind: PROBE_KIND_PROBE,
+                seq,
+                declared_size: size as u16,
+            };
+            let len = pkt
+                .encode(&mut send_buf)
+                .expect("send buffer sized for MAX_PROBE_PAYLOAD");
+            match socket.send(&send_buf[..len]).await {
+                Ok(_) => {}
+                Err(e) if is_emsgsize(&e) => {
+                    local_limit = true;
+                    break;
+                }
+                Err(e) => {
+                    // Transient send failures (e.g. ECONNREFUSED surfaced
+                    // from an ICMP unreachable on a connected socket)
+                    // count as a lost attempt, not a fatal error — the
+                    // search needs the verdict either way.
+                    tracing::debug!("probe send failed at {}B: {}", size, e);
+                    continue;
+                }
+            }
+
+            let (got_ack, got_echo) = collect_replies(socket, &mut recv_buf, seq, size).await;
+            if got_ack {
+                forward_ok += 1;
+            }
+            if got_echo {
+                reverse_ok += 1;
+            }
+            // Both directions proven at this size; no need to keep going.
+            if got_ack && got_echo {
+                break;
+            }
+        }
+
+        let forward = if local_limit {
+            SizeVerdict::LocalLimit
+        } else if forward_ok > 0 {
+            SizeVerdict::Pass
+        } else {
+            SizeVerdict::Fail
+        };
+        let reverse = if reverse_ok > 0 {
+            SizeVerdict::Pass
+        } else if forward == SizeVerdict::Pass {
+            SizeVerdict::Fail
+        } else {
+            SizeVerdict::Untested
+        };
+        if reverse == SizeVerdict::Pass && reverse_max.is_none_or(|m| size > m) {
+            reverse_max = Some(size);
+        }
+        sizes.push(SizeResult {
+            payload: size,
+            forward_ok,
+            reverse_ok,
+            attempts,
+            forward,
+            reverse,
+        });
+        search.record(size, forward);
+    }
+
+    let overhead = ip_overhead(is_ipv6);
+    Ok(MtuProbeReport {
+        forward_max_payload: search.forward_max(),
+        reverse_max_payload: reverse_max,
+        forward_path_mtu: search.forward_max().map(|p| p + overhead),
+        reverse_path_mtu: reverse_max.map(|p| p + overhead),
+        ipv6: is_ipv6,
+        sizes,
+    })
+}
+
+/// Wait up to [`PROBE_REPLY_TIMEOUT`] for the ack/echo pair belonging to
+/// `seq`, returning early once both arrive. Echo validity requires the
+/// datagram to actually be `size` bytes on the wire — the declared-size
+/// field alone would also match a truncated delivery.
+async fn collect_replies(
+    socket: &tokio::net::UdpSocket,
+    recv_buf: &mut [u8],
+    seq: u32,
+    size: usize,
+) -> (bool, bool) {
+    let deadline = tokio::time::Instant::now() + PROBE_REPLY_TIMEOUT;
+    let mut got_ack = false;
+    let mut got_echo = false;
+    while !(got_ack && got_echo) {
+        let now = tokio::time::Instant::now();
+        if now >= deadline {
+            break;
+        }
+        match tokio::time::timeout(deadline - now, socket.recv(recv_buf)).await {
+            Err(_) => break, // reply window elapsed
+            Ok(Err(e)) => {
+                // ICMP-derived errors on a connected socket (port
+                // unreachable etc.) read as recv failures; treat like a
+                // lost reply and let the timeout bound the wait.
+                tracing::debug!("probe recv failed for seq {}: {}", seq, e);
+            }
+            Ok(Ok(n)) => {
+                let Some(reply) = ProbePacket::decode(&recv_buf[..n]) else {
+                    continue;
+                };
+                if reply.seq != seq || usize::from(reply.declared_size) != size {
+                    continue; // stale reply from an earlier attempt
+                }
+                match reply.kind {
+                    PROBE_KIND_ACK => got_ack = true,
+                    PROBE_KIND_ECHO if n == size => got_echo = true,
+                    _ => {}
+                }
+            }
+        }
+    }
+    (got_ack, got_echo)
+}
+
+#[cfg(unix)]
+fn is_emsgsize(e: &std::io::Error) -> bool {
+    e.raw_os_error() == Some(libc::EMSGSIZE)
+}
+
+#[cfg(not(unix))]
+fn is_emsgsize(_e: &std::io::Error) -> bool {
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn probe_packet_roundtrip_all_kinds() {
+        let mut buf = vec![0u8; MAX_PROBE_PAYLOAD];
+        for kind in [PROBE_KIND_PROBE, PROBE_KIND_ACK, PROBE_KIND_ECHO] {
+            let p = ProbePacket {
+                kind,
+                seq: 0xDEAD_BEEF_u32 >> 8,
+                declared_size: 1472,
+            };
+            let n = p.encode(&mut buf).expect("encode");
+            if kind == PROBE_KIND_ACK {
+                assert_eq!(n, PROBE_HEADER_SIZE, "acks are always header-sized");
+            } else {
+                assert_eq!(n, 1472, "padded kinds send declared_size bytes");
+            }
+            let back = ProbePacket::decode(&buf[..n]).expect("decode");
+            assert_eq!(back, p);
+        }
+    }
+
+    #[test]
+    fn probe_packet_rejects_foreign_and_short() {
+        assert!(ProbePacket::decode(b"XFRF_not_probe_lane").is_none());
+        assert!(ProbePacket::decode(&[0u8; 4]).is_none());
+        // Unknown kind
+        let mut buf = vec![0u8; 64];
+        let p = ProbePacket {
+            kind: PROBE_KIND_PROBE,
+            seq: 1,
+            declared_size: 64,
+        };
+        let n = p.encode(&mut buf).unwrap();
+        buf[5] = 9;
+        assert!(ProbePacket::decode(&buf[..n]).is_none());
+        // Wrong version
+        buf[5] = PROBE_KIND_PROBE;
+        buf[4] = 2;
+        assert!(ProbePacket::decode(&buf[..n]).is_none());
+    }
+
+    #[test]
+    fn probe_packet_encode_rejects_undersized_declared() {
+        let mut buf = vec![0u8; 64];
+        let p = ProbePacket {
+            kind: PROBE_KIND_PROBE,
+            seq: 1,
+            declared_size: (PROBE_HEADER_SIZE - 1) as u16,
+        };
+        assert!(p.encode(&mut buf).is_none());
+    }
+
+    #[test]
+    fn ladder_is_sorted_dedup_and_bracketed() {
+        for ipv6 in [false, true] {
+            let ladder = size_ladder(ipv6);
+            assert!(ladder.windows(2).all(|w| w[0] < w[1]), "sorted+dedup");
+            assert_eq!(*ladder.first().unwrap(), MIN_PROBE_PAYLOAD);
+            assert_eq!(*ladder.last().unwrap(), MAX_PROBE_PAYLOAD);
+        }
+    }
+
+    /// Simulate a path with a given max payload and verify the search
+    /// converges to exactly that size.
+    fn run_search(path_max: usize, is_ipv6: bool) -> (Option<usize>, usize) {
+        let mut search = SizeSearch::new(is_ipv6);
+        let mut steps = 0;
+        while let Some(size) = search.next_size() {
+            steps += 1;
+            assert!(steps < 64, "search must terminate");
+            let verdict = if size <= path_max {
+                SizeVerdict::Pass
+            } else {
+                SizeVerdict::Fail
+            };
+            search.record(size, verdict);
+        }
+        (search.forward_max(), steps)
+    }
+
+    #[test]
+    fn search_converges_to_exact_path_limit() {
+        // Ethernet-ish, an awkward in-between value, jumbo, and the
+        // bracket edges.
+        for path_max in [1472, 1473, 2000, 8999, MIN_PROBE_PAYLOAD, MAX_PROBE_PAYLOAD] {
+            let (found, _) = run_search(path_max, false);
+            let expected = path_max.min(MAX_PROBE_PAYLOAD);
+            assert_eq!(
+                found,
+                Some(expected),
+                "path_max {path_max} should converge exactly"
+            );
+        }
+    }
+
+    #[test]
+    fn search_with_nothing_passing_returns_none() {
+        // Path blocks everything (pathological, but the report must
+        // say "no size passed" rather than picking one).
+        let mut search = SizeSearch::new(false);
+        let mut steps = 0;
+        while let Some(size) = search.next_size() {
+            steps += 1;
+            assert!(steps < 64);
+            search.record(size, SizeVerdict::Fail);
+        }
+        assert_eq!(search.forward_max(), None);
+    }
+
+    #[test]
+    fn search_skips_ladder_rungs_above_known_failure() {
+        let mut search = SizeSearch::new(false);
+        let first = search.next_size().unwrap();
+        assert_eq!(first, MIN_PROBE_PAYLOAD);
+        search.record(first, SizeVerdict::Pass);
+        let second = search.next_size().unwrap();
+        // Fail the second rung; every later rung is larger and must be
+        // skipped, sending the search straight to binary refinement
+        // strictly inside (first, second).
+        search.record(second, SizeVerdict::Fail);
+        let next = search.next_size().unwrap();
+        assert!(
+            next > first && next < second,
+            "expected binary midpoint inside ({first}, {second}), got {next}"
+        );
+    }
+
+    #[test]
+    fn local_limit_brackets_like_failure() {
+        let mut search = SizeSearch::new(false);
+        let mut last_pass = None;
+        while let Some(size) = search.next_size() {
+            // Kernel refuses anything over 1300, path is clean below.
+            let verdict = if size > 1300 {
+                SizeVerdict::LocalLimit
+            } else {
+                last_pass = Some(size);
+                SizeVerdict::Pass
+            };
+            search.record(size, verdict);
+        }
+        assert_eq!(search.forward_max(), Some(1300));
+        assert_eq!(last_pass, Some(1300));
+    }
+
+    #[test]
+    fn ip_overhead_values() {
+        assert_eq!(ip_overhead(false), 28);
+        assert_eq!(ip_overhead(true), 48);
+    }
+
+    /// Full driver/responder exchange over loopback. The loopback MTU
+    /// (65536 on Linux, ~16k on macOS) exceeds every trial size, so the
+    /// search must converge to MAX_PROBE_PAYLOAD in both directions.
+    #[tokio::test]
+    async fn run_probe_against_responder_on_loopback() {
+        let server = std::sync::Arc::new(
+            tokio::net::UdpSocket::bind("127.0.0.1:0")
+                .await
+                .expect("bind server"),
+        );
+        let server_addr = server.local_addr().unwrap();
+        let (_cancel_tx, cancel_rx) = tokio::sync::watch::channel(false);
+        let responder = tokio::spawn(crate::udp::respond_mtu_probes(server.clone(), cancel_rx));
+
+        let client = tokio::net::UdpSocket::bind("127.0.0.1:0")
+            .await
+            .expect("bind client");
+        client.connect(server_addr).await.expect("connect");
+        let report = run_probe(&client, false).await.expect("probe");
+
+        assert_eq!(report.forward_max_payload, Some(MAX_PROBE_PAYLOAD));
+        assert_eq!(report.reverse_max_payload, Some(MAX_PROBE_PAYLOAD));
+        assert_eq!(report.forward_path_mtu, Some(MAX_PROBE_PAYLOAD + 28));
+        assert!(!report.ipv6);
+        assert!(
+            report.sizes.iter().all(|s| s.forward == SizeVerdict::Pass),
+            "loopback passes every size: {:?}",
+            report.sizes
+        );
+        // Every successful size short-circuits after one attempt.
+        assert!(report.sizes.iter().all(|s| s.attempts == 1));
+
+        responder.abort();
+    }
+
+    /// A responder that never echoes (acks only) must yield forward
+    /// passes with reverse failures — the asymmetric-path shape.
+    #[tokio::test]
+    async fn run_probe_ack_only_responder_reports_reverse_blocked() {
+        use crate::probe::{PROBE_KIND_ACK, PROBE_KIND_PROBE};
+
+        let server = tokio::net::UdpSocket::bind("127.0.0.1:0")
+            .await
+            .expect("bind server");
+        let server_addr = server.local_addr().unwrap();
+        let responder = tokio::spawn(async move {
+            let mut buf = vec![0u8; MAX_PROBE_PAYLOAD + 100];
+            let mut out = vec![0u8; PROBE_HEADER_SIZE];
+            loop {
+                let Ok((n, from)) = server.recv_from(&mut buf).await else {
+                    break;
+                };
+                let Some(pkt) = ProbePacket::decode(&buf[..n]) else {
+                    continue;
+                };
+                if pkt.kind != PROBE_KIND_PROBE {
+                    continue;
+                }
+                let ack = ProbePacket {
+                    kind: PROBE_KIND_ACK,
+                    seq: pkt.seq,
+                    declared_size: pkt.declared_size,
+                };
+                let len = ack.encode(&mut out).unwrap();
+                let _ = server.send_to(&out[..len], from).await;
+            }
+        });
+
+        let client = tokio::net::UdpSocket::bind("127.0.0.1:0")
+            .await
+            .expect("bind client");
+        client.connect(server_addr).await.expect("connect");
+        let report = run_probe(&client, false).await.expect("probe");
+
+        assert_eq!(report.forward_max_payload, Some(MAX_PROBE_PAYLOAD));
+        assert_eq!(report.reverse_max_payload, None);
+        assert!(
+            report.sizes.iter().all(|s| s.reverse == SizeVerdict::Fail),
+            "acked-but-never-echoed must read as reverse Fail: {:?}",
+            report.sizes
+        );
+
+        responder.abort();
+    }
+}

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -125,6 +125,15 @@ pub enum ControlMessage {
         /// client warns via the `zerocopy_v1` capability when that happens.
         #[serde(default, skip_serializing_if = "std::ops::Not::not")]
         zerocopy: bool,
+        /// Run a path-MTU probe instead of a throughput test (issue #64,
+        /// `--probe-mtu`). The server answers variable-size `XFRP` probe
+        /// packets on the data socket with an ack + same-size echo
+        /// instead of running bulk handlers. Wire-additive: absent means
+        /// false; the client refuses to start against a server that
+        /// doesn't advertise `mtu_probe_v1` (an old server would treat
+        /// probes as junk data and never reply).
+        #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+        mtu_probe: bool,
     },
     TestAck {
         id: String,
@@ -301,6 +310,12 @@ pub struct TestResult {
     /// Bidirectional test: per-direction throughput (download) in Mbps.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub throughput_recv_mbps: Option<f64>,
+    /// Path-MTU probe report (issue #64). Populated client-side after a
+    /// `--probe-mtu` run — the client is the only side with the full
+    /// per-size picture — so it rides into `--json` output. The server
+    /// never sets it; wire-additive, absent for throughput tests.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mtu_probe: Option<crate::probe::MtuProbeReport>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -443,6 +458,11 @@ pub const SUPPORTED_CAPABILITIES: &[&str] = &[
     // download/bidir TCP, issue #33). Advertised so clients can warn when
     // a `-R --zerocopy` request lands on a server that will ignore it.
     "zerocopy_v1",
+    // v0.9.17: server answers XFRP path-MTU probe packets (ack + echo)
+    // when TestStart.mtu_probe is set (issue #64). Hard requirement for
+    // --probe-mtu — without it the client refuses to start, since an old
+    // server would silently count probes as malformed data packets.
+    "mtu_probe_v1",
 ];
 
 fn supported_capabilities() -> Vec<String> {
@@ -546,6 +566,7 @@ mod tests {
             dscp: None,
             window_size: None,
             zerocopy: false,
+            mtu_probe: false,
         };
         let json = msg.serialize().unwrap();
         let decoded = ControlMessage::deserialize(&json).unwrap();
@@ -594,6 +615,7 @@ mod tests {
             dscp: None,
             window_size: Some(262_144),
             zerocopy: false,
+            mtu_probe: false,
         };
         let json = msg.serialize().unwrap();
         assert!(json.contains("\"window_size\":262144"));
@@ -623,6 +645,7 @@ mod tests {
             dscp: None,
             window_size: Some(big),
             zerocopy: false,
+            mtu_probe: false,
         };
         let json = msg.serialize().unwrap();
         let decoded = ControlMessage::deserialize(&json).unwrap();
@@ -650,6 +673,7 @@ mod tests {
             dscp: None,
             window_size: None,
             zerocopy: false,
+            mtu_probe: false,
         };
         let json = msg.serialize().unwrap();
         assert!(
@@ -691,6 +715,7 @@ mod tests {
             dscp: None,
             window_size: None,
             zerocopy: true,
+            mtu_probe: false,
         };
         let json = msg.serialize().unwrap();
         assert!(json.contains("\"zerocopy\":true"));

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -1259,6 +1259,7 @@ async fn handle_test_request(
             dscp,
             window_size,
             zerocopy,
+            mtu_probe,
         } => {
             // Validate stream count
             if streams == 0 || streams > MAX_STREAMS {
@@ -1361,6 +1362,7 @@ async fn handle_test_request(
                 dscp,
                 window_size,
                 zerocopy,
+                mtu_probe,
             )
             .await;
 
@@ -1692,6 +1694,7 @@ async fn run_quic_test(
         bytes_received,
         throughput_send_mbps,
         throughput_recv_mbps,
+        mtu_probe: None,
     });
 
     ctrl_send
@@ -1749,6 +1752,7 @@ async fn run_test(
     dscp: Option<u8>,
     client_window_size: Option<u64>,
     zerocopy: bool,
+    mtu_probe: bool,
 ) -> anyhow::Result<(u64, u64, f64)> {
     let mut line = String::new();
 
@@ -1928,6 +1932,35 @@ async fn run_test(
                 (None, Vec::new())
             }
         }
+        Protocol::Udp if mtu_probe => {
+            // Probe mode replaces the bulk handlers entirely: every
+            // socket answers XFRP probes with ack + same-size echo until
+            // the control channel ends the test. DF is set so oversized
+            // echoes die at the constraining hop instead of fragmenting;
+            // a failure to set it degrades reverse-direction results, so
+            // it warns rather than aborting the probe.
+            let handles = udp_sockets
+                .iter()
+                .map(|socket| {
+                    let ipv6 = socket.local_addr().map(|a| a.is_ipv6()).unwrap_or(false);
+                    if let Err(e) = net::set_dont_fragment(socket, ipv6) {
+                        warn!(
+                            "MTU probe: could not set don't-fragment on echo socket: {} \
+                             (oversized echoes may fragment and overstate the reverse path)",
+                            e
+                        );
+                    }
+                    let socket = socket.clone();
+                    let cancel = cancel_rx.clone();
+                    tokio::spawn(async move {
+                        if let Err(e) = udp::respond_mtu_probes(socket, cancel).await {
+                            error!("MTU probe responder error: {}", e);
+                        }
+                    })
+                })
+                .collect();
+            (None, handles)
+        }
         Protocol::Udp => {
             let handles = spawn_udp_handlers(
                 udp_sockets,
@@ -2106,6 +2139,7 @@ async fn run_test(
         bytes_received,
         throughput_send_mbps,
         throughput_recv_mbps,
+        mtu_probe: None,
     });
 
     // Send result FIRST so the client isn't blocked by slow post-processing

--- a/src/udp.rs
+++ b/src/udp.rs
@@ -774,6 +774,85 @@ pub async fn receive_udp_feedback_only(
     Ok(())
 }
 
+/// Server side of `--probe-mtu` (issue #64, `mtu_probe_v1`): answer each
+/// incoming `XFRP` probe with a small ack plus a same-size echo, both
+/// addressed to wherever the probe came from. The ack is header-sized so
+/// it survives nearly any path and proves the forward direction; the
+/// echo is padded to the probe's declared size and proves the reverse
+/// direction. Runs until `cancel` fires (the control channel owns test
+/// lifetime, same as the bulk handlers).
+///
+/// The echo is sent with don't-fragment set by the caller on the socket;
+/// an oversized echo then dies at the constraining hop instead of being
+/// fragmented into deceptive success. EMSGSIZE on the echo send means
+/// the server's own interface MTU is the reverse-path limit — that's a
+/// legitimate probe outcome, not an error, so it's logged at debug and
+/// the ack still goes out.
+pub async fn respond_mtu_probes(
+    socket: Arc<UdpSocket>,
+    mut cancel: watch::Receiver<bool>,
+) -> anyhow::Result<()> {
+    use crate::probe::{PROBE_KIND_ACK, PROBE_KIND_ECHO, PROBE_KIND_PROBE, ProbePacket};
+
+    let mut recv_buf = vec![0u8; crate::probe::MAX_PROBE_PAYLOAD + 100];
+    let mut send_buf = vec![0u8; crate::probe::MAX_PROBE_PAYLOAD];
+
+    let cancel_changed = async move {
+        loop {
+            if *cancel.borrow() {
+                return;
+            }
+            if cancel.changed().await.is_err() {
+                return;
+            }
+        }
+    };
+    tokio::pin!(cancel_changed);
+
+    loop {
+        tokio::select! {
+            result = socket.recv_from(&mut recv_buf) => {
+                let (n, from) = match result {
+                    Ok(v) => v,
+                    Err(e) => {
+                        debug!("MTU probe recv error: {}", e);
+                        continue;
+                    }
+                };
+                let Some(pkt) = ProbePacket::decode(&recv_buf[..n]) else {
+                    continue;
+                };
+                if pkt.kind != PROBE_KIND_PROBE {
+                    continue;
+                }
+                let ack = ProbePacket {
+                    kind: PROBE_KIND_ACK,
+                    seq: pkt.seq,
+                    declared_size: pkt.declared_size,
+                };
+                if let Some(len) = ack.encode(&mut send_buf)
+                    && let Err(e) = socket.send_to(&send_buf[..len], from).await
+                {
+                    debug!("MTU probe ack send failed (seq {}): {}", pkt.seq, e);
+                }
+                let echo = ProbePacket {
+                    kind: PROBE_KIND_ECHO,
+                    seq: pkt.seq,
+                    declared_size: pkt.declared_size,
+                };
+                if let Some(len) = echo.encode(&mut send_buf)
+                    && let Err(e) = socket.send_to(&send_buf[..len], from).await
+                {
+                    // EMSGSIZE here is the reverse path speaking, not a bug.
+                    debug!("MTU probe echo send failed (seq {}, {}B): {}", pkt.seq, len, e);
+                }
+            }
+            _ = &mut cancel_changed => break,
+        }
+    }
+    Ok(())
+}
+
 /// Wait for the first packet from a client and return their address.
 /// Used in server reverse mode to learn where to send data.
 pub async fn wait_for_client(socket: &UdpSocket, timeout: Duration) -> anyhow::Result<SocketAddr> {

--- a/test-mtu-probe-ns.sh
+++ b/test-mtu-probe-ns.sh
@@ -1,0 +1,118 @@
+#!/bin/bash -e
+
+# MTU probe network namespace test (issue #64)
+# Builds a 3-namespace path with a constrained middle hop:
+#
+#   cli ---(veth, MTU 9000)--- mid ---(veth, MTU 1500)--- srv
+#
+# The client's own interface is jumbo, so oversized probes leave the
+# client fine and die at the middle hop (or, once the kernel caches the
+# ICMP frag-needed PMTU, get EMSGSIZE locally — both verdicts must
+# bracket the search identically). Expected convergence: 1472-byte
+# payload, 1500-byte path MTU, in both directions.
+#
+# Usage:
+#   sudo ./test-mtu-probe-ns.sh          # human output
+#   sudo ./test-mtu-probe-ns.sh --ci     # JSON + assertions
+
+CI=false
+if [[ "$1" == "--ci" ]]; then
+	CI=true
+	shift
+fi
+
+XFR="./target/release/xfr"
+if [[ ! -x "$XFR" ]]; then
+	echo "ERROR: $XFR not found. Run 'cargo build --release' first."
+	exit 1
+fi
+
+export NS=xfrmtu
+HOSTS=(cli mid srv)
+NSS=()
+FAILED=0
+
+cleanup()
+{
+	local ns
+	for ns in "${NSS[@]}"; do
+		ip netns pids "${ns}" 2>/dev/null | xargs -r kill 2>/dev/null
+		ip netns del "${ns}" >/dev/null 2>&1
+	done
+}
+
+trap cleanup EXIT
+
+setup()
+{
+	local suffix
+	for suffix in "${HOSTS[@]}"; do
+		local ns="${NS}_${suffix}"
+		ip netns add "${ns}"
+		NSS+=("${ns}")
+		ip -n "${ns}" link set lo up
+		ip netns exec "${ns}" sysctl -wq net.ipv4.ip_forward=1
+	done
+
+	ip link add "mid" netns "${NS}_cli" type veth peer name "cli" netns "${NS}_mid"
+	ip link add "srv" netns "${NS}_mid" type veth peer name "mid" netns "${NS}_srv"
+
+	# Client side: jumbo, so oversized probes are not refused locally
+	# at first — they must die in the path.
+	ip -n "${NS}_cli" link set "mid" mtu 9000 up
+	ip -n "${NS}_cli" addr add dev "mid" "10.0.20.2/24"
+	ip -n "${NS}_cli" route add default via "10.0.20.1"
+
+	ip -n "${NS}_mid" link set "cli" mtu 9000 up
+	ip -n "${NS}_mid" addr add dev "cli" "10.0.20.1/24"
+
+	# Constrained hop: standard Ethernet MTU.
+	ip -n "${NS}_mid" link set "srv" mtu 1500 up
+	ip -n "${NS}_mid" addr add dev "srv" "10.0.21.1/24"
+
+	ip -n "${NS}_srv" link set "mid" mtu 1500 up
+	ip -n "${NS}_srv" addr add dev "mid" "10.0.21.2/24"
+	ip -n "${NS}_srv" route add default via "10.0.21.1"
+}
+
+assert_eq()
+{
+	local actual="$1" expected="$2" label="$3"
+	if [[ "$actual" != "$expected" ]]; then
+		echo "FAIL: $label — expected ${expected}, got ${actual:-<missing>}"
+		FAILED=1
+	else
+		echo "  PASS: $label (${actual})"
+	fi
+}
+
+setup
+
+ip netns exec "${NS}_srv" "$XFR" serve &
+sleep .5
+
+echo "=== MTU probe through a 1500-byte middle hop (expect payload 1472) ==="
+OUTPUT=$(ip netns exec "${NS}_cli" "$XFR" 10.0.21.2 --probe-mtu --json 2>/dev/null)
+
+FWD=$(echo "$OUTPUT" | grep -o '"forward_max_payload": *[0-9]*' | head -1 | grep -o '[0-9]*$')
+REV=$(echo "$OUTPUT" | grep -o '"reverse_max_payload": *[0-9]*' | head -1 | grep -o '[0-9]*$')
+FWD_MTU=$(echo "$OUTPUT" | grep -o '"forward_path_mtu": *[0-9]*' | head -1 | grep -o '[0-9]*$')
+
+if [[ -z "$FWD" ]]; then
+	echo "FAIL: no mtu_probe report in output"
+	echo "$OUTPUT" | head -10
+	FAILED=1
+else
+	assert_eq "$FWD" 1472 "client→server max payload"
+	assert_eq "$REV" 1472 "server→client max payload"
+	assert_eq "$FWD_MTU" 1500 "derived path MTU"
+fi
+
+if [[ "$FAILED" -eq 0 ]]; then
+	echo "=== MTU probe test passed ==="
+	exit 0
+else
+	echo "=== MTU probe test FAILED ==="
+	[[ "$CI" == "true" ]] && exit 1
+	exit 1
+fi

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -61,6 +61,7 @@ async fn test_tcp_single_stream() {
         // regular-write fallback elsewhere (macOS CI).
         zerocopy: ZerocopyMode::Auto,
         dscp: None,
+        mtu_probe: false,
     };
 
     let client = Client::new(config);
@@ -113,6 +114,7 @@ async fn test_tcp_multi_stream() {
         random_payload: false,
         zerocopy: ZerocopyMode::Off,
         dscp: None,
+        mtu_probe: false,
     };
 
     let client = Client::new(config);
@@ -147,6 +149,7 @@ async fn test_connection_refused() {
         random_payload: false,
         zerocopy: ZerocopyMode::Off,
         dscp: None,
+        mtu_probe: false,
     };
 
     let client = Client::new(config);
@@ -181,6 +184,7 @@ async fn test_tcp_download() {
         random_payload: false,
         zerocopy: ZerocopyMode::Off,
         dscp: None,
+        mtu_probe: false,
     };
 
     let client = Client::new(config);
@@ -220,6 +224,7 @@ async fn test_tcp_bidir() {
         random_payload: false,
         zerocopy: ZerocopyMode::Off,
         dscp: None,
+        mtu_probe: false,
     };
 
     let client = Client::new(config);
@@ -277,6 +282,7 @@ async fn test_udp_upload() {
         random_payload: false,
         zerocopy: ZerocopyMode::Off,
         dscp: None,
+        mtu_probe: false,
     };
 
     let client = Client::new(config);
@@ -288,6 +294,59 @@ async fn test_udp_upload() {
 
     let result = result.unwrap();
     assert!(result.duration_ms > 0, "Should have duration");
+}
+
+/// `--probe-mtu` end to end (issue #64): full control-channel handshake,
+/// probe exchange against the server's responder, cancel, and the report
+/// riding home on the result. Loopback passes every size, so both
+/// directions must converge to the probe ceiling.
+#[tokio::test]
+async fn test_mtu_probe() {
+    let port = get_test_port();
+    let _server = start_test_server(port).await;
+
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let config = ClientConfig {
+        host: "127.0.0.1".to_string(),
+        port,
+        protocol: Protocol::Udp,
+        streams: 1,
+        duration: Duration::from_secs(60), // server-side safety deadline only
+        direction: Direction::Upload,
+        bitrate: None,
+        tcp_nodelay: false,
+        window_size: None,
+        tcp_congestion: None,
+        psk: None,
+        address_family: xfr::net::AddressFamily::default(),
+        bind_addr: None,
+        sequential_ports: false,
+        mptcp: false,
+        random_payload: false,
+        zerocopy: ZerocopyMode::Off,
+        dscp: None,
+        mtu_probe: true,
+    };
+
+    let client = Client::new(config);
+    let result = timeout(Duration::from_secs(30), client.run(None)).await;
+
+    assert!(result.is_ok(), "probe should complete well under deadline");
+    let result = result.unwrap().expect("probe should succeed");
+
+    let report = result.mtu_probe.expect("result must carry a probe report");
+    assert_eq!(
+        report.forward_max_payload,
+        Some(xfr::probe::MAX_PROBE_PAYLOAD),
+        "loopback passes every size forward"
+    );
+    assert_eq!(
+        report.reverse_max_payload,
+        Some(xfr::probe::MAX_PROBE_PAYLOAD),
+        "loopback passes every size in reverse"
+    );
+    assert!(!report.sizes.is_empty());
 }
 
 #[tokio::test]
@@ -317,6 +376,7 @@ async fn test_udp_download() {
         random_payload: false,
         zerocopy: ZerocopyMode::Off,
         dscp: None,
+        mtu_probe: false,
     };
 
     let client = Client::new(config);
@@ -354,6 +414,7 @@ async fn test_udp_bidir() {
         random_payload: false,
         zerocopy: ZerocopyMode::Off,
         dscp: None,
+        mtu_probe: false,
     };
 
     let client = Client::new(config);
@@ -393,6 +454,7 @@ async fn test_udp_multi_stream() {
         random_payload: false,
         zerocopy: ZerocopyMode::Off,
         dscp: None,
+        mtu_probe: false,
     };
 
     let client = Client::new(config);
@@ -437,6 +499,7 @@ async fn test_multi_client_concurrent() {
         random_payload: false,
         zerocopy: ZerocopyMode::Off,
         dscp: None,
+        mtu_probe: false,
     };
 
     let config2 = ClientConfig {
@@ -458,6 +521,7 @@ async fn test_multi_client_concurrent() {
         random_payload: false,
         zerocopy: ZerocopyMode::Off,
         dscp: None,
+        mtu_probe: false,
     };
 
     let client1 = Client::new(config1);
@@ -545,6 +609,7 @@ async fn test_psk_auth_success() {
         random_payload: false,
         zerocopy: ZerocopyMode::Off,
         dscp: None,
+        mtu_probe: false,
     };
 
     let client = Client::new(config);
@@ -588,6 +653,7 @@ async fn test_psk_auth_failure() {
         random_payload: false,
         zerocopy: ZerocopyMode::Off,
         dscp: None,
+        mtu_probe: false,
     };
 
     let client = Client::new(config);
@@ -631,6 +697,7 @@ async fn test_psk_auth_missing_client_key() {
         random_payload: false,
         zerocopy: ZerocopyMode::Off,
         dscp: None,
+        mtu_probe: false,
     };
 
     let client = Client::new(config);
@@ -672,6 +739,7 @@ async fn test_acl_allow() {
         random_payload: false,
         zerocopy: ZerocopyMode::Off,
         dscp: None,
+        mtu_probe: false,
     };
 
     let client = Client::new(config);
@@ -710,6 +778,7 @@ async fn test_rate_limit() {
         random_payload: false,
         zerocopy: ZerocopyMode::Off,
         dscp: None,
+        mtu_probe: false,
     };
 
     let client1 = Client::new(config1.clone());
@@ -738,6 +807,7 @@ async fn test_rate_limit() {
         random_payload: false,
         zerocopy: ZerocopyMode::Off,
         dscp: None,
+        mtu_probe: false,
     };
 
     let client2 = Client::new(config2);
@@ -787,6 +857,7 @@ async fn test_quic_upload() {
         random_payload: false,
         zerocopy: ZerocopyMode::Off,
         dscp: None,
+        mtu_probe: false,
     };
 
     let client = Client::new(config);
@@ -827,6 +898,7 @@ async fn test_quic_download() {
         random_payload: false,
         zerocopy: ZerocopyMode::Off,
         dscp: None,
+        mtu_probe: false,
     };
 
     let client = Client::new(config);
@@ -866,6 +938,7 @@ async fn test_quic_multi_stream() {
         random_payload: false,
         zerocopy: ZerocopyMode::Off,
         dscp: None,
+        mtu_probe: false,
     };
 
     let client = Client::new(config);
@@ -909,6 +982,7 @@ async fn test_quic_bidir() {
         random_payload: false,
         zerocopy: ZerocopyMode::Off,
         dscp: None,
+        mtu_probe: false,
     };
 
     let client = Client::new(config);
@@ -949,6 +1023,7 @@ async fn test_quic_with_psk() {
         random_payload: false,
         zerocopy: ZerocopyMode::Off,
         dscp: None,
+        mtu_probe: false,
     };
 
     let client = Client::new(config);
@@ -991,6 +1066,7 @@ async fn test_acl_deny() {
         random_payload: false,
         zerocopy: ZerocopyMode::Off,
         dscp: None,
+        mtu_probe: false,
     };
 
     let client = Client::new(config);
@@ -1048,6 +1124,7 @@ async fn test_ipv6_localhost() {
         random_payload: false,
         zerocopy: ZerocopyMode::Off,
         dscp: None,
+        mtu_probe: false,
     };
 
     let client = Client::new(config);
@@ -1092,6 +1169,7 @@ async fn test_tcp_infinite_duration_with_cancel() {
         random_payload: false,
         zerocopy: ZerocopyMode::Off,
         dscp: None,
+        mtu_probe: false,
     };
 
     let client = Client::new(config);
@@ -1144,6 +1222,7 @@ async fn test_udp_infinite_duration_with_cancel() {
         random_payload: false,
         zerocopy: ZerocopyMode::Off,
         dscp: None,
+        mtu_probe: false,
     };
 
     let client = Client::new(config);
@@ -1192,6 +1271,7 @@ async fn test_quic_infinite_duration_with_cancel() {
         random_payload: false,
         zerocopy: ZerocopyMode::Off,
         dscp: None,
+        mtu_probe: false,
     };
 
     let client = Client::new(config);
@@ -1262,6 +1342,7 @@ async fn test_udp_ipv4_explicit() {
         random_payload: false,
         zerocopy: ZerocopyMode::Off,
         dscp: None,
+        mtu_probe: false,
     };
 
     let client = Client::new(config);
@@ -1319,6 +1400,7 @@ async fn test_udp_ipv6_explicit() {
         random_payload: false,
         zerocopy: ZerocopyMode::Off,
         dscp: None,
+        mtu_probe: false,
     };
 
     let client = Client::new(config);
@@ -1376,6 +1458,7 @@ async fn test_udp_cport_dualstack_ipv6_target() {
         random_payload: false,
         zerocopy: ZerocopyMode::Off,
         dscp: None,
+        mtu_probe: false,
     };
 
     let client = Client::new(config);
@@ -1417,6 +1500,7 @@ async fn test_tcp_cport_single_stream() {
         random_payload: false,
         zerocopy: ZerocopyMode::Off,
         dscp: None,
+        mtu_probe: false,
     };
 
     let client = Client::new(config);
@@ -1461,6 +1545,7 @@ async fn test_tcp_cport_multi_stream() {
         random_payload: false,
         zerocopy: ZerocopyMode::Off,
         dscp: None,
+        mtu_probe: false,
     };
 
     let client = Client::new(config);
@@ -1521,6 +1606,7 @@ async fn test_tcp_cport_dualstack_ipv6_target() {
         random_payload: false,
         zerocopy: ZerocopyMode::Off,
         dscp: None,
+        mtu_probe: false,
     };
 
     let client = Client::new(config);
@@ -1577,6 +1663,7 @@ async fn test_quic_cport_dualstack_ipv6_target() {
         random_payload: false,
         zerocopy: ZerocopyMode::Off,
         dscp: None,
+        mtu_probe: false,
     };
 
     let client = Client::new(config);
@@ -1618,6 +1705,7 @@ async fn test_udp_invalid_sequential_ports_config_fails() {
         random_payload: false,
         zerocopy: ZerocopyMode::Off,
         dscp: None,
+        mtu_probe: false,
     };
 
     let client = Client::new(config);
@@ -1666,6 +1754,7 @@ async fn test_udp_bitrate_underflow_regression() {
         random_payload: false,
         zerocopy: ZerocopyMode::Off,
         dscp: None,
+        mtu_probe: false,
     };
 
     let client = Client::new(config);
@@ -1737,6 +1826,7 @@ async fn test_quic_ipv6() {
         random_payload: false,
         zerocopy: ZerocopyMode::Off,
         dscp: None,
+        mtu_probe: false,
     };
 
     let client = Client::new(config);
@@ -1794,6 +1884,7 @@ async fn test_tcp_one_off_multi_stream() {
         random_payload: false,
         zerocopy: ZerocopyMode::Off,
         dscp: None,
+        mtu_probe: false,
     };
 
     let client = Client::new(config);
@@ -1860,6 +1951,7 @@ async fn test_quic_one_off() {
         random_payload: false,
         zerocopy: ZerocopyMode::Off,
         dscp: None,
+        mtu_probe: false,
     };
 
     let client = Client::new(config);
@@ -1905,6 +1997,7 @@ fn test_pause_not_ready_before_test_run() {
         random_payload: false,
         zerocopy: ZerocopyMode::Off,
         dscp: None,
+        mtu_probe: false,
     };
 
     let client = Client::new(config);

--- a/tests/protocol.rs
+++ b/tests/protocol.rs
@@ -41,6 +41,7 @@ fn test_test_start_roundtrip() {
         dscp: None,
         window_size: None,
         zerocopy: false,
+        mtu_probe: false,
     };
 
     let json = msg.serialize().unwrap();
@@ -103,6 +104,7 @@ fn test_udp_test_start() {
         dscp: None,
         window_size: None,
         zerocopy: false,
+        mtu_probe: false,
     };
 
     let json = msg.serialize().unwrap();
@@ -293,6 +295,7 @@ fn test_result_message() {
         bytes_received: None,
         throughput_send_mbps: None,
         throughput_recv_mbps: None,
+        mtu_probe: None,
     };
 
     let msg = ControlMessage::Result(result);
@@ -337,6 +340,7 @@ fn test_large_result_message_exceeds_old_8k_guard_but_fits_64k() {
         bytes_received: None,
         throughput_send_mbps: None,
         throughput_recv_mbps: None,
+        mtu_probe: None,
     };
 
     let msg = ControlMessage::Result(result);


### PR DESCRIPTION
Closes #64.

`xfr <host> --probe-mtu` discovers the largest UDP payload that survives the path — per direction — instead of running a throughput test.

**How it works:**
- Walks a ladder of common wire MTUs (576, 1280, 1492, 1500, 4352, 9000, 9216), then binary-searches the gap between the largest pass and smallest fail, RFC 8899 style. Every probe is sent with the don't-fragment flag (`IP_MTU_DISCOVER`/`IP_PMTUDISC_DO` on Linux, `IP_DONTFRAG` on macOS/FreeBSD) so middleboxes must drop oversized packets rather than hide the limit by fragmenting.
- Per-direction attribution via a three-packet exchange (@brettowe's echo suggestion from the issue thread): each probe is answered with a small ack (proves client→server) plus a same-size DF echo (proves server→client). Ack-without-echo reads as a reverse-path block. Reverse results are a lower bound capped by the forward path — echoes are only as large as the probes that arrived — which the report says explicitly.
- The TCP-channel coordination from the issue is the control-channel handshake itself: the probe rides the normal TestStart/TestAck flow on the allocated UDP data socket, then cancels so the server returns its result immediately.
- `EMSGSIZE` on a DF send is a "local MTU limit" verdict and brackets the search the same as a path drop (matters because the kernel caches ICMP frag-needed PMTU mid-search).

**Wire:** new `mtu_probe_v1` capability — a hard requirement, the client refuses old servers up front since they'd silently swallow probes as junk data. `TestStart.mtu_probe` and `TestResult.mtu_probe` are wire-additive. The report rides the result, so `--json` carries the full per-size table.

**Validation:** 13 new unit tests (framing roundtrips, search convergence at awkward sizes, loopback driver/responder exchange, ack-only asymmetric responder), an end-to-end integration test, and a new netns CI job (`test-mtu-probe-ns.sh`): a jumbo-framed client probing through a 1500-byte middle hop converges to exactly 1472/1500 in both directions — verified on real namespaces before pushing.

Sample output:
```
  Payload      client → server    server → client
      548      pass (1/1)         pass (1/1)
     1472      pass (1/1)         pass (1/1)
     4324      BLOCKED (0/3)      untested
  Largest payload client → server: 1472 bytes  (path MTU ≈ 1500)
```