### PR TITLE
Single-port UDP data plane (single_port_udp_v1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Single-port UDP data plane (`single_port_udp_v1` capability)** (issue #63) — all per-stream UDP test traffic now flows to the server's main port (default 5201/UDP) instead of per-stream ephemeral ports, so firewalls only need one UDP port open. Per stream, the client sends a small token-bearing hello datagram to the main port (retried at 100 ms up to ~5 s, then the test fails loudly); the server creates a fresh UDP socket, binds it to the same port via `SO_REUSEADDR`+`SO_REUSEPORT`, `connect()`s it to the client's source address, and acks from that socket. The kernel's UDP lookup scores connected sockets above the wildcard, so line-rate data rides the connected socket and the shared socket only ever sees hellos. The per-test token (16 random bytes, returned in `TestAck.udp_token`) routes hellos to the right test across NAT and concurrent clients. The main UDP port is owned by the quinn QUIC endpoint; it now gets a tee implementing `quinn::AsyncUdpSocket` that delegates to the runtime's quinn-udp-backed socket (GSO/GRO/ECN paths intact) and diverts only xfr hello datagrams. The classifier (hello framing first, then QUIC long-header bit 0x80, then short-header fixed bit 0x40) is made sound by disabling QUIC-bit greasing on the server endpoint — RFC 9287 greasing is permission-based, so not advertising it stops compliant peers from clearing the fixed bit toward us. The hello/ack magic `b"\x00XFR"` lives in the 0b00 first-byte space QUIC can never use. With `--no-quic`, a plain shared socket serves the hello lane instead. The server advertises the capability only after a startup self-test proves the running kernel actually routes a connected-socket datagram past a same-port wildcard (SO_REUSEPORT semantics vary by platform); on failure — and against older peers — the legacy per-stream ephemeral-port path is used unchanged. Single-port is the default when both peers advertise, mirroring `single_port_tcp`, and covers upload, download, bidir, and `--probe-mtu`.
+
+### Library API (pre-1.0 break)
+- `protocol::ControlMessage::TestAck` gains `udp_token: Option<String>` (serde-default, wire-additive); struct-literal constructors must supply it.
+- `udp::receive_udp` and `udp::respond_mtu_probes` gain a trailing `single_port_ack: Option<[u8; 24]>` parameter.
+- New public items: `udp::{UdpHelloPacket, SharedSocketLane, classify_shared_datagram, single_port_udp_handshake, respond_single_port_hellos, encode_hello_token, parse_hello_token, UDP_HELLO_*}`; `net::{create_shared_udp_socket, create_connected_udp_same_port, single_port_udp_self_test}`; `quic::XfrHelloDatagram`; `protocol::{SINGLE_PORT_UDP_CAPABILITY, supported_capabilities, supported_capabilities_without}`; `ControlMessage::{server_hello_with_capabilities, server_hello_with_auth_and_capabilities}`.
+- `quic::create_server_endpoint` gains a trailing `xfr_hello_tx: Option<mpsc::Sender<XfrHelloDatagram>>` parameter.
+
 ## [0.9.17] - 2026-06-11
 
 ### Added

--- a/src/client.rs
+++ b/src/client.rs
@@ -695,10 +695,14 @@ impl Client {
         read_bounded_line(&mut reader, &mut line).await?;
         let msg: ControlMessage = ControlMessage::deserialize(line.trim())?;
 
-        let data_ports = match msg {
-            ControlMessage::TestAck { data_ports, .. } => {
+        let (data_ports, udp_token) = match msg {
+            ControlMessage::TestAck {
+                data_ports,
+                udp_token,
+                ..
+            } => {
                 debug!("Server allocated ports: {:?}", data_ports);
-                data_ports
+                (data_ports, udp_token)
             }
             ControlMessage::Error { message } => {
                 return Err(anyhow::anyhow!("Server error: {}", message));
@@ -723,12 +727,43 @@ impl Client {
             }
         }
 
+        // Single-port UDP (issue #63): the server signals the mode with an
+        // empty port list plus a routing token, and must have advertised
+        // the capability. Anything else with empty ports is a broken peer.
+        let single_port_udp_token: Option<[u8; udp::UDP_HELLO_TOKEN_LEN]> =
+            if self.config.protocol == Protocol::Udp && data_ports.is_empty() {
+                let server_supports = crate::protocol::capability_advertised(
+                    &server_capabilities,
+                    crate::protocol::SINGLE_PORT_UDP_CAPABILITY,
+                );
+                match udp_token.as_deref().and_then(udp::parse_hello_token) {
+                    Some(token) if server_supports => Some(token),
+                    _ => {
+                        return Err(anyhow::anyhow!(
+                            "Server returned no UDP data ports but single-port UDP was not \
+                             negotiated (missing {} capability or routing token). The server \
+                             may be an incompatible version.",
+                            crate::protocol::SINGLE_PORT_UDP_CAPABILITY
+                        ));
+                    }
+                }
+            } else {
+                None
+            };
+
         // --probe-mtu: the handshake above is shared with throughput
         // tests, but from here probe mode runs its own exchange on the
         // data socket instead of bulk streams, then cancels the test.
         if self.config.mtu_probe {
             return self
-                .run_mtu_probe_exchange(&mut reader, &mut writer, &test_id, server_ip, &data_ports)
+                .run_mtu_probe_exchange(
+                    &mut reader,
+                    &mut writer,
+                    &test_id,
+                    server_ip,
+                    &data_ports,
+                    single_port_udp_token,
+                )
                 .await;
         }
 
@@ -794,6 +829,7 @@ impl Client {
                     cancel_rx.clone(),
                     pause_rx.clone(),
                     feedback_aggregator,
+                    single_port_udp_token,
                 )
                 .await?
             }
@@ -1377,6 +1413,7 @@ impl Client {
     /// socket, then cancel the test on the control channel and wait for
     /// the server's Result so the connection closes out the normal way.
     /// The probe report rides home on the result's `mtu_probe` field.
+    #[allow(clippy::too_many_arguments)]
     async fn run_mtu_probe_exchange(
         &self,
         reader: &mut BufReader<tokio::net::tcp::OwnedReadHalf>,
@@ -1384,11 +1421,17 @@ impl Client {
         test_id: &str,
         server_ip: SocketAddr,
         data_ports: &[u16],
+        single_port_token: Option<[u8; udp::UDP_HELLO_TOKEN_LEN]>,
     ) -> anyhow::Result<TestResult> {
-        let port = data_ports
-            .first()
-            .copied()
-            .ok_or_else(|| anyhow::anyhow!("Server allocated no UDP port for the MTU probe"))?;
+        // Single-port mode probes the main port after a hello/ack
+        // handshake; legacy mode uses the allocated ephemeral port.
+        let port = match single_port_token {
+            Some(_) => self.config.port,
+            None => data_ports
+                .first()
+                .copied()
+                .ok_or_else(|| anyhow::anyhow!("Server allocated no UDP port for the MTU probe"))?,
+        };
         let server_addr = SocketAddr::new(server_ip.ip(), port);
 
         let socket = net::create_udp_socket_for_remote(server_addr).await?;
@@ -1404,6 +1447,12 @@ impl Client {
                  (client-to-server results may overstate the path)",
                 e
             );
+        }
+
+        // Hello/ack first so the server's connected socket and probe
+        // responder exist before the first probe flies (issue #63).
+        if let Some(token) = single_port_token {
+            udp::single_port_udp_handshake(&socket, &token, 0).await?;
         }
 
         let report = crate::probe::run_probe(&socket, ipv6).await?;
@@ -1453,11 +1502,14 @@ impl Client {
         cancel: watch::Receiver<bool>,
         pause: watch::Receiver<bool>,
         feedback_aggregator: Option<UdpFeedbackAggregator>,
+        single_port_token: Option<[u8; udp::UDP_HELLO_TOKEN_LEN]>,
     ) -> anyhow::Result<Vec<tokio::task::JoinHandle<()>>> {
+        let single_port = single_port_token.is_some();
+        let stream_count = self.config.streams as usize;
         let base_bind_addr = sequential_bind_base(
             self.config.bind_addr,
             self.config.sequential_ports,
-            data_ports.len(),
+            stream_count,
         )?;
 
         let bitrate = self.config.bitrate.unwrap_or(1_000_000_000); // 1 Gbps default
@@ -1471,12 +1523,55 @@ impl Client {
             (bitrate / self.config.streams as u64).max(1)
         };
 
-        if data_ports.len() != self.config.streams as usize {
+        if !single_port && data_ports.len() != stream_count {
             return Err(anyhow::anyhow!(
                 "Server returned {} data ports but {} streams were requested",
                 data_ports.len(),
                 self.config.streams
             ));
+        }
+
+        // Single-port mode (issue #63): set up every socket and complete
+        // every hello/ack handshake BEFORE any data task starts. The ack
+        // proves the server's connected same-port socket exists, which is
+        // what keeps line-rate data off the shared QUIC socket; a missing
+        // ack fails the whole test loudly instead of degrading quietly.
+        if let Some(token) = single_port_token {
+            let server_port = SocketAddr::new(server_addr.ip(), self.config.port);
+            let mut sockets = Vec::with_capacity(stream_count);
+            for i in 0..stream_count {
+                let bind_addr = stream_bind_addr(base_bind_addr, self.config.sequential_ports, i);
+                let socket = self
+                    .create_udp_stream_socket(bind_addr, server_port)
+                    .await?;
+                sockets.push(socket);
+            }
+            futures::future::try_join_all(
+                sockets
+                    .iter()
+                    .enumerate()
+                    .map(|(i, socket)| udp::single_port_udp_handshake(socket, &token, i as u16)),
+            )
+            .await?;
+
+            let mut handles = Vec::with_capacity(stream_count);
+            for (i, socket) in sockets.into_iter().enumerate() {
+                handles.push(tokio::spawn(run_udp_stream_io(
+                    socket,
+                    self.config.direction,
+                    self.config.duration,
+                    stream_bitrate,
+                    self.config.random_payload,
+                    stats.streams[i].clone(),
+                    stats.clone(),
+                    cancel.clone(),
+                    pause.clone(),
+                    feedback_aggregator.clone(),
+                    i,
+                    true,
+                )));
+            }
+            return Ok(handles);
         }
 
         let mut handles = Vec::new();
@@ -1543,140 +1638,64 @@ impl Client {
                     warn!("Failed to set UDP buffer size to {}: {}", size, e);
                 }
 
-                match direction {
-                    Direction::Upload => {
-                        if let Some(aggregator) = feedback_aggregator {
-                            // Server advertised udp_feedback_v1: spawn the
-                            // feedback recv task alongside the sender so
-                            // live UDP loss can be reported back without
-                            // riding the TCP control channel that competes
-                            // with the saturated upload.
-                            let send_socket = socket.clone();
-                            let recv_socket = socket;
-                            let send_cancel = cancel.clone();
-                            let recv_cancel = cancel;
-                            let send_handle = tokio::spawn(async move {
-                                if let Err(e) = udp::send_udp_paced(
-                                    send_socket,
-                                    None,
-                                    stream_bitrate,
-                                    duration,
-                                    stream_stats,
-                                    send_cancel,
-                                    pause,
-                                    random_payload,
-                                )
-                                .await
-                                {
-                                    error!("UDP send error: {}", e);
-                                }
-                            });
-                            let recv_handle = tokio::spawn(async move {
-                                if let Err(e) = udp::receive_udp_feedback_only(
-                                    recv_socket,
-                                    aggregator,
-                                    stream_index,
-                                    recv_cancel,
-                                )
-                                .await
-                                {
-                                    debug!(
-                                        "UDP feedback recv error on stream {}: {}",
-                                        stream_index, e
-                                    );
-                                }
-                            });
-                            let _ = tokio::join!(send_handle, recv_handle);
-                        } else if let Err(e) = udp::send_udp_paced(
-                            socket,
-                            None, // Connected socket, no target needed
-                            stream_bitrate,
-                            duration,
-                            stream_stats,
-                            cancel,
-                            pause,
-                            random_payload,
-                        )
-                        .await
-                        {
-                            error!("UDP send error: {}", e);
-                        }
-                    }
-                    Direction::Download => {
-                        // Send hello packets concurrently with receiving
-                        // This ensures server learns our address even if first packets are missed
-                        let hello_socket = socket.clone();
-                        let hello_cancel = cancel.clone();
-                        let hello_handle = tokio::spawn(async move {
-                            // Send hello packets every 100ms until cancelled or 5 seconds
-                            for _ in 0..50 {
-                                if *hello_cancel.borrow() {
-                                    break;
-                                }
-                                let _ = hello_socket.send(&[0u8; 1]).await;
-                                tokio::time::sleep(Duration::from_millis(100)).await;
-                            }
-                        });
-
-                        // Keep the receiver-side UdpStats (loss/jitter):
-                        // run_test overlays them onto the server's
-                        // sender-side Result (issue #81).
-                        match udp::receive_udp(socket, stream_stats, cancel, pause, false).await {
-                            Ok((udp_stats, _bytes)) => test_stats.add_udp_stats(udp_stats),
-                            Err(e) => error!("UDP receive error: {}", e),
-                        }
-                        hello_handle.abort();
-                    }
-                    Direction::Bidir => {
-                        // UDP can send/receive concurrently on same socket
-                        let send_socket = socket.clone();
-                        let recv_socket = socket;
-                        let send_stats = stream_stats.clone();
-                        let recv_stats = stream_stats;
-                        let send_cancel = cancel.clone();
-                        let recv_cancel = cancel;
-                        let send_pause = pause.clone();
-                        let recv_pause = pause;
-
-                        let send_handle = tokio::spawn(async move {
-                            if let Err(e) = udp::send_udp_paced(
-                                send_socket,
-                                None, // Connected socket, no target needed
-                                stream_bitrate,
-                                duration,
-                                send_stats,
-                                send_cancel,
-                                send_pause,
-                                random_payload,
-                            )
-                            .await
-                            {
-                                error!("UDP bidir send error: {}", e);
-                            }
-                        });
-
-                        let recv_handle = tokio::spawn(async move {
-                            if let Err(e) = udp::receive_udp(
-                                recv_socket,
-                                recv_stats,
-                                recv_cancel,
-                                recv_pause,
-                                false,
-                            )
-                            .await
-                            {
-                                error!("UDP bidir receive error: {}", e);
-                            }
-                        });
-
-                        let _ = tokio::join!(send_handle, recv_handle);
-                    }
-                }
+                run_udp_stream_io(
+                    socket,
+                    direction,
+                    duration,
+                    stream_bitrate,
+                    random_payload,
+                    stream_stats,
+                    test_stats,
+                    cancel,
+                    pause,
+                    feedback_aggregator,
+                    stream_index,
+                    false,
+                )
+                .await;
             }));
         }
 
         tokio::time::sleep(Duration::from_millis(100)).await;
         Ok(handles)
+    }
+
+    /// Create, connect, and configure one client-side UDP data socket
+    /// (single-port mode, where socket setup happens before the spawned
+    /// task so handshake failures can fail the test loudly).
+    async fn create_udp_stream_socket(
+        &self,
+        bind_addr: Option<SocketAddr>,
+        server_port: SocketAddr,
+    ) -> anyhow::Result<Arc<tokio::net::UdpSocket>> {
+        let socket = if let Some(local) = bind_addr {
+            let local = net::match_bind_family(local, server_port);
+            net::create_udp_socket_bound(local)
+                .await
+                .map_err(|e| anyhow::anyhow!("Failed to bind UDP socket to {}: {}", local, e))?
+        } else {
+            net::create_udp_socket_for_remote(server_port)
+                .await
+                .map_err(|e| anyhow::anyhow!("Failed to create UDP socket: {}", e))?
+        };
+        socket
+            .connect(server_port)
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to connect UDP socket: {}", e))?;
+        debug!("UDP connected to {}", server_port);
+
+        if let Some(tos) = self.config.dscp
+            && let Err(e) = net::set_tos_on_udp(&socket, tos)
+        {
+            warn!("Failed to set IP_TOS on UDP socket: {}", e);
+        }
+        // See spawn_udp_streams for why both buffers are set.
+        if let Some(size) = self.config.window_size
+            && let Err(e) = net::set_udp_buffer_size(&socket, size)
+        {
+            warn!("Failed to set UDP buffer size to {}: {}", size, e);
+        }
+        Ok(Arc::new(socket))
     }
 
     /// Run a test using QUIC transport
@@ -2069,6 +2088,162 @@ impl Client {
             }
         }
         PauseResult::NotReady
+    }
+}
+
+/// Per-direction client-side UDP stream IO on an already-connected,
+/// already-configured socket. Shared by the legacy per-port path and the
+/// single-port path (issue #63); `single_port` only suppresses the
+/// legacy 1-byte address-discovery hellos in download mode — the
+/// token-bearing handshake has already told the server where we are.
+#[allow(clippy::too_many_arguments)]
+async fn run_udp_stream_io(
+    socket: Arc<tokio::net::UdpSocket>,
+    direction: Direction,
+    duration: Duration,
+    stream_bitrate: u64,
+    random_payload: bool,
+    stream_stats: Arc<crate::stats::StreamStats>,
+    test_stats: Arc<TestStats>,
+    cancel: watch::Receiver<bool>,
+    pause: watch::Receiver<bool>,
+    feedback_aggregator: Option<UdpFeedbackAggregator>,
+    stream_index: usize,
+    single_port: bool,
+) {
+    match direction {
+        Direction::Upload => {
+            if let Some(aggregator) = feedback_aggregator {
+                // Server advertised udp_feedback_v1: spawn the
+                // feedback recv task alongside the sender so
+                // live UDP loss can be reported back without
+                // riding the TCP control channel that competes
+                // with the saturated upload.
+                let send_socket = socket.clone();
+                let recv_socket = socket;
+                let send_cancel = cancel.clone();
+                let recv_cancel = cancel;
+                let send_handle = tokio::spawn(async move {
+                    if let Err(e) = udp::send_udp_paced(
+                        send_socket,
+                        None,
+                        stream_bitrate,
+                        duration,
+                        stream_stats,
+                        send_cancel,
+                        pause,
+                        random_payload,
+                    )
+                    .await
+                    {
+                        error!("UDP send error: {}", e);
+                    }
+                });
+                let recv_handle = tokio::spawn(async move {
+                    if let Err(e) = udp::receive_udp_feedback_only(
+                        recv_socket,
+                        aggregator,
+                        stream_index,
+                        recv_cancel,
+                    )
+                    .await
+                    {
+                        debug!("UDP feedback recv error on stream {}: {}", stream_index, e);
+                    }
+                });
+                let _ = tokio::join!(send_handle, recv_handle);
+            } else if let Err(e) = udp::send_udp_paced(
+                socket,
+                None, // Connected socket, no target needed
+                stream_bitrate,
+                duration,
+                stream_stats,
+                cancel,
+                pause,
+                random_payload,
+            )
+            .await
+            {
+                error!("UDP send error: {}", e);
+            }
+        }
+        Direction::Download => {
+            // Legacy mode: send hello packets concurrently with receiving
+            // so the server learns our address even if first packets are
+            // missed. Single-port mode already did a token handshake.
+            let hello_handle = if single_port {
+                None
+            } else {
+                let hello_socket = socket.clone();
+                let hello_cancel = cancel.clone();
+                Some(tokio::spawn(async move {
+                    // Send hello packets every 100ms until cancelled or 5 seconds
+                    for _ in 0..50 {
+                        if *hello_cancel.borrow() {
+                            break;
+                        }
+                        let _ = hello_socket.send(&[0u8; 1]).await;
+                        tokio::time::sleep(Duration::from_millis(100)).await;
+                    }
+                }))
+            };
+
+            // Keep the receiver-side UdpStats (loss/jitter):
+            // run_test overlays them onto the server's
+            // sender-side Result (issue #81).
+            match udp::receive_udp(socket, stream_stats, cancel, pause, false, None).await {
+                Ok((udp_stats, _bytes)) => test_stats.add_udp_stats(udp_stats),
+                Err(e) => error!("UDP receive error: {}", e),
+            }
+            if let Some(handle) = hello_handle {
+                handle.abort();
+            }
+        }
+        Direction::Bidir => {
+            // UDP can send/receive concurrently on same socket
+            let send_socket = socket.clone();
+            let recv_socket = socket;
+            let send_stats = stream_stats.clone();
+            let recv_stats = stream_stats;
+            let send_cancel = cancel.clone();
+            let recv_cancel = cancel;
+            let send_pause = pause.clone();
+            let recv_pause = pause;
+
+            let send_handle = tokio::spawn(async move {
+                if let Err(e) = udp::send_udp_paced(
+                    send_socket,
+                    None, // Connected socket, no target needed
+                    stream_bitrate,
+                    duration,
+                    send_stats,
+                    send_cancel,
+                    send_pause,
+                    random_payload,
+                )
+                .await
+                {
+                    error!("UDP bidir send error: {}", e);
+                }
+            });
+
+            let recv_handle = tokio::spawn(async move {
+                if let Err(e) = udp::receive_udp(
+                    recv_socket,
+                    recv_stats,
+                    recv_cancel,
+                    recv_pause,
+                    false,
+                    None,
+                )
+                .await
+                {
+                    error!("UDP bidir receive error: {}", e);
+                }
+            });
+
+            let _ = tokio::join!(send_handle, recv_handle);
+        }
     }
 }
 

--- a/src/net.rs
+++ b/src/net.rs
@@ -406,10 +406,12 @@ pub async fn create_connected_udp_same_port(
 }
 
 /// Startup self-test gating the `single_port_udp_v1` capability (issue
-/// #63): replicate the exact production socket arrangement on a
-/// loopback ephemeral port — shared wildcard-style socket bound first,
-/// same-port connected socket second — and verify a datagram from the
-/// connected peer lands on the connected socket, not the shared one.
+/// #63): replicate the production socket topology on an ephemeral port —
+/// shared WILDCARD-bound socket first (same bind shape and v6only as
+/// the real lane), same-port connected socket second — and verify a
+/// datagram from the connected peer lands on the connected socket, not
+/// the shared one. Dual-stack additionally proves the IPv4-mapped path
+/// (`::ffff:x` sources), which is what every plain-IPv4 client hits.
 /// Kernel UDP lookup is supposed to score connected sockets above
 /// wildcards, but SO_REUSEPORT group semantics vary across kernels and
 /// platforms, so we prove it on the running system instead of assuming.
@@ -432,26 +434,82 @@ pub async fn single_port_udp_self_test(family: AddressFamily) -> bool {
 }
 
 async fn single_port_udp_self_test_inner(family: AddressFamily) -> io::Result<()> {
-    use std::time::Duration;
-
-    let loopback: IpAddr = match family {
-        AddressFamily::V4Only => IpAddr::V4(Ipv4Addr::LOCALHOST),
-        AddressFamily::V6Only | AddressFamily::DualStack => IpAddr::V6(Ipv6Addr::LOCALHOST),
-    };
+    // Bind the shared socket exactly the way production binds the main
+    // UDP lane: WILDCARD for the family, same v6only setting. A concrete
+    // loopback bind would exercise a different kernel lookup path
+    // (exact-address-bound sockets score differently from wildcard-bound
+    // ones), and the whole point of this gate is to prove the production
+    // topology, not a lookalike.
     let v6only = match family {
         AddressFamily::V4Only => None,
         AddressFamily::V6Only => Some(true),
         AddressFamily::DualStack => Some(false),
     };
+    let wildcard = family.bind_addr(0);
+    let shared = create_shared_udp_socket(wildcard, v6only).await?;
+    let port = shared.local_addr()?.port();
+    // Production passes the shared socket's own local address when
+    // binding each connected socket; mirror that.
+    let local = SocketAddr::new(wildcard.ip(), port);
 
-    let shared = create_shared_udp_socket(SocketAddr::new(loopback, 0), v6only).await?;
-    let shared_addr = shared.local_addr()?;
-    let peer = UdpSocket::bind(SocketAddr::new(loopback, 0)).await?;
+    let native_loopback: IpAddr = match family {
+        AddressFamily::V4Only => IpAddr::V4(Ipv4Addr::LOCALHOST),
+        AddressFamily::V6Only | AddressFamily::DualStack => IpAddr::V6(Ipv6Addr::LOCALHOST),
+    };
+    check_connected_precedence(&shared, local, v6only, native_loopback, port, false).await?;
+
+    // A dual-stack lane also serves IPv4 clients, whose source addresses
+    // arrive as ::ffff:x.x.x.x and whose connected sockets are
+    // connect()ed to that mapped form. That is the path every ordinary
+    // IPv4 client takes, so prove it separately — native-IPv6 routing
+    // passing says nothing about mapped-address routing.
+    if family == AddressFamily::DualStack {
+        check_connected_precedence(
+            &shared,
+            local,
+            v6only,
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+            port,
+            true,
+        )
+        .await?;
+    }
+    Ok(())
+}
+
+/// One self-test round: a peer on `peer_loopback` gets a same-port
+/// connected socket (connect target in the mapped form when `map_peer`,
+/// mirroring how a dual-stack lane observes IPv4 sources), then we
+/// verify (1) the peer's datagram lands on the connected socket and
+/// (2) an unrelated source on the same family still reaches the shared
+/// socket — guarding against reuseport semantics where the last-bound
+/// group member captures all unicast, which would starve QUIC and
+/// new-client hellos in production.
+async fn check_connected_precedence(
+    shared: &UdpSocket,
+    local: SocketAddr,
+    v6only: Option<bool>,
+    peer_loopback: IpAddr,
+    port: u16,
+    map_peer: bool,
+) -> io::Result<()> {
+    use std::time::Duration;
+
+    let peer = UdpSocket::bind(SocketAddr::new(peer_loopback, 0)).await?;
     let peer_addr = peer.local_addr()?;
-    let connected = create_connected_udp_same_port(shared_addr, v6only, peer_addr).await?;
+    let connect_to = match (map_peer, peer_addr.ip()) {
+        (true, IpAddr::V4(v4)) => {
+            SocketAddr::new(IpAddr::V6(v4.to_ipv6_mapped()), peer_addr.port())
+        }
+        _ => peer_addr,
+    };
+    let connected = create_connected_udp_same_port(local, v6only, connect_to).await?;
+    // The shared socket is wildcard-bound; the peer reaches it via its
+    // own family's loopback at the shared port.
+    let dest = SocketAddr::new(peer_loopback, port);
 
     const PROBE: &[u8] = b"xfr-single-port-self-test";
-    peer.send_to(PROBE, shared_addr).await?;
+    peer.send_to(PROBE, dest).await?;
 
     let mut connected_buf = [0u8; 64];
     let mut shared_buf = [0u8; 64];
@@ -472,13 +530,8 @@ async fn single_port_udp_self_test_inner(family: AddressFamily) -> io::Result<()
         )),
     }
 
-    // Second half: traffic from an UNRELATED source must still reach the
-    // shared socket while the connected one is in the group. Guards
-    // against reuseport semantics where the last-bound socket captures
-    // all unicast — that would pass the check above while silently
-    // starving QUIC and new-client hellos in production.
-    let stranger = UdpSocket::bind(SocketAddr::new(loopback, 0)).await?;
-    stranger.send_to(PROBE, shared_addr).await?;
+    let stranger = UdpSocket::bind(SocketAddr::new(peer_loopback, 0)).await?;
+    stranger.send_to(PROBE, dest).await?;
     tokio::select! {
         result = shared.recv_from(&mut shared_buf) => {
             let (n, _) = result?;

--- a/src/net.rs
+++ b/src/net.rs
@@ -323,6 +323,182 @@ pub async fn create_udp_socket_for_remote(remote: SocketAddr) -> io::Result<UdpS
     UdpSocket::from_std(std_socket)
 }
 
+/// Create the shared UDP socket for the single-port data plane (issue
+/// #63) when no QUIC endpoint owns the main port: SO_REUSEADDR +
+/// SO_REUSEPORT set before bind so per-stream connected sockets can join
+/// the same address later. `v6only` follows the server's address-family
+/// mode (`None` for IPv4 sockets).
+///
+/// Unix-only: SO_REUSEPORT doesn't exist on Windows, and the capability
+/// is never advertised there (the self-test below fails closed).
+#[cfg(unix)]
+pub async fn create_shared_udp_socket(
+    addr: SocketAddr,
+    v6only: Option<bool>,
+) -> io::Result<UdpSocket> {
+    let socket = new_reuseport_udp_socket(addr, v6only)?;
+    socket.bind(&SockAddr::from(addr))?;
+    socket.set_nonblocking(true)?;
+    let std_socket: std::net::UdpSocket = socket.into();
+    UdpSocket::from_std(std_socket)
+}
+
+/// Create a per-stream data socket for single-port UDP (issue #63):
+/// bound to the same local address as the shared socket (SO_REUSEPORT)
+/// and `connect()`ed to the client's source address. Once connected, the
+/// kernel's UDP lookup scores it above the shared wildcard socket, so
+/// line-rate data flows here and never touches the shared-socket tee.
+#[cfg(unix)]
+pub async fn create_connected_udp_same_port(
+    local: SocketAddr,
+    v6only: Option<bool>,
+    peer: SocketAddr,
+) -> io::Result<UdpSocket> {
+    let socket = new_reuseport_udp_socket(local, v6only)?;
+    socket.bind(&SockAddr::from(local))?;
+    socket.set_nonblocking(true)?;
+    let std_socket: std::net::UdpSocket = socket.into();
+    let udp = UdpSocket::from_std(std_socket)?;
+    udp.connect(peer).await?;
+    Ok(udp)
+}
+
+#[cfg(unix)]
+fn new_reuseport_udp_socket(addr: SocketAddr, v6only: Option<bool>) -> io::Result<Socket> {
+    let domain = if addr.is_ipv4() {
+        Domain::IPV4
+    } else {
+        Domain::IPV6
+    };
+    let socket = Socket::new(domain, Type::DGRAM, Some(Protocol::UDP))?;
+    socket.set_reuse_address(true)?;
+    // Plain SO_REUSEPORT everywhere — never SO_REUSEPORT_LB (FreeBSD),
+    // whose load-balancing group semantics would defeat the
+    // connected-socket-wins routing this feature depends on.
+    socket.set_reuse_port(true)?;
+    if let Some(v6only) = v6only {
+        socket.set_only_v6(v6only)?;
+    }
+    Ok(socket)
+}
+
+#[cfg(not(unix))]
+pub async fn create_shared_udp_socket(
+    _addr: SocketAddr,
+    _v6only: Option<bool>,
+) -> io::Result<UdpSocket> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "single-port UDP requires SO_REUSEPORT, which this platform lacks",
+    ))
+}
+
+#[cfg(not(unix))]
+pub async fn create_connected_udp_same_port(
+    _local: SocketAddr,
+    _v6only: Option<bool>,
+    _peer: SocketAddr,
+) -> io::Result<UdpSocket> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "single-port UDP requires SO_REUSEPORT, which this platform lacks",
+    ))
+}
+
+/// Startup self-test gating the `single_port_udp_v1` capability (issue
+/// #63): replicate the exact production socket arrangement on a
+/// loopback ephemeral port — shared wildcard-style socket bound first,
+/// same-port connected socket second — and verify a datagram from the
+/// connected peer lands on the connected socket, not the shared one.
+/// Kernel UDP lookup is supposed to score connected sockets above
+/// wildcards, but SO_REUSEPORT group semantics vary across kernels and
+/// platforms, so we prove it on the running system instead of assuming.
+/// Sub-millisecond when it passes; runs once at server start. Any
+/// failure means the server simply doesn't advertise the capability and
+/// clients fall back to legacy per-stream ports.
+pub async fn single_port_udp_self_test(family: AddressFamily) -> bool {
+    match single_port_udp_self_test_inner(family).await {
+        Ok(()) => true,
+        Err(e) => {
+            debug!(
+                "single-port UDP self-test failed ({}); not advertising {}: {}",
+                family,
+                crate::protocol::SINGLE_PORT_UDP_CAPABILITY,
+                e
+            );
+            false
+        }
+    }
+}
+
+async fn single_port_udp_self_test_inner(family: AddressFamily) -> io::Result<()> {
+    use std::time::Duration;
+
+    let loopback: IpAddr = match family {
+        AddressFamily::V4Only => IpAddr::V4(Ipv4Addr::LOCALHOST),
+        AddressFamily::V6Only | AddressFamily::DualStack => IpAddr::V6(Ipv6Addr::LOCALHOST),
+    };
+    let v6only = match family {
+        AddressFamily::V4Only => None,
+        AddressFamily::V6Only => Some(true),
+        AddressFamily::DualStack => Some(false),
+    };
+
+    let shared = create_shared_udp_socket(SocketAddr::new(loopback, 0), v6only).await?;
+    let shared_addr = shared.local_addr()?;
+    let peer = UdpSocket::bind(SocketAddr::new(loopback, 0)).await?;
+    let peer_addr = peer.local_addr()?;
+    let connected = create_connected_udp_same_port(shared_addr, v6only, peer_addr).await?;
+
+    const PROBE: &[u8] = b"xfr-single-port-self-test";
+    peer.send_to(PROBE, shared_addr).await?;
+
+    let mut connected_buf = [0u8; 64];
+    let mut shared_buf = [0u8; 64];
+    tokio::select! {
+        result = connected.recv(&mut connected_buf) => {
+            let n = result?;
+            if &connected_buf[..n] != PROBE {
+                return Err(io::Error::other("connected socket received unexpected data"));
+            }
+        }
+        _ = shared.recv_from(&mut shared_buf) => return Err(io::Error::other(
+            "kernel delivered the datagram to the shared wildcard socket \
+             instead of the connected socket",
+        )),
+        _ = tokio::time::sleep(Duration::from_millis(500)) => return Err(io::Error::new(
+            io::ErrorKind::TimedOut,
+            "datagram reached neither socket",
+        )),
+    }
+
+    // Second half: traffic from an UNRELATED source must still reach the
+    // shared socket while the connected one is in the group. Guards
+    // against reuseport semantics where the last-bound socket captures
+    // all unicast — that would pass the check above while silently
+    // starving QUIC and new-client hellos in production.
+    let stranger = UdpSocket::bind(SocketAddr::new(loopback, 0)).await?;
+    stranger.send_to(PROBE, shared_addr).await?;
+    tokio::select! {
+        result = shared.recv_from(&mut shared_buf) => {
+            let (n, _) = result?;
+            if &shared_buf[..n] == PROBE {
+                Ok(())
+            } else {
+                Err(io::Error::other("shared socket received unexpected data"))
+            }
+        }
+        _ = connected.recv(&mut connected_buf) => Err(io::Error::other(
+            "kernel delivered an unrelated source's datagram to the \
+             connected socket",
+        )),
+        _ = tokio::time::sleep(Duration::from_millis(500)) => Err(io::Error::new(
+            io::ErrorKind::TimedOut,
+            "unrelated-source datagram reached neither socket",
+        )),
+    }
+}
+
 /// Resolve a hostname to addresses, filtered by address family preference
 pub fn resolve_host(host: &str, port: u16, family: AddressFamily) -> io::Result<Vec<SocketAddr>> {
     // Handle zone IDs for link-local IPv6 (e.g., fe80::1%eth0)
@@ -942,6 +1118,28 @@ mod tests {
         );
 
         let _ = accept_task.await;
+    }
+
+    /// The self-test must pass for real on Linux (CI and dev machines) —
+    /// it is what turns single-port UDP on, so a regression here silently
+    /// downgrades every client to legacy ephemeral ports.
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn single_port_udp_self_test_passes_on_linux() {
+        assert!(single_port_udp_self_test(AddressFamily::V4Only).await);
+        assert!(single_port_udp_self_test(AddressFamily::DualStack).await);
+    }
+
+    /// On every platform the self-test must come back with a verdict
+    /// rather than hang or panic — failure just means legacy fallback.
+    #[tokio::test]
+    async fn single_port_udp_self_test_returns_verdict() {
+        let _ = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            single_port_udp_self_test(AddressFamily::V4Only),
+        )
+        .await
+        .expect("self-test must complete promptly");
     }
 
     #[test]

--- a/src/probe.rs
+++ b/src/probe.rs
@@ -628,7 +628,11 @@ mod tests {
         );
         let server_addr = server.local_addr().unwrap();
         let (_cancel_tx, cancel_rx) = tokio::sync::watch::channel(false);
-        let responder = tokio::spawn(crate::udp::respond_mtu_probes(server.clone(), cancel_rx));
+        let responder = tokio::spawn(crate::udp::respond_mtu_probes(
+            server.clone(),
+            cancel_rx,
+            None,
+        ));
 
         let client = tokio::net::UdpSocket::bind("127.0.0.1:0")
             .await

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -138,6 +138,15 @@ pub enum ControlMessage {
     TestAck {
         id: String,
         data_ports: Vec<u16>,
+        /// Per-test routing token for single-port UDP mode (issue #63),
+        /// hex-encoded 16 random bytes. Present (with empty `data_ports`)
+        /// when the server selected single-port UDP; the client echoes it
+        /// inside each per-stream UDP hello datagram so the server can
+        /// route hellos to the right test even across NAT or multiple
+        /// concurrent clients. Wire-additive: absent for TCP/QUIC and for
+        /// legacy multi-port UDP.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        udp_token: Option<String>,
     },
     Interval {
         id: String,
@@ -463,11 +472,35 @@ pub const SUPPORTED_CAPABILITIES: &[&str] = &[
     // --probe-mtu — without it the client refuses to start, since an old
     // server would silently count probes as malformed data packets.
     "mtu_probe_v1",
+    // Issue #63: all per-stream UDP data rides connected sockets bound to
+    // the server's main port instead of per-stream ephemeral ports, so a
+    // firewall only needs one UDP port open. The client always advertises
+    // it; the server advertises it only when its startup self-test proved
+    // the kernel routes connected-socket traffic past the shared wildcard
+    // socket (see net::single_port_udp_self_test). Default when both
+    // peers advertise, mirroring single_port_tcp.
+    SINGLE_PORT_UDP_CAPABILITY,
 ];
 
-fn supported_capabilities() -> Vec<String> {
+/// Capability string for single-port UDP (issue #63). Kept as a named
+/// constant because the server filters it out of its hello at runtime
+/// when the startup self-test fails.
+pub const SINGLE_PORT_UDP_CAPABILITY: &str = "single_port_udp_v1";
+
+pub fn supported_capabilities() -> Vec<String> {
     SUPPORTED_CAPABILITIES
         .iter()
+        .map(|s| s.to_string())
+        .collect()
+}
+
+/// The full capability list minus one entry. Used by the server to
+/// suppress runtime-gated capabilities (currently only
+/// [`SINGLE_PORT_UDP_CAPABILITY`]) without duplicating the list.
+pub fn supported_capabilities_without(excluded: &str) -> Vec<String> {
+    SUPPORTED_CAPABILITIES
+        .iter()
+        .filter(|c| **c != excluded)
         .map(|s| s.to_string())
         .collect()
 }
@@ -495,21 +528,34 @@ impl ControlMessage {
     }
 
     pub fn server_hello() -> Self {
+        Self::server_hello_with_capabilities(supported_capabilities())
+    }
+
+    /// Server hello with a runtime-determined capability list (the static
+    /// list minus capabilities whose startup self-tests failed).
+    pub fn server_hello_with_capabilities(capabilities: Vec<String>) -> Self {
         ControlMessage::Hello {
             version: PROTOCOL_VERSION.to_string(),
             client: None,
             server: Some(format!("xfr/{}", env!("CARGO_PKG_VERSION"))),
-            capabilities: Some(supported_capabilities()),
+            capabilities: Some(capabilities),
             auth: None,
         }
     }
 
     pub fn server_hello_with_auth(nonce: String) -> Self {
+        Self::server_hello_with_auth_and_capabilities(nonce, supported_capabilities())
+    }
+
+    pub fn server_hello_with_auth_and_capabilities(
+        nonce: String,
+        capabilities: Vec<String>,
+    ) -> Self {
         ControlMessage::Hello {
             version: PROTOCOL_VERSION.to_string(),
             client: None,
             server: Some(format!("xfr/{}", env!("CARGO_PKG_VERSION"))),
-            capabilities: Some(supported_capabilities()),
+            capabilities: Some(capabilities),
             auth: Some(AuthChallenge {
                 method: "psk".to_string(),
                 nonce,
@@ -732,5 +778,49 @@ mod tests {
     fn test_protocol_display() {
         assert_eq!(Protocol::Tcp.to_string(), "TCP");
         assert_eq!(Protocol::Udp.to_string(), "UDP");
+    }
+
+    #[test]
+    fn test_test_ack_udp_token_roundtrip_and_omission() {
+        let msg = ControlMessage::TestAck {
+            id: "x".to_string(),
+            data_ports: vec![],
+            udp_token: Some("00112233445566778899aabbccddeeff".to_string()),
+        };
+        let json = msg.serialize().unwrap();
+        assert!(json.contains("\"udp_token\""));
+        match ControlMessage::deserialize(&json).unwrap() {
+            ControlMessage::TestAck { udp_token, .. } => {
+                assert_eq!(
+                    udp_token.as_deref(),
+                    Some("00112233445566778899aabbccddeeff")
+                );
+            }
+            _ => panic!("wrong message type"),
+        }
+
+        // None must be omitted so pre-#63 deserializers never see the field,
+        // and a legacy TestAck without it must decode as None.
+        let msg = ControlMessage::TestAck {
+            id: "x".to_string(),
+            data_ports: vec![5202],
+            udp_token: None,
+        };
+        let json = msg.serialize().unwrap();
+        assert!(!json.contains("udp_token"));
+        let legacy = r#"{"type":"test_ack","id":"x","data_ports":[5202]}"#;
+        match ControlMessage::deserialize(legacy).unwrap() {
+            ControlMessage::TestAck { udp_token, .. } => assert!(udp_token.is_none()),
+            _ => panic!("wrong message type"),
+        }
+    }
+
+    #[test]
+    fn test_supported_capabilities_without_filters_only_named_entry() {
+        let full = supported_capabilities();
+        assert!(full.iter().any(|c| c == SINGLE_PORT_UDP_CAPABILITY));
+        let filtered = supported_capabilities_without(SINGLE_PORT_UDP_CAPABILITY);
+        assert!(!filtered.iter().any(|c| c == SINGLE_PORT_UDP_CAPABILITY));
+        assert_eq!(filtered.len(), full.len() - 1);
     }
 }

--- a/src/quic.rs
+++ b/src/quic.rs
@@ -33,22 +33,30 @@
 //! 2. PSK authentication provides mutual authentication when needed
 //! 3. CA infrastructure is impractical for ephemeral test servers
 
+use std::io;
 use std::net::SocketAddr;
+use std::pin::Pin;
 use std::sync::Arc;
+use std::task::{Context, Poll};
 use std::time::Duration;
 
 use quinn::{
-    ClientConfig, Connection, Endpoint, EndpointConfig, RecvStream, SendStream, ServerConfig,
-    TransportConfig, VarInt,
+    AsyncUdpSocket, ClientConfig, Connection, Endpoint, EndpointConfig, RecvStream, SendStream,
+    ServerConfig, TransportConfig, UdpPoller, VarInt,
     crypto::rustls::{QuicClientConfig, QuicServerConfig},
 };
 use rustls::pki_types::{CertificateDer, PrivateKeyDer};
 use socket2::{Protocol, Socket, Type};
-use tokio::sync::watch;
+use tokio::sync::{mpsc, watch};
 use tracing::{debug, error, info};
 
 use crate::net::AddressFamily;
 use crate::stats::StreamStats;
+use crate::udp::SharedSocketLane;
+
+/// A single-port UDP hello diverted off the shared server socket:
+/// raw datagram bytes plus the client's source address.
+pub type XfrHelloDatagram = (Vec<u8>, SocketAddr);
 
 /// Default buffer size for QUIC send/receive operations (128 KB)
 const DEFAULT_BUFFER_SIZE: usize = 128 * 1024;
@@ -71,11 +79,19 @@ pub fn generate_self_signed_cert()
 /// Uses socket2 to create the UDP socket with proper dual-stack handling.
 /// On Windows, `std::net::UdpSocket::bind("[::]:port")` does NOT accept IPv4
 /// connections by default — we must explicitly set `IPV6_V6ONLY=false`.
+///
+/// When `xfr_hello_tx` is `Some` (single-port UDP enabled, issue #63),
+/// the socket also joins an SO_REUSEPORT group so per-stream connected
+/// data sockets can bind the same port later, and quinn receives a tee
+/// wrapper that diverts xfr hello datagrams to the dispatcher while
+/// passing QUIC through untouched. The endpoint then disables QUIC-bit
+/// greasing — see [`XfrLaneTee`] for why that is load-bearing.
 pub fn create_server_endpoint(
     addr: SocketAddr,
     family: AddressFamily,
     cert: Vec<CertificateDer<'static>>,
     key: PrivateKeyDer<'static>,
+    xfr_hello_tx: Option<mpsc::Sender<XfrHelloDatagram>>,
 ) -> anyhow::Result<Endpoint> {
     let mut crypto = rustls::ServerConfig::builder()
         .with_no_client_auth()
@@ -100,21 +116,138 @@ pub fn create_server_endpoint(
         socket.set_only_v6(v6only)?;
         debug!("QUIC socket IPV6_V6ONLY={} for {} mode", v6only, family);
     }
+    if xfr_hello_tx.is_some() {
+        // Both options must be set BEFORE bind for later same-port
+        // connected sockets to be admitted to the group.
+        socket.set_reuse_address(true)?;
+        #[cfg(unix)]
+        socket.set_reuse_port(true)?;
+    }
     socket.bind(&socket2::SockAddr::from(addr))?;
     socket.set_nonblocking(true)?;
     let std_socket: std::net::UdpSocket = socket.into();
 
     let runtime =
         quinn::default_runtime().ok_or_else(|| anyhow::anyhow!("no async runtime found"))?;
-    let endpoint = Endpoint::new(
-        EndpointConfig::default(),
-        Some(server_config),
-        std_socket,
-        runtime,
-    )?;
+    let mut endpoint_config = EndpointConfig::default();
+    // Wrap the runtime's own quinn-udp-backed socket object so the
+    // GSO/GRO/ECN metadata paths are preserved — the tee only inspects
+    // and reroutes, it never reimplements IO.
+    let inner = runtime.wrap_udp_socket(std_socket)?;
+    let socket: Arc<dyn AsyncUdpSocket> = match xfr_hello_tx {
+        Some(hello_tx) => {
+            // The shared-socket classifier routes short-header QUIC by its
+            // fixed bit (0x40). Quinn greases that bit by default (RFC
+            // 9287); greasing is permission-based, so a server that never
+            // advertises the grease transport parameter stops compliant
+            // peers from clearing the bit toward us — which is what makes
+            // the classifier sound.
+            endpoint_config.grease_quic_bit(false);
+            Arc::new(XfrLaneTee { inner, hello_tx })
+        }
+        None => inner,
+    };
+    let endpoint =
+        Endpoint::new_with_abstract_socket(endpoint_config, Some(server_config), socket, runtime)?;
     info!("QUIC server listening on {} ({})", addr, family);
 
     Ok(endpoint)
+}
+
+/// Tee on the shared server UDP socket (issue #63): inbound datagrams
+/// matching the xfr single-port hello lane divert to the dispatcher
+/// channel; everything else flows through to quinn untouched. Delegates
+/// every `AsyncUdpSocket` operation to the real quinn-udp-backed socket,
+/// so send-side GSO/ECN and recv-side GRO behavior are unchanged.
+///
+/// This is a low-rate hello/straggler lane ONLY. Per-stream data rides
+/// connected sockets that the kernel scores above this wildcard, so
+/// after the handshake the tee never sees test traffic.
+#[derive(Debug)]
+struct XfrLaneTee {
+    inner: Arc<dyn AsyncUdpSocket>,
+    hello_tx: mpsc::Sender<XfrHelloDatagram>,
+}
+
+impl AsyncUdpSocket for XfrLaneTee {
+    fn create_io_poller(self: Arc<Self>) -> Pin<Box<dyn UdpPoller>> {
+        self.inner.clone().create_io_poller()
+    }
+
+    fn try_send(&self, transmit: &quinn::udp::Transmit) -> io::Result<()> {
+        self.inner.try_send(transmit)
+    }
+
+    fn poll_recv(
+        &self,
+        cx: &mut Context,
+        bufs: &mut [io::IoSliceMut<'_>],
+        meta: &mut [quinn::udp::RecvMeta],
+    ) -> Poll<io::Result<usize>> {
+        loop {
+            let n = match self.inner.poll_recv(cx, bufs, meta) {
+                Poll::Ready(Ok(n)) => n,
+                other => return other,
+            };
+            // Divert xfr-lane entries and compact the QUIC ones down so
+            // quinn sees a contiguous prefix of buffers it owns.
+            let mut kept = 0;
+            for i in 0..n {
+                let len = meta[i].len.min(bufs[i].len());
+                match crate::udp::classify_shared_datagram(&bufs[i][..len]) {
+                    SharedSocketLane::Quic => {
+                        if kept != i {
+                            let (front, back) = bufs.split_at_mut(i);
+                            if front[kept].len() < len {
+                                // Can't happen with quinn's equal-size recv
+                                // buffers; drop rather than panic in poll.
+                                debug!("shared-socket tee: buffer too small to compact");
+                                continue;
+                            }
+                            front[kept][..len].copy_from_slice(&back[0][..len]);
+                            meta[kept] = meta[i];
+                        }
+                        kept += 1;
+                    }
+                    SharedSocketLane::XfrHello => {
+                        // Low-rate lane with client-side retry: dropping on
+                        // a full channel is safe, blocking quinn's recv
+                        // path is not.
+                        let _ = self
+                            .hello_tx
+                            .try_send((bufs[i][..len].to_vec(), meta[i].addr));
+                    }
+                    SharedSocketLane::XfrStray => {
+                        debug!(
+                            "shared-socket tee: dropping {}-byte non-QUIC datagram from {}",
+                            meta[i].len, meta[i].addr
+                        );
+                    }
+                }
+            }
+            if kept > 0 || n == 0 {
+                return Poll::Ready(Ok(kept));
+            }
+            // Every datagram in the batch was diverted; poll the inner
+            // socket again instead of handing quinn an empty result.
+        }
+    }
+
+    fn local_addr(&self) -> io::Result<SocketAddr> {
+        self.inner.local_addr()
+    }
+
+    fn max_transmit_segments(&self) -> usize {
+        self.inner.max_transmit_segments()
+    }
+
+    fn max_receive_segments(&self) -> usize {
+        self.inner.max_receive_segments()
+    }
+
+    fn may_fragment(&self) -> bool {
+        self.inner.may_fragment()
+    }
 }
 
 /// Create a QUIC client endpoint with optional local bind address

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -114,6 +114,238 @@ struct SecurityContext {
     bind_addr: Option<IpAddr>,
     tui_tx: Option<mpsc::Sender<ServerEvent>>,
     push_gateway_url: Option<String>,
+    /// Runtime capability list for server hellos: the static list minus
+    /// `single_port_udp_v1` when the startup self-test failed.
+    capabilities: Vec<String>,
+    /// Token → test routing table for single-port UDP hellos (issue #63).
+    /// `None` when the self-test failed or the shared socket couldn't be
+    /// set up — tests then fall back to legacy per-stream ports.
+    udp_hello_routes: Option<UdpHelloRoutes>,
+}
+
+/// Per-test routing entry for single-port UDP hellos (issue #63),
+/// registered under the test's random token before the TestAck goes out.
+struct UdpHelloRoute {
+    /// Hands freshly connected per-stream sockets to the test's handler
+    /// collection task.
+    socket_tx: mpsc::Sender<(Arc<UdpSocket>, u16)>,
+    /// Hellos must come from the control connection's IP, mirroring the
+    /// DataHello check for single-port TCP.
+    control_peer_ip: IpAddr,
+    expected_streams: u8,
+    /// Client's `-w` request, applied to each connected socket.
+    udp_buffer: Option<usize>,
+    /// Connected sockets created so far, kept so a retried hello (whose
+    /// ack was lost before the kernel started routing retries to the
+    /// connected socket) gets a fresh ack instead of a duplicate socket.
+    sockets: Vec<Option<Arc<UdpSocket>>>,
+}
+
+/// Synchronous mutex: the dispatcher only holds it across map operations,
+/// never across socket IO, and a sync lock lets the route guard clean up
+/// in Drop on every run_test exit path.
+type UdpHelloRoutes = Arc<parking_lot::Mutex<HashMap<[u8; 16], UdpHelloRoute>>>;
+
+/// Removes a test's hello route when run_test exits by any path.
+struct UdpRouteGuard {
+    routes: UdpHelloRoutes,
+    token: [u8; 16],
+}
+
+impl Drop for UdpRouteGuard {
+    fn drop(&mut self) {
+        self.routes.lock().remove(&self.token);
+    }
+}
+
+/// Validation verdict for an inbound single-port UDP hello.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum UdpHelloVerdict {
+    /// First hello for this stream: create a connected socket.
+    Accept,
+    /// Stream already has a socket: re-send the ack from it.
+    Resend,
+    UnknownToken,
+    IpMismatch,
+    BadStreamIndex,
+}
+
+/// Pure validation half of the hello dispatcher, factored out so the
+/// token/IP/stream checks are unit-testable without sockets.
+fn check_udp_hello(
+    route: Option<&UdpHelloRoute>,
+    pkt: &udp::UdpHelloPacket,
+    src_ip: IpAddr,
+) -> UdpHelloVerdict {
+    let Some(route) = route else {
+        return UdpHelloVerdict::UnknownToken;
+    };
+    // normalize_ip handles IPv4-mapped IPv6 (control over IPv4, hello on
+    // a dual-stack UDP socket appears as ::ffff:x.x.x.x).
+    if net::normalize_ip(src_ip) != net::normalize_ip(route.control_peer_ip) {
+        return UdpHelloVerdict::IpMismatch;
+    }
+    if pkt.stream_index >= u16::from(route.expected_streams) {
+        return UdpHelloVerdict::BadStreamIndex;
+    }
+    if route
+        .sockets
+        .get(usize::from(pkt.stream_index))
+        .is_some_and(|s| s.is_some())
+    {
+        return UdpHelloVerdict::Resend;
+    }
+    UdpHelloVerdict::Accept
+}
+
+/// Single-port UDP hello dispatcher (issue #63): consumes hello
+/// datagrams diverted off the shared socket, validates them against the
+/// active-test routing table, and for each new stream creates the
+/// connected same-port data socket, acks the client FROM that socket
+/// (so the client knows the fast path exists before it sends data), and
+/// hands the socket to the test's collection task.
+fn spawn_udp_hello_dispatcher(
+    mut hello_rx: mpsc::Receiver<crate::quic::XfrHelloDatagram>,
+    routes: UdpHelloRoutes,
+    local_addr: SocketAddr,
+    v6only: Option<bool>,
+) {
+    tokio::spawn(async move {
+        while let Some((data, src)) = hello_rx.recv().await {
+            let Some(pkt) = udp::UdpHelloPacket::decode(&data) else {
+                continue;
+            };
+            if pkt.kind != udp::UDP_HELLO_KIND_HELLO {
+                continue;
+            }
+            let ack = udp::UdpHelloPacket {
+                kind: udp::UDP_HELLO_KIND_ACK,
+                stream_index: pkt.stream_index,
+                token: pkt.token,
+            }
+            .encode();
+
+            // Validate under the lock, but do socket IO outside it. The
+            // dispatcher is a single task, so no other writer can race a
+            // Create decision for the same stream between lock drops.
+            enum Action {
+                Create {
+                    socket_tx: mpsc::Sender<(Arc<UdpSocket>, u16)>,
+                    udp_buffer: Option<usize>,
+                },
+                Resend(Arc<UdpSocket>),
+                Drop,
+            }
+            let action = {
+                let map = routes.lock();
+                let route = map.get(&pkt.token);
+                match check_udp_hello(route, &pkt, src.ip()) {
+                    UdpHelloVerdict::Accept => {
+                        let route = route.expect("Accept implies route exists");
+                        Action::Create {
+                            socket_tx: route.socket_tx.clone(),
+                            udp_buffer: route.udp_buffer,
+                        }
+                    }
+                    UdpHelloVerdict::Resend => {
+                        let socket = route
+                            .and_then(|r| r.sockets[usize::from(pkt.stream_index)].clone())
+                            .expect("Resend implies socket exists");
+                        Action::Resend(socket)
+                    }
+                    verdict => {
+                        debug!(
+                            "UDP hello from {} rejected ({:?}) for stream {}",
+                            src, verdict, pkt.stream_index
+                        );
+                        Action::Drop
+                    }
+                }
+            };
+
+            match action {
+                Action::Resend(socket) => {
+                    if let Err(e) = socket.send(&ack).await {
+                        debug!("UDP hello ack resend to {} failed: {}", src, e);
+                    }
+                }
+                Action::Create {
+                    socket_tx,
+                    udp_buffer,
+                } => {
+                    let socket =
+                        match net::create_connected_udp_same_port(local_addr, v6only, src).await {
+                            Ok(s) => Arc::new(s),
+                            Err(e) => {
+                                warn!(
+                                    "single-port UDP: failed to create connected socket for {}: {}",
+                                    src, e
+                                );
+                                continue;
+                            }
+                        };
+                    if let Some(size) = udp_buffer
+                        && let Err(e) = net::set_udp_buffer_size(&socket, size)
+                    {
+                        warn!("Failed to set UDP buffer size to {}: {}", size, e);
+                    }
+                    if let Err(e) = socket.send(&ack).await {
+                        debug!("UDP hello ack to {} failed: {}", src, e);
+                    }
+                    // Store for ack-resend dedupe; the route may have been
+                    // removed if the test ended while we were creating the
+                    // socket — drop the socket in that case.
+                    {
+                        let mut map = routes.lock();
+                        match map.get_mut(&pkt.token) {
+                            Some(route) => {
+                                route.sockets[usize::from(pkt.stream_index)] = Some(socket.clone());
+                            }
+                            None => continue,
+                        }
+                    }
+                    if socket_tx.send((socket, pkt.stream_index)).await.is_err() {
+                        debug!("single-port UDP: test ended before socket handoff");
+                    }
+                }
+                Action::Drop => {}
+            }
+        }
+    });
+}
+
+/// Hello listener for the `--no-quic` case (issue #63): without a quinn
+/// endpoint there is no tee, so a plain shared socket owns the main UDP
+/// port and this loop classifies inbound datagrams itself. Same
+/// classifier, same low-rate-lane rules; QUIC-looking packets are
+/// dropped since QUIC is disabled.
+fn spawn_plain_udp_hello_listener(
+    socket: UdpSocket,
+    hello_tx: mpsc::Sender<crate::quic::XfrHelloDatagram>,
+) {
+    tokio::spawn(async move {
+        let mut buf = vec![0u8; 2048];
+        loop {
+            match socket.recv_from(&mut buf).await {
+                Ok((n, src)) => {
+                    if matches!(
+                        udp::classify_shared_datagram(&buf[..n]),
+                        udp::SharedSocketLane::XfrHello
+                    ) {
+                        let _ = hello_tx.try_send((buf[..n].to_vec(), src));
+                    } else {
+                        debug!(
+                            "shared UDP socket: dropping {}-byte non-hello datagram from {}",
+                            n, src
+                        );
+                    }
+                }
+                Err(e) => {
+                    debug!("shared UDP socket recv error: {}", e);
+                }
+            }
+        }
+    });
 }
 
 struct ActiveTest {
@@ -199,20 +431,85 @@ impl Server {
                 .await?
         };
 
+        // Single-port UDP (issue #63): advertise the capability only when
+        // the running kernel demonstrably routes connected-socket traffic
+        // past a same-port wildcard (SO_REUSEPORT group semantics vary).
+        let single_port_udp_ok = net::single_port_udp_self_test(self.config.address_family).await;
+        let udp_bind_addr = if let Some(ip) = self.config.bind_addr {
+            SocketAddr::new(ip, self.config.port)
+        } else {
+            self.config.address_family.bind_addr(self.config.port)
+        };
+        let udp_v6only = match self.config.address_family {
+            AddressFamily::V4Only => None,
+            AddressFamily::V6Only => Some(true),
+            AddressFamily::DualStack => Some(false),
+        };
+        let (udp_hello_tx, udp_hello_rx) = if single_port_udp_ok {
+            let (tx, rx) = mpsc::channel::<crate::quic::XfrHelloDatagram>(256);
+            (Some(tx), Some(rx))
+        } else {
+            (None, None)
+        };
+
         // Create QUIC endpoint on the same port (UDP) - only if enabled
         let quic_endpoint = if self.config.enable_quic {
             let (cert, key) = quic::generate_self_signed_cert()?;
-            let bind_addr = if let Some(ip) = self.config.bind_addr {
-                SocketAddr::new(ip, self.config.port)
-            } else {
-                self.config.address_family.bind_addr(self.config.port)
-            };
-            let endpoint =
-                quic::create_server_endpoint(bind_addr, self.config.address_family, cert, key)?;
+            let endpoint = quic::create_server_endpoint(
+                udp_bind_addr,
+                self.config.address_family,
+                cert,
+                key,
+                udp_hello_tx.clone(),
+            )?;
             info!("QUIC endpoint ready on port {}", self.config.port);
             Some(endpoint)
         } else {
             None
+        };
+
+        // Single-port UDP needs something listening on the main UDP port
+        // for hellos. With QUIC enabled the tee inside the endpoint does
+        // it; otherwise bind a plain shared socket for the hello lane.
+        let mut udp_hello_active = false;
+        if let Some(tx) = udp_hello_tx {
+            if self.config.enable_quic {
+                udp_hello_active = true;
+            } else {
+                match net::create_shared_udp_socket(udp_bind_addr, udp_v6only).await {
+                    Ok(socket) => {
+                        spawn_plain_udp_hello_listener(socket, tx);
+                        udp_hello_active = true;
+                    }
+                    Err(e) => {
+                        warn!(
+                            "single-port UDP disabled: failed to bind shared UDP socket on {}: {}",
+                            udp_bind_addr, e
+                        );
+                    }
+                }
+            }
+        }
+        let udp_hello_routes: Option<UdpHelloRoutes> = if udp_hello_active {
+            let routes: UdpHelloRoutes = Arc::new(parking_lot::Mutex::new(HashMap::new()));
+            // The dispatcher consumes diverted hellos for the whole server
+            // lifetime; per-test entries come and go in the routes map.
+            spawn_udp_hello_dispatcher(
+                udp_hello_rx.expect("hello channel exists when lane is active"),
+                routes.clone(),
+                udp_bind_addr,
+                udp_v6only,
+            );
+            Some(routes)
+        } else {
+            None
+        };
+        let capabilities = if udp_hello_routes.is_some() {
+            crate::protocol::supported_capabilities()
+        } else {
+            crate::protocol::supported_capabilities_without(
+                crate::protocol::SINGLE_PORT_UDP_CAPABILITY,
+            )
         };
 
         // Initialize security context
@@ -240,6 +537,8 @@ impl Server {
             bind_addr: self.config.bind_addr,
             tui_tx: self.config.tui_tx.clone(),
             push_gateway_url: self.config.push_gateway_url.clone(),
+            capabilities,
+            udp_hello_routes,
         });
 
         // Start rate limiter cleanup task if enabled
@@ -815,13 +1114,17 @@ async fn handle_quic_client(
             // Send server hello (with auth challenge if required)
             if security.psk.is_some() {
                 let nonce = auth::generate_nonce();
-                let hello = ControlMessage::server_hello_with_auth(nonce.clone());
+                let hello = ControlMessage::server_hello_with_auth_and_capabilities(
+                    nonce.clone(),
+                    security.capabilities.clone(),
+                );
                 ctrl_send
                     .write_all(format!("{}\n", hello.serialize()?).as_bytes())
                     .await?;
                 Some(nonce)
             } else {
-                let hello = ControlMessage::server_hello();
+                let hello =
+                    ControlMessage::server_hello_with_capabilities(security.capabilities.clone());
                 ctrl_send
                     .write_all(format!("{}\n", hello.serialize()?).as_bytes())
                     .await?;
@@ -951,6 +1254,7 @@ async fn handle_quic_client(
             let ack = ControlMessage::TestAck {
                 id: id.clone(),
                 data_ports: vec![], // Empty for QUIC
+                udp_token: None,
             };
             ctrl_send
                 .write_all(format!("{}\n", ack.serialize()?).as_bytes())
@@ -1022,13 +1326,17 @@ async fn handle_client_with_first_message(
             // Send server hello (with auth challenge if required)
             if security.psk.is_some() {
                 let nonce = auth::generate_nonce();
-                let hello = ControlMessage::server_hello_with_auth(nonce.clone());
+                let hello = ControlMessage::server_hello_with_auth_and_capabilities(
+                    nonce.clone(),
+                    security.capabilities.clone(),
+                );
                 writer
                     .write_all(format!("{}\n", hello.serialize()?).as_bytes())
                     .await?;
                 (Some(nonce), capabilities)
             } else {
-                let hello = ControlMessage::server_hello();
+                let hello =
+                    ControlMessage::server_hello_with_capabilities(security.capabilities.clone());
                 writer
                     .write_all(format!("{}\n", hello.serialize()?).as_bytes())
                     .await?;
@@ -1083,6 +1391,10 @@ async fn handle_client_with_first_message(
         crate::protocol::capability_advertised(&client_capabilities, "single_port_tcp");
     let client_supports_udp_feedback =
         crate::protocol::capability_advertised(&client_capabilities, "udp_feedback_v1");
+    let client_supports_single_port_udp = crate::protocol::capability_advertised(
+        &client_capabilities,
+        crate::protocol::SINGLE_PORT_UDP_CAPABILITY,
+    );
 
     // Continue with test handling
     handle_test_request(
@@ -1094,6 +1406,7 @@ async fn handle_client_with_first_message(
         security,
         client_supports_single_port,
         client_supports_udp_feedback,
+        client_supports_single_port_udp,
     )
     .await
 }
@@ -1168,6 +1481,7 @@ async fn handle_client_with_auth(
         security,
         true,
         true,
+        true,
     )
     .await
 }
@@ -1203,13 +1517,17 @@ async fn perform_auth_handshake<W: tokio::io::AsyncWrite + Unpin>(
             // Send server hello (with auth challenge if required)
             if security.psk.is_some() {
                 let nonce = auth::generate_nonce();
-                let hello = ControlMessage::server_hello_with_auth(nonce.clone());
+                let hello = ControlMessage::server_hello_with_auth_and_capabilities(
+                    nonce.clone(),
+                    security.capabilities.clone(),
+                );
                 writer
                     .write_all(format!("{}\n", hello.serialize()?).as_bytes())
                     .await?;
                 Ok(Some(nonce))
             } else {
-                let hello = ControlMessage::server_hello();
+                let hello =
+                    ControlMessage::server_hello_with_capabilities(security.capabilities.clone());
                 writer
                     .write_all(format!("{}\n", hello.serialize()?).as_bytes())
                     .await?;
@@ -1237,6 +1555,7 @@ async fn handle_test_request(
     security: &SecurityContext,
     client_supports_single_port: bool,
     client_supports_udp_feedback: bool,
+    client_supports_single_port_udp: bool,
 ) -> anyhow::Result<()> {
     let mut line = String::new();
 
@@ -1359,6 +1678,14 @@ async fn handle_test_request(
                 &security.push_gateway_url,
                 client_supports_single_port,
                 client_supports_udp_feedback,
+                // Single-port UDP needs both peers on board: the client
+                // must know to send hellos, the server must have a
+                // working hello lane (self-test + shared socket).
+                if client_supports_single_port_udp {
+                    security.udp_hello_routes.clone()
+                } else {
+                    None
+                },
                 dscp,
                 window_size,
                 zerocopy,
@@ -1749,6 +2076,7 @@ async fn run_test(
     push_gateway_url: &Option<String>,
     client_supports_single_port: bool,
     client_supports_udp_feedback: bool,
+    udp_single_port_routes: Option<UdpHelloRoutes>,
     dscp: Option<u8>,
     client_window_size: Option<u64>,
     zerocopy: bool,
@@ -1757,9 +2085,13 @@ async fn run_test(
     let mut line = String::new();
 
     // For TCP: single-port mode (data connections come on control port)
-    // For UDP: allocate per-stream sockets
+    // For UDP: single-port mode (hello-routed connected sockets on the
+    // main port, issue #63) or legacy per-stream sockets
     let mut data_ports = Vec::new();
     let mut udp_sockets: Vec<Arc<UdpSocket>> = Vec::new();
+    let mut udp_token: Option<[u8; 16]> = None;
+    let mut udp_socket_rx: Option<mpsc::Receiver<(Arc<UdpSocket>, u16)>> = None;
+    let mut _udp_route_guard: Option<UdpRouteGuard> = None;
 
     // Create cancel channel early so fallback listeners can use it
     let (cancel_tx, cancel_rx) = watch::channel(false);
@@ -1819,6 +2151,41 @@ async fn run_test(
             // Don't store tx in active_tests since we don't need DataHello routing
             (None, Some(rx))
         }
+        Protocol::Udp if udp_single_port_routes.is_some() => {
+            // Single-port mode (issue #63): no ports allocated. The client
+            // sends a token-bearing hello per stream to the main port; the
+            // dispatcher creates connected same-port sockets and hands
+            // them to this test through the channel registered here.
+            let routes = udp_single_port_routes
+                .as_ref()
+                .expect("guarded by match arm");
+            let (socket_tx, socket_rx) = mpsc::channel::<(Arc<UdpSocket>, u16)>(streams as usize);
+            let token = {
+                use std::collections::hash_map::Entry;
+                let mut map = routes.lock();
+                loop {
+                    let mut candidate = [0u8; 16];
+                    rand::RngExt::fill(&mut rand::rng(), &mut candidate[..]);
+                    if let Entry::Vacant(entry) = map.entry(candidate) {
+                        entry.insert(UdpHelloRoute {
+                            socket_tx,
+                            control_peer_ip: peer_addr.ip(),
+                            expected_streams: streams,
+                            udp_buffer: client_window_to_host(client_window_size),
+                            sockets: vec![None; streams as usize],
+                        });
+                        break candidate;
+                    }
+                }
+            };
+            _udp_route_guard = Some(UdpRouteGuard {
+                routes: routes.clone(),
+                token,
+            });
+            udp_token = Some(token);
+            udp_socket_rx = Some(socket_rx);
+            (None, None)
+        }
         Protocol::Udp => {
             // Apply the client's `-w` to each receive socket. Without this,
             // high-rate UDP runs against weak/loaded receivers can saturate
@@ -1871,10 +2238,11 @@ async fn run_test(
         );
     }
 
-    // Send test ack with allocated ports
+    // Send test ack with allocated ports (or the single-port UDP token)
     let ack = ControlMessage::TestAck {
         id: id.to_string(),
         data_ports: data_ports.clone(),
+        udp_token: udp_token.as_ref().map(udp::encode_hello_token),
     };
     writer
         .write_all(format!("{}\n", ack.serialize()?).as_bytes())
@@ -1900,9 +2268,10 @@ async fn run_test(
     crate::output::prometheus::on_test_start();
 
     // Spawn data stream handlers
-    // For TCP: spawn stream collection in background to not block interval loop
-    // For UDP: handlers are spawned immediately
-    let (tcp_collection_handle, udp_handles) = match protocol {
+    // For TCP and single-port UDP: spawn stream collection in background
+    // to not block the interval loop
+    // For legacy UDP: handlers are spawned immediately
+    let (collection_handle, udp_handles) = match protocol {
         Protocol::Tcp => {
             // Single-port mode: spawn stream collection in background
             // This allows interval loop and cancel handling to run while waiting for streams
@@ -1932,6 +2301,29 @@ async fn run_test(
                 (None, Vec::new())
             }
         }
+        Protocol::Udp if udp_socket_rx.is_some() => {
+            // Single-port mode: connected sockets stream in from the hello
+            // dispatcher as the client's per-stream handshakes land; the
+            // collection task mirrors the TCP DataHello flow. Covers both
+            // bulk transfers and --probe-mtu (handled per socket inside).
+            let rx = udp_socket_rx.take().expect("guarded by match arm");
+            let token = udp_token.expect("single-port UDP always has a token");
+            let handle = tokio::spawn(spawn_single_port_udp_handlers(
+                rx,
+                streams as usize,
+                token,
+                stats.clone(),
+                direction,
+                duration,
+                bitrate.unwrap_or(DEFAULT_BITRATE_BPS),
+                cancel_rx.clone(),
+                pause_rx.clone(),
+                dscp,
+                client_supports_udp_feedback,
+                mtu_probe,
+            ));
+            (Some(handle), Vec::new())
+        }
         Protocol::Udp if mtu_probe => {
             // Probe mode replaces the bulk handlers entirely: every
             // socket answers XFRP probes with ack + same-size echo until
@@ -1953,7 +2345,7 @@ async fn run_test(
                     let socket = socket.clone();
                     let cancel = cancel_rx.clone();
                     tokio::spawn(async move {
-                        if let Err(e) = udp::respond_mtu_probes(socket, cancel).await {
+                        if let Err(e) = udp::respond_mtu_probes(socket, cancel, None).await {
                             error!("MTU probe responder error: {}", e);
                         }
                     })
@@ -2070,25 +2462,26 @@ async fn run_test(
     }
 
     // Wait for all data handlers to complete
-    match (tcp_collection_handle, udp_handles) {
+    match (collection_handle, udp_handles) {
         (Some(handle), _) => {
-            // TCP: wait for stream collection task, then wait for individual handlers
+            // TCP / single-port UDP: wait for the stream collection task,
+            // then wait for individual handlers
             match handle.await {
-                Ok(tcp_handles) => {
-                    let results = futures::future::join_all(tcp_handles).await;
+                Ok(stream_handles) => {
+                    let results = futures::future::join_all(stream_handles).await;
                     for result in results {
                         if let Err(e) = result
                             && e.is_panic()
                         {
-                            error!("TCP stream handler panicked: {:?}", e);
+                            error!("Stream handler panicked: {:?}", e);
                         }
                     }
                 }
                 Err(e) => {
                     if e.is_panic() {
-                        error!("TCP stream collection task panicked: {:?}", e);
+                        error!("Stream collection task panicked: {:?}", e);
                     } else {
-                        warn!("TCP stream collection task was cancelled");
+                        warn!("Stream collection task was cancelled");
                     }
                 }
             }
@@ -2624,6 +3017,7 @@ async fn spawn_udp_handlers(
                         cancel,
                         pause,
                         client_supports_udp_feedback,
+                        None,
                     )
                     .await
                     {
@@ -2696,6 +3090,7 @@ async fn spawn_udp_handlers(
                                     recv_cancel,
                                     recv_pause,
                                     false,
+                                    None,
                                 )
                                 .await
                                 {
@@ -2713,6 +3108,219 @@ async fn spawn_udp_handlers(
             }
         });
         handles.push(handle);
+    }
+
+    handles
+}
+
+/// Single-port UDP mode (issue #63): receive connected per-stream
+/// sockets from the hello dispatcher and spawn the per-direction
+/// handlers on each, mirroring `spawn_tcp_stream_handlers`. Each
+/// handler carries the precomputed hello ack so retried hellos (which
+/// the kernel routes to the connected socket once it exists) get
+/// re-acked instead of polluting the data accounting.
+#[allow(clippy::too_many_arguments)]
+async fn spawn_single_port_udp_handlers(
+    mut rx: mpsc::Receiver<(Arc<UdpSocket>, u16)>,
+    num_streams: usize,
+    token: [u8; 16],
+    stats: Arc<TestStats>,
+    direction: Direction,
+    duration: Duration,
+    bitrate: u64,
+    cancel: watch::Receiver<bool>,
+    pause: watch::Receiver<bool>,
+    dscp: Option<u8>,
+    client_supports_udp_feedback: bool,
+    mtu_probe: bool,
+) -> Vec<JoinHandle<()>> {
+    let per_stream_bitrate = if bitrate == 0 {
+        0 // Unlimited mode (explicit -b 0)
+    } else {
+        (bitrate / num_streams.max(1) as u64).max(1)
+    };
+    let mut handles = Vec::new();
+    let mut received = vec![false; num_streams];
+    let deadline = tokio::time::Instant::now() + STREAM_COLLECTION_TIMEOUT;
+    let mut cancel = cancel;
+
+    while received.iter().any(|&r| !r) {
+        if *cancel.borrow() {
+            warn!("Test cancelled during UDP stream collection");
+            break;
+        }
+
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            warn!("Timeout waiting for all single-port UDP streams");
+            break;
+        }
+
+        let stream_result = tokio::select! {
+            biased;
+            result = cancel.changed() => {
+                match result {
+                    Ok(()) if *cancel.borrow() => {
+                        warn!("Test cancelled during UDP stream collection");
+                        break;
+                    }
+                    Ok(()) => continue,
+                    Err(_) => {
+                        warn!("Cancel channel closed during UDP stream collection");
+                        break;
+                    }
+                }
+            }
+            result = tokio::time::timeout(remaining, rx.recv()) => result,
+        };
+
+        match stream_result {
+            Ok(Some((socket, stream_index))) => {
+                let i = stream_index as usize;
+                if i >= num_streams {
+                    warn!("Invalid UDP stream index: {}", stream_index);
+                    continue;
+                }
+                if received[i] {
+                    warn!("Duplicate UDP stream index: {}", stream_index);
+                    continue;
+                }
+                received[i] = true;
+
+                // Apply DSCP/TOS marking if requested by client
+                if let Some(tos) = dscp
+                    && let Err(e) = crate::net::set_tos_on_udp(&socket, tos)
+                {
+                    warn!("Failed to set DSCP on server UDP socket {}: {}", i, e);
+                }
+
+                let ack = udp::UdpHelloPacket {
+                    kind: udp::UDP_HELLO_KIND_ACK,
+                    stream_index,
+                    token,
+                }
+                .encode();
+                let stream_stats = stats.streams[i].clone();
+                let test_stats = stats.clone();
+                let cancel = cancel.clone();
+                let pause = pause.clone();
+
+                let handle = tokio::spawn(async move {
+                    if mtu_probe {
+                        // Probe mode replaces bulk handlers, same as the
+                        // legacy branch in run_test; DF is best-effort.
+                        let ipv6 = socket.local_addr().map(|a| a.is_ipv6()).unwrap_or(false);
+                        if let Err(e) = net::set_dont_fragment(&socket, ipv6) {
+                            warn!(
+                                "MTU probe: could not set don't-fragment on echo socket: {} \
+                                 (oversized echoes may fragment and overstate the reverse path)",
+                                e
+                            );
+                        }
+                        if let Err(e) = udp::respond_mtu_probes(socket, cancel, Some(ack)).await {
+                            error!("MTU probe responder error: {}", e);
+                        }
+                        return;
+                    }
+                    match direction {
+                        Direction::Upload => {
+                            if let Ok((udp_stats, _bytes)) = udp::receive_udp(
+                                socket,
+                                stream_stats,
+                                cancel,
+                                pause,
+                                client_supports_udp_feedback,
+                                Some(ack),
+                            )
+                            .await
+                            {
+                                test_stats.add_udp_stats(udp_stats);
+                            }
+                        }
+                        Direction::Download => {
+                            // Nothing else recvs on this socket in download
+                            // mode, so a dedicated responder keeps answering
+                            // hello retries while the sender runs.
+                            let responder_socket = socket.clone();
+                            let responder_cancel = cancel.clone();
+                            let responder = tokio::spawn(async move {
+                                udp::respond_single_port_hellos(
+                                    responder_socket,
+                                    ack,
+                                    responder_cancel,
+                                )
+                                .await;
+                            });
+                            let _ = udp::send_udp_paced(
+                                socket,
+                                None, // connected socket
+                                per_stream_bitrate,
+                                duration,
+                                stream_stats,
+                                cancel,
+                                pause,
+                                true,
+                            )
+                            .await;
+                            let _ = responder.await;
+                        }
+                        Direction::Bidir => {
+                            let send_socket = socket.clone();
+                            let recv_socket = socket;
+                            let send_stats = stream_stats.clone();
+                            let recv_stats = stream_stats;
+                            let send_cancel = cancel.clone();
+                            let recv_cancel = cancel;
+                            let send_pause = pause.clone();
+                            let recv_pause = pause;
+
+                            let send_handle = tokio::spawn(async move {
+                                let _ = udp::send_udp_paced(
+                                    send_socket,
+                                    None, // connected socket
+                                    per_stream_bitrate,
+                                    duration,
+                                    send_stats,
+                                    send_cancel,
+                                    send_pause,
+                                    true,
+                                )
+                                .await;
+                            });
+
+                            let recv_handle = tokio::spawn(async move {
+                                // Feedback stays upload-mode-only (see the
+                                // legacy bidir handler); the recv side also
+                                // re-acks hello retries here.
+                                if let Ok((udp_stats, _bytes)) = udp::receive_udp(
+                                    recv_socket,
+                                    recv_stats,
+                                    recv_cancel,
+                                    recv_pause,
+                                    false,
+                                    Some(ack),
+                                )
+                                .await
+                                {
+                                    test_stats.add_udp_stats(udp_stats);
+                                }
+                            });
+
+                            let _ = tokio::join!(send_handle, recv_handle);
+                        }
+                    }
+                });
+                handles.push(handle);
+            }
+            Ok(None) => {
+                warn!("UDP socket channel closed");
+                break;
+            }
+            Err(_) => {
+                warn!("Timeout waiting for single-port UDP stream");
+                break;
+            }
+        }
     }
 
     handles
@@ -2795,6 +3403,89 @@ mod tests {
         assert_eq!(
             initial_read_timeout_for_peer(&tests, peer_b),
             INITIAL_READ_TIMEOUT
+        );
+    }
+
+    fn make_udp_route(streams: u8, ip: IpAddr) -> UdpHelloRoute {
+        let (socket_tx, _rx) = mpsc::channel(1);
+        UdpHelloRoute {
+            socket_tx,
+            control_peer_ip: ip,
+            expected_streams: streams,
+            udp_buffer: None,
+            sockets: vec![None; streams as usize],
+        }
+    }
+
+    fn make_hello(stream_index: u16, token: [u8; 16]) -> udp::UdpHelloPacket {
+        udp::UdpHelloPacket {
+            kind: udp::UDP_HELLO_KIND_HELLO,
+            stream_index,
+            token,
+        }
+    }
+
+    #[test]
+    fn test_check_udp_hello_unknown_token_rejected() {
+        // A hello whose token misses the routing table must be dropped —
+        // this is the token-mismatch path (the map is keyed by token, so
+        // a wrong token IS a missed lookup).
+        let pkt = make_hello(0, [9; 16]);
+        let src: IpAddr = "10.0.0.2".parse().unwrap();
+        assert_eq!(
+            check_udp_hello(None, &pkt, src),
+            UdpHelloVerdict::UnknownToken
+        );
+    }
+
+    #[test]
+    fn test_check_udp_hello_ip_mismatch_rejected() {
+        let route = make_udp_route(2, "10.0.0.2".parse().unwrap());
+        let pkt = make_hello(0, [1; 16]);
+        assert_eq!(
+            check_udp_hello(Some(&route), &pkt, "10.0.0.3".parse().unwrap()),
+            UdpHelloVerdict::IpMismatch
+        );
+    }
+
+    #[test]
+    fn test_check_udp_hello_accepts_and_normalizes_mapped_ip() {
+        // Control over IPv4, hello observed as IPv4-mapped IPv6 on the
+        // dual-stack shared socket: must still match.
+        let route = make_udp_route(2, "10.0.0.2".parse().unwrap());
+        let pkt = make_hello(1, [1; 16]);
+        let mapped: IpAddr = "::ffff:10.0.0.2".parse().unwrap();
+        assert_eq!(
+            check_udp_hello(Some(&route), &pkt, mapped),
+            UdpHelloVerdict::Accept
+        );
+    }
+
+    #[test]
+    fn test_check_udp_hello_stream_bounds_and_resend() {
+        let mut route = make_udp_route(2, "10.0.0.2".parse().unwrap());
+        let src: IpAddr = "10.0.0.2".parse().unwrap();
+
+        let out_of_range = make_hello(2, [1; 16]);
+        assert_eq!(
+            check_udp_hello(Some(&route), &out_of_range, src),
+            UdpHelloVerdict::BadStreamIndex
+        );
+
+        // A retried hello for a stream that already has its connected
+        // socket re-acks instead of creating a second socket.
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let socket = runtime
+            .block_on(tokio::net::UdpSocket::bind("127.0.0.1:0"))
+            .unwrap();
+        route.sockets[1] = Some(Arc::new(socket));
+        let retry = make_hello(1, [1; 16]);
+        assert_eq!(
+            check_udp_hello(Some(&route), &retry, src),
+            UdpHelloVerdict::Resend
         );
     }
 

--- a/src/udp.rs
+++ b/src/udp.rs
@@ -134,6 +134,257 @@ impl UdpFeedbackPacket {
     }
 }
 
+/// Magic prefix on single-port UDP hello/ack packets (issue #63). These
+/// are the only xfr packets that ever cross the server's shared wildcard
+/// socket, where QUIC traffic is demuxed by header bits: the first byte
+/// must have the top two bits clear so it can never look like a QUIC
+/// long header (0x80, RFC 8999) or short header (0x40 fixed bit). The
+/// legacy `XFRF`/`XFRP` magics start with 'X' (0x58 = 0b0101_1000) and
+/// stay off the shared socket entirely — they ride connected sockets
+/// where the existing demux is unchanged.
+pub const UDP_HELLO_MAGIC: [u8; 4] = *b"\x00XFR";
+/// Fixed on-wire size of a hello/ack packet.
+pub const UDP_HELLO_SIZE: usize = 24;
+/// Currently-supported hello packet protocol version.
+pub const UDP_HELLO_VERSION: u8 = 1;
+/// `kind` byte for the client→server stream hello.
+pub const UDP_HELLO_KIND_HELLO: u8 = 1;
+/// `kind` byte for the server→client ack, sent from the per-stream
+/// connected socket so the client learns the connected path is live.
+pub const UDP_HELLO_KIND_ACK: u8 = 2;
+/// Length of the per-test routing token carried in every hello/ack.
+pub const UDP_HELLO_TOKEN_LEN: usize = 16;
+/// How often the client re-sends an unacknowledged hello.
+pub const UDP_HELLO_RETRY_INTERVAL: Duration = Duration::from_millis(100);
+/// Total hello attempts before the handshake fails loudly (~5 s budget).
+pub const UDP_HELLO_MAX_ATTEMPTS: u32 = 50;
+
+/// Single-port UDP hello/ack packet (issue #63).
+///
+/// The client sends a hello per stream to the server's main port; the
+/// server answers with an ack from a freshly connected same-port socket.
+/// The token (server-generated, carried back in `TestAck.udp_token`) is
+/// what routes the hello to the right test — source address alone would
+/// break under NAT or multiple concurrent clients.
+///
+/// Wire layout, all multi-byte fields big-endian:
+/// ```text
+/// offset  size  field
+///   0      4    magic = b"\x00XFR"
+///   4      1    version = 1
+///   5      1    kind (1 = hello, 2 = ack)
+///   6      2    stream_index (u16)
+///   8     16    token
+/// total: 24 bytes, fixed
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UdpHelloPacket {
+    pub kind: u8,
+    pub stream_index: u16,
+    pub token: [u8; UDP_HELLO_TOKEN_LEN],
+}
+
+impl UdpHelloPacket {
+    /// Encode the packet into a fixed 24-byte buffer.
+    pub fn encode(&self) -> [u8; UDP_HELLO_SIZE] {
+        let mut buffer = [0u8; UDP_HELLO_SIZE];
+        buffer[0..4].copy_from_slice(&UDP_HELLO_MAGIC);
+        buffer[4] = UDP_HELLO_VERSION;
+        buffer[5] = self.kind;
+        buffer[6..8].copy_from_slice(&self.stream_index.to_be_bytes());
+        buffer[8..24].copy_from_slice(&self.token);
+        buffer
+    }
+
+    /// Decode a hello/ack packet. Returns `None` if length, magic,
+    /// version, or kind don't match the v1 schema — fixed-size like the
+    /// feedback packet, forward-compatible only via new `kind` values.
+    pub fn decode(buffer: &[u8]) -> Option<Self> {
+        if buffer.len() != UDP_HELLO_SIZE {
+            return None;
+        }
+        if buffer[0..4] != UDP_HELLO_MAGIC {
+            return None;
+        }
+        if buffer[4] != UDP_HELLO_VERSION {
+            return None;
+        }
+        let kind = buffer[5];
+        if !matches!(kind, UDP_HELLO_KIND_HELLO | UDP_HELLO_KIND_ACK) {
+            return None;
+        }
+        let stream_index = u16::from_be_bytes(buffer[6..8].try_into().ok()?);
+        let token = buffer[8..24].try_into().ok()?;
+        Some(Self {
+            kind,
+            stream_index,
+            token,
+        })
+    }
+}
+
+/// Hex-encode a routing token for the `TestAck.udp_token` wire field.
+pub fn encode_hello_token(token: &[u8; UDP_HELLO_TOKEN_LEN]) -> String {
+    token.iter().map(|b| format!("{:02x}", b)).collect()
+}
+
+/// Parse a `TestAck.udp_token` hex string back into raw token bytes.
+/// Returns `None` for anything that isn't exactly 32 hex digits.
+pub fn parse_hello_token(s: &str) -> Option<[u8; UDP_HELLO_TOKEN_LEN]> {
+    if s.len() != UDP_HELLO_TOKEN_LEN * 2 || !s.is_ascii() {
+        return None;
+    }
+    let mut token = [0u8; UDP_HELLO_TOKEN_LEN];
+    for (i, chunk) in s.as_bytes().chunks(2).enumerate() {
+        token[i] = u8::from_str_radix(std::str::from_utf8(chunk).ok()?, 16).ok()?;
+    }
+    Some(token)
+}
+
+/// Which lane a datagram on the shared server socket belongs to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SharedSocketLane {
+    /// Single-port UDP hello — divert to the hello dispatcher.
+    XfrHello,
+    /// QUIC — pass through to quinn untouched.
+    Quic,
+    /// Neither: shouldn't normally happen, since once a stream's
+    /// connected socket exists the kernel routes its data there and the
+    /// shared socket never sees it. Logged at debug and dropped.
+    XfrStray,
+}
+
+/// Classify a datagram arriving on the shared (QUIC + xfr hello) socket.
+///
+/// Order matters and matches the design for issue #63:
+/// 1. exact match on the single-port hello framing → xfr hello lane;
+/// 2. first byte with 0x80 set → QUIC long header (version-independent
+///    per RFC 8999);
+/// 3. first byte with 0x40 set → QUIC short header. Sound only because
+///    the server endpoint sets `grease_quic_bit(false)`: RFC 9287
+///    greasing is permission-based, so a server that doesn't advertise
+///    the grease transport parameter stops compliant peers from clearing
+///    the fixed bit toward it;
+/// 4. anything else → stray xfr lane.
+pub fn classify_shared_datagram(datagram: &[u8]) -> SharedSocketLane {
+    if datagram.len() == UDP_HELLO_SIZE && datagram[0..4] == UDP_HELLO_MAGIC {
+        return SharedSocketLane::XfrHello;
+    }
+    match datagram.first() {
+        Some(b) if b & 0x80 != 0 => SharedSocketLane::Quic,
+        Some(b) if b & 0x40 != 0 => SharedSocketLane::Quic,
+        _ => SharedSocketLane::XfrStray,
+    }
+}
+
+/// Client side of the single-port UDP stream handshake (issue #63).
+///
+/// Sends a hello datagram on the connected `socket` every
+/// [`UDP_HELLO_RETRY_INTERVAL`] until the server's ack arrives, up to
+/// [`UDP_HELLO_MAX_ATTEMPTS`]. Inbound datagrams are `peek`ed, not
+/// consumed: a matching ack is consumed and completes the handshake; a
+/// foreign hello-lane packet is consumed and dropped; anything else
+/// (test data in download mode, where the server starts sending as soon
+/// as the hello routes) is treated as an implicit ack and left queued
+/// for the data path so it isn't lost from the receiver's accounting.
+///
+/// The caller must not start sending data until this returns Ok — that
+/// ordering is what eliminates the race where data reaches the server's
+/// shared socket before the per-stream connected socket exists.
+pub async fn single_port_udp_handshake(
+    socket: &UdpSocket,
+    token: &[u8; UDP_HELLO_TOKEN_LEN],
+    stream_index: u16,
+) -> anyhow::Result<()> {
+    let hello = UdpHelloPacket {
+        kind: UDP_HELLO_KIND_HELLO,
+        stream_index,
+        token: *token,
+    }
+    .encode();
+    // Full-size buffer: Windows fails peek/recv with WSAEMSGSIZE when the
+    // buffer is smaller than the datagram, and download-mode data packets
+    // can arrive here.
+    let mut buf = [0u8; UDP_PAYLOAD_SIZE + 100];
+
+    for _ in 0..UDP_HELLO_MAX_ATTEMPTS {
+        socket.send(&hello).await?;
+        let retry_at = tokio::time::Instant::now() + UDP_HELLO_RETRY_INTERVAL;
+        loop {
+            let n = tokio::select! {
+                result = socket.peek(&mut buf) => result?,
+                _ = tokio::time::sleep_until(retry_at) => break,
+            };
+            if n == UDP_HELLO_SIZE && buf[0..4] == UDP_HELLO_MAGIC {
+                let matched = UdpHelloPacket::decode(&buf[..n]).is_some_and(|pkt| {
+                    pkt.kind == UDP_HELLO_KIND_ACK
+                        && pkt.token == *token
+                        && pkt.stream_index == stream_index
+                });
+                // Consume the hello-lane packet either way; only a full
+                // match completes the handshake.
+                let _ = socket.recv(&mut buf).await;
+                if matched {
+                    return Ok(());
+                }
+                continue;
+            }
+            // Non-hello-lane traffic from the server means our hello was
+            // already routed (data only flows after that). Leave it queued.
+            return Ok(());
+        }
+    }
+
+    Err(anyhow::anyhow!(
+        "single-port UDP handshake timed out for stream {}: no ack from the server \
+         after {} attempts over {:?}. The server's UDP port may be reachable while \
+         replies are filtered, or the server dropped the test.",
+        stream_index,
+        UDP_HELLO_MAX_ATTEMPTS,
+        UDP_HELLO_RETRY_INTERVAL * UDP_HELLO_MAX_ATTEMPTS
+    ))
+}
+
+/// Server-side ack responder for directions where no receive loop runs
+/// on the connected socket (download mode). The first ack from the
+/// dispatcher can be lost; the client's retried hellos then arrive on
+/// the connected socket (the kernel routes them past the shared
+/// wildcard), so someone must keep answering until one ack lands. Runs
+/// until `cancel` fires; idles on recv once the client stops retrying.
+pub async fn respond_single_port_hellos(
+    socket: Arc<UdpSocket>,
+    ack: [u8; UDP_HELLO_SIZE],
+    mut cancel: watch::Receiver<bool>,
+) {
+    let mut buf = [0u8; UDP_PAYLOAD_SIZE + 100];
+
+    let cancel_changed = async move {
+        loop {
+            if *cancel.borrow() {
+                return;
+            }
+            if cancel.changed().await.is_err() {
+                return;
+            }
+        }
+    };
+    tokio::pin!(cancel_changed);
+
+    loop {
+        tokio::select! {
+            result = socket.recv(&mut buf) => {
+                if let Ok(n) = result
+                    && let Some(pkt) = UdpHelloPacket::decode(&buf[..n])
+                    && pkt.kind == UDP_HELLO_KIND_HELLO
+                {
+                    let _ = socket.send(&ack).await;
+                }
+            }
+            _ = &mut cancel_changed => break,
+        }
+    }
+}
+
 /// UDP packet header
 /// [seq: u64][timestamp_us: u64][payload...]
 ///
@@ -505,12 +756,21 @@ async fn send_udp_unlimited(
 }
 
 /// Receive UDP data and track statistics
+///
+/// `single_port_ack` is `Some` only on the server side of a single-port
+/// UDP test (issue #63), where the socket is connected to the client:
+/// retried stream hellos arriving here (the kernel routes them past the
+/// shared wildcard once the connected socket exists) are answered with
+/// the precomputed ack instead of being counted, and feedback packets
+/// use `send()` rather than `send_to()` — macOS rejects `send_to` on a
+/// connected UDP socket with EISCONN.
 pub async fn receive_udp(
     socket: Arc<UdpSocket>,
     stats: Arc<StreamStats>,
     mut cancel: watch::Receiver<bool>,
     mut pause: watch::Receiver<bool>,
     feedback_enabled: bool,
+    single_port_ack: Option<[u8; UDP_HELLO_SIZE]>,
 ) -> anyhow::Result<(UdpStats, u64)> {
     let mut buffer = vec![0u8; UDP_PAYLOAD_SIZE + 100];
     let mut jitter_calc = JitterCalculator::new();
@@ -589,6 +849,22 @@ pub async fn receive_udp(
                         if is_feedback {
                             continue;
                         }
+                        // Single-port hello lane (issue #63): skipped from all
+                        // accounting on both ends for the same reasons as
+                        // feedback — a 24-byte hello/ack would otherwise decode
+                        // as a data header with a wild sequence number. On the
+                        // server (ack configured), a retried hello also gets
+                        // re-acked here in case the dispatcher's ack was lost.
+                        if n == UDP_HELLO_SIZE && buffer[0..4] == UDP_HELLO_MAGIC {
+                            if let Some(ack) = single_port_ack
+                                && UdpHelloPacket::decode(&buffer[..n])
+                                    .is_some_and(|pkt| pkt.kind == UDP_HELLO_KIND_HELLO)
+                                && let Err(e) = socket.send(&ack).await
+                            {
+                                debug!("single-port hello re-ack failed: {}", e);
+                            }
+                            continue;
+                        }
                         stats.add_bytes_received(n as u64);
 
                         if let Some(header) = UdpPacketHeader::decode(&buffer[..n]) {
@@ -642,16 +918,24 @@ pub async fn receive_udp(
                         packets_lost: snap.packets_lost,
                     };
                     let mut buf = [0u8; UDP_FEEDBACK_SIZE];
-                    if pkt.encode(&mut buf)
-                        && let Err(e) = socket.send_to(&buf, addr).await
-                    {
-                        // Non-fatal: ICMP port-unreachable from a
-                        // closed peer surfaces as ConnectionRefused
-                        // here. Log at debug; next tick retries.
-                        debug!(
-                            "UDP feedback send_to({}) failed: {}",
-                            addr, e
-                        );
+                    if pkt.encode(&mut buf) {
+                        // Connected single-port sockets must use send():
+                        // the address equals the connected peer anyway,
+                        // and macOS rejects send_to with EISCONN.
+                        let result = if single_port_ack.is_some() {
+                            socket.send(&buf).await
+                        } else {
+                            socket.send_to(&buf, addr).await
+                        };
+                        if let Err(e) = result {
+                            // Non-fatal: ICMP port-unreachable from a
+                            // closed peer surfaces as ConnectionRefused
+                            // here. Log at debug; next tick retries.
+                            debug!(
+                                "UDP feedback send to {} failed: {}",
+                                addr, e
+                            );
+                        }
                     }
                 }
             }
@@ -788,9 +1072,16 @@ pub async fn receive_udp_feedback_only(
 /// the server's own interface MTU is the reverse-path limit — that's a
 /// legitimate probe outcome, not an error, so it's logged at debug and
 /// the ack still goes out.
+///
+/// `single_port_ack` is `Some` when the probe runs in single-port mode
+/// (issue #63): the socket is connected, so replies use `send()` (macOS
+/// rejects `send_to` on connected sockets), and retried stream hellos
+/// that land here after the dispatcher's ack was lost get re-acked so
+/// the client's handshake can complete.
 pub async fn respond_mtu_probes(
     socket: Arc<UdpSocket>,
     mut cancel: watch::Receiver<bool>,
+    single_port_ack: Option<[u8; UDP_HELLO_SIZE]>,
 ) -> anyhow::Result<()> {
     use crate::probe::{PROBE_KIND_ACK, PROBE_KIND_ECHO, PROBE_KIND_PROBE, ProbePacket};
 
@@ -819,32 +1110,55 @@ pub async fn respond_mtu_probes(
                         continue;
                     }
                 };
+                if let Some(hello_ack) = single_port_ack
+                    && UdpHelloPacket::decode(&recv_buf[..n])
+                        .is_some_and(|pkt| pkt.kind == UDP_HELLO_KIND_HELLO)
+                {
+                    if let Err(e) = socket.send(&hello_ack).await {
+                        debug!("single-port hello re-ack failed during probe: {}", e);
+                    }
+                    continue;
+                }
                 let Some(pkt) = ProbePacket::decode(&recv_buf[..n]) else {
                     continue;
                 };
                 if pkt.kind != PROBE_KIND_PROBE {
                     continue;
                 }
+                // Connected single-port sockets must reply with send():
+                // `from` equals the connected peer, and macOS rejects
+                // send_to on a connected socket with EISCONN.
+                let connected = single_port_ack.is_some();
                 let ack = ProbePacket {
                     kind: PROBE_KIND_ACK,
                     seq: pkt.seq,
                     declared_size: pkt.declared_size,
                 };
-                if let Some(len) = ack.encode(&mut send_buf)
-                    && let Err(e) = socket.send_to(&send_buf[..len], from).await
-                {
-                    debug!("MTU probe ack send failed (seq {}): {}", pkt.seq, e);
+                if let Some(len) = ack.encode(&mut send_buf) {
+                    let result = if connected {
+                        socket.send(&send_buf[..len]).await
+                    } else {
+                        socket.send_to(&send_buf[..len], from).await
+                    };
+                    if let Err(e) = result {
+                        debug!("MTU probe ack send failed (seq {}): {}", pkt.seq, e);
+                    }
                 }
                 let echo = ProbePacket {
                     kind: PROBE_KIND_ECHO,
                     seq: pkt.seq,
                     declared_size: pkt.declared_size,
                 };
-                if let Some(len) = echo.encode(&mut send_buf)
-                    && let Err(e) = socket.send_to(&send_buf[..len], from).await
-                {
-                    // EMSGSIZE here is the reverse path speaking, not a bug.
-                    debug!("MTU probe echo send failed (seq {}, {}B): {}", pkt.seq, len, e);
+                if let Some(len) = echo.encode(&mut send_buf) {
+                    let result = if connected {
+                        socket.send(&send_buf[..len]).await
+                    } else {
+                        socket.send_to(&send_buf[..len], from).await
+                    };
+                    if let Err(e) = result {
+                        // EMSGSIZE here is the reverse path speaking, not a bug.
+                        debug!("MTU probe echo send failed (seq {}, {}B): {}", pkt.seq, len, e);
+                    }
                 }
             }
             _ = &mut cancel_changed => break,
@@ -1033,6 +1347,163 @@ mod tests {
             peak,
             "jitter_max must retain the prior peak, not track the current value"
         );
+    }
+
+    #[test]
+    fn hello_packet_roundtrip() {
+        let pkt = UdpHelloPacket {
+            kind: UDP_HELLO_KIND_HELLO,
+            stream_index: 17,
+            token: [0xAB; UDP_HELLO_TOKEN_LEN],
+        };
+        let buffer = pkt.encode();
+        assert_eq!(UdpHelloPacket::decode(&buffer), Some(pkt));
+
+        let ack = UdpHelloPacket {
+            kind: UDP_HELLO_KIND_ACK,
+            stream_index: 0,
+            token: [0; UDP_HELLO_TOKEN_LEN],
+        };
+        let buffer = ack.encode();
+        assert_eq!(UdpHelloPacket::decode(&buffer), Some(ack));
+    }
+
+    #[test]
+    fn hello_packet_rejects_foreign() {
+        let pkt = UdpHelloPacket {
+            kind: UDP_HELLO_KIND_HELLO,
+            stream_index: 1,
+            token: [7; UDP_HELLO_TOKEN_LEN],
+        };
+        let good = pkt.encode();
+
+        // Wrong magic
+        let mut bad = good;
+        bad[0..4].copy_from_slice(b"XFRF");
+        assert!(UdpHelloPacket::decode(&bad).is_none());
+
+        // Unknown version
+        let mut bad = good;
+        bad[4] = 2;
+        assert!(UdpHelloPacket::decode(&bad).is_none());
+
+        // Unknown kind
+        let mut bad = good;
+        bad[5] = 99;
+        assert!(UdpHelloPacket::decode(&bad).is_none());
+
+        // Wrong length, both directions — fixed-size framing
+        assert!(UdpHelloPacket::decode(&good[..UDP_HELLO_SIZE - 1]).is_none());
+        let mut oversize = [0u8; UDP_HELLO_SIZE + 1];
+        oversize[..UDP_HELLO_SIZE].copy_from_slice(&good);
+        assert!(UdpHelloPacket::decode(&oversize).is_none());
+    }
+
+    #[test]
+    fn hello_token_hex_roundtrip() {
+        let token: [u8; UDP_HELLO_TOKEN_LEN] = [
+            0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD,
+            0xEE, 0xFF,
+        ];
+        let hex = encode_hello_token(&token);
+        assert_eq!(hex, "00112233445566778899aabbccddeeff");
+        assert_eq!(parse_hello_token(&hex), Some(token));
+
+        assert!(parse_hello_token("").is_none());
+        assert!(parse_hello_token("0011").is_none()); // too short
+        assert!(parse_hello_token("zz112233445566778899aabbccddeeff").is_none()); // non-hex
+        assert!(parse_hello_token("00112233445566778899aabbccddeeff00").is_none()); // too long
+    }
+
+    #[test]
+    fn classify_shared_datagram_all_lanes() {
+        // 1. Exact hello framing → xfr hello lane.
+        let hello = UdpHelloPacket {
+            kind: UDP_HELLO_KIND_HELLO,
+            stream_index: 0,
+            token: [1; UDP_HELLO_TOKEN_LEN],
+        }
+        .encode();
+        assert_eq!(classify_shared_datagram(&hello), SharedSocketLane::XfrHello);
+
+        // 2. QUIC long header: 0x80 set (RFC 8999, version-independent).
+        let long_header = [0xC3u8, 0, 0, 0, 1];
+        assert_eq!(
+            classify_shared_datagram(&long_header),
+            SharedSocketLane::Quic
+        );
+
+        // 3. QUIC short header: 0x40 fixed bit set, 0x80 clear.
+        let short_header = [0x41u8, 9, 9, 9];
+        assert_eq!(
+            classify_shared_datagram(&short_header),
+            SharedSocketLane::Quic
+        );
+
+        // 4. Top two bits clear and not a hello → stray xfr lane. This is
+        // what a *greased* short header (fixed bit cleared, RFC 9287)
+        // would look like — it must never be possible toward this server
+        // because the endpoint sets grease_quic_bit(false), so routing it
+        // away from quinn is correct rather than lossy.
+        let greased_looking = [0x05u8, 1, 2, 3];
+        assert_eq!(
+            classify_shared_datagram(&greased_looking),
+            SharedSocketLane::XfrStray
+        );
+        assert_eq!(classify_shared_datagram(&[]), SharedSocketLane::XfrStray);
+
+        // Hello magic with the wrong length is not the hello lane (fixed
+        // size is part of the match), and its first byte is 0x00 → stray.
+        let truncated_hello = &hello[..UDP_HELLO_SIZE - 4];
+        assert_eq!(
+            classify_shared_datagram(truncated_hello),
+            SharedSocketLane::XfrStray
+        );
+    }
+
+    /// The client handshake must skip an ack carrying the wrong token or
+    /// stream index (token is the route key — a mismatched ack proves
+    /// nothing about our stream) and complete on the matching one.
+    #[tokio::test]
+    async fn handshake_ignores_mismatched_ack() {
+        let server = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let server_addr = server.local_addr().unwrap();
+        let client = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        client.connect(server_addr).await.unwrap();
+
+        let token = [0x42u8; UDP_HELLO_TOKEN_LEN];
+        let responder = tokio::spawn(async move {
+            let mut buf = [0u8; 64];
+            let (_, from) = server.recv_from(&mut buf).await.unwrap();
+            // Wrong token first, then wrong stream, then the real ack.
+            let wrong_token = UdpHelloPacket {
+                kind: UDP_HELLO_KIND_ACK,
+                stream_index: 3,
+                token: [0xFFu8; UDP_HELLO_TOKEN_LEN],
+            };
+            let wrong_stream = UdpHelloPacket {
+                kind: UDP_HELLO_KIND_ACK,
+                stream_index: 4,
+                token,
+            };
+            let good = UdpHelloPacket {
+                kind: UDP_HELLO_KIND_ACK,
+                stream_index: 3,
+                token,
+            };
+            for pkt in [wrong_token, wrong_stream, good] {
+                server.send_to(&pkt.encode(), from).await.unwrap();
+            }
+        });
+
+        tokio::time::timeout(
+            Duration::from_secs(5),
+            single_port_udp_handshake(&client, &token, 3),
+        )
+        .await
+        .expect("handshake should not hit the retry budget")
+        .expect("handshake should succeed on the matching ack");
+        responder.await.unwrap();
     }
 
     #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2507,3 +2507,292 @@ async fn test_serve_bind_ipv4_udp() {
         "UDP to bound 127.0.0.1 should succeed"
     );
 }
+
+// ============================================================================
+// Single-port UDP (issue #63)
+// ============================================================================
+
+/// Raw control-channel driver for protocol-shape assertions that the
+/// `Client` API hides (capability negotiation, TestAck contents).
+struct RawControl {
+    reader: tokio::io::BufReader<tokio::net::tcp::OwnedReadHalf>,
+    writer: tokio::net::tcp::OwnedWriteHalf,
+    server_capabilities: Vec<String>,
+}
+
+impl RawControl {
+    async fn connect(port: u16, capabilities: Vec<String>) -> Self {
+        use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
+        use xfr::protocol::ControlMessage;
+
+        let stream = tokio::net::TcpStream::connect(("127.0.0.1", port))
+            .await
+            .expect("control connect");
+        let (reader, mut writer) = stream.into_split();
+        let mut reader = tokio::io::BufReader::new(reader);
+
+        let hello = ControlMessage::Hello {
+            version: "1.1".to_string(),
+            client: Some("xfr-test".to_string()),
+            server: None,
+            capabilities: Some(capabilities),
+            auth: None,
+        };
+        writer
+            .write_all(format!("{}\n", hello.serialize().unwrap()).as_bytes())
+            .await
+            .expect("send hello");
+
+        let mut line = String::new();
+        reader
+            .read_line(&mut line)
+            .await
+            .expect("read server hello");
+        let server_capabilities = match ControlMessage::deserialize(line.trim()).unwrap() {
+            ControlMessage::Hello { capabilities, .. } => capabilities.unwrap_or_default(),
+            other => panic!("expected server hello, got {:?}", other),
+        };
+
+        Self {
+            reader,
+            writer,
+            server_capabilities,
+        }
+    }
+
+    /// Send a UDP TestStart and return the TestAck's (data_ports, udp_token).
+    async fn start_udp_test(&mut self, duration_secs: u32) -> (Vec<u16>, Option<String>) {
+        use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
+        use xfr::protocol::ControlMessage;
+
+        let start = ControlMessage::TestStart {
+            id: "raw-test".to_string(),
+            protocol: Protocol::Udp,
+            streams: 1,
+            duration_secs,
+            direction: Direction::Upload,
+            bitrate: Some(10_000_000),
+            congestion: None,
+            mptcp: false,
+            dscp: None,
+            window_size: None,
+            zerocopy: false,
+            mtu_probe: false,
+        };
+        self.writer
+            .write_all(format!("{}\n", start.serialize().unwrap()).as_bytes())
+            .await
+            .expect("send test_start");
+
+        let mut line = String::new();
+        self.reader.read_line(&mut line).await.expect("read ack");
+        match ControlMessage::deserialize(line.trim()).unwrap() {
+            ControlMessage::TestAck {
+                data_ports,
+                udp_token,
+                ..
+            } => (data_ports, udp_token),
+            other => panic!("expected test_ack, got {:?}", other),
+        }
+    }
+
+    /// Drain Interval messages until the final Result arrives.
+    async fn wait_for_result(&mut self) -> xfr::protocol::TestResult {
+        use tokio::io::AsyncBufReadExt;
+        use xfr::protocol::ControlMessage;
+
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(20);
+        loop {
+            let mut line = String::new();
+            let n = tokio::time::timeout_at(deadline, self.reader.read_line(&mut line))
+                .await
+                .expect("result before deadline")
+                .expect("control read");
+            assert!(n > 0, "connection closed before Result");
+            match ControlMessage::deserialize(line.trim()).unwrap() {
+                ControlMessage::Result(result) => return result,
+                _ => continue,
+            }
+        }
+    }
+}
+
+/// The TestAck shape must match what was negotiated: a server that
+/// advertises single_port_udp_v1 (self-test passed) answers a capable
+/// client with no data ports plus a routing token; a server that
+/// doesn't (platforms where the kernel routing check fails) must keep
+/// allocating per-stream ports. Self-validating on either platform.
+#[tokio::test]
+async fn test_single_port_udp_testack_shape() {
+    let port = get_test_port();
+    let _server = start_test_server(port).await;
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    let mut control = RawControl::connect(port, xfr::protocol::supported_capabilities()).await;
+    let server_single_port = control
+        .server_capabilities
+        .iter()
+        .any(|c| c == xfr::protocol::SINGLE_PORT_UDP_CAPABILITY);
+    let (data_ports, udp_token) = control.start_udp_test(1).await;
+
+    if server_single_port {
+        assert!(
+            data_ports.is_empty(),
+            "single-port UDP must not allocate per-stream ports, got {:?}",
+            data_ports
+        );
+        let token = udp_token.expect("single-port TestAck must carry a routing token");
+        assert!(
+            xfr::udp::parse_hello_token(&token).is_some(),
+            "token must be 32 hex digits, got {:?}",
+            token
+        );
+    } else {
+        assert!(
+            !data_ports.is_empty(),
+            "without the capability the server must allocate legacy ports"
+        );
+        assert!(udp_token.is_none());
+    }
+
+    // Let the 1s test run out so the server tears down cleanly.
+    let _ = control.wait_for_result().await;
+}
+
+/// Legacy fallback: a client that doesn't advertise single_port_udp_v1
+/// must get per-stream ephemeral ports and a fully working legacy data
+/// plane, even on a server with single-port enabled.
+#[tokio::test]
+async fn test_legacy_udp_fallback_allocates_ports() {
+    let port = get_test_port();
+    let _server = start_test_server(port).await;
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    let legacy_caps: Vec<String> = ["tcp", "udp", "multistream"]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+    let mut control = RawControl::connect(port, legacy_caps).await;
+    let (data_ports, udp_token) = control.start_udp_test(2).await;
+
+    assert_eq!(data_ports.len(), 1, "legacy client must get a data port");
+    assert!(
+        udp_token.is_none(),
+        "legacy negotiation must not carry a token"
+    );
+
+    // Drive the legacy data plane for real: send sequenced packets to the
+    // allocated ephemeral port and verify the server counted them.
+    let socket = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+    socket.connect(("127.0.0.1", data_ports[0])).await.unwrap();
+    let mut packet = vec![0u8; 1400];
+    for seq in 0..200u64 {
+        let header = xfr::udp::UdpPacketHeader {
+            sequence: seq,
+            timestamp_us: seq * 1000,
+        };
+        assert!(header.encode(&mut packet));
+        socket.send(&packet).await.unwrap();
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+
+    let result = control.wait_for_result().await;
+    assert!(
+        result.bytes_total > 0,
+        "server must have counted legacy UDP data, got {} bytes",
+        result.bytes_total
+    );
+}
+
+/// QUIC and single-port UDP share the server's main UDP port (the tee on
+/// quinn's socket). Run both protocols against the same server instance
+/// at the same time to prove neither lane disturbs the other.
+#[tokio::test]
+async fn test_quic_and_single_port_udp_coexist() {
+    let port = get_test_port();
+    let _server = start_test_server(port).await;
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    let udp_config = ClientConfig {
+        host: "127.0.0.1".to_string(),
+        port,
+        protocol: Protocol::Udp,
+        streams: 2,
+        duration: Duration::from_secs(2),
+        direction: Direction::Upload,
+        bitrate: Some(50_000_000),
+        random_payload: false,
+        zerocopy: ZerocopyMode::Off,
+        ..Default::default()
+    };
+    let quic_config = ClientConfig {
+        host: "127.0.0.1".to_string(),
+        port,
+        protocol: Protocol::Quic,
+        streams: 1,
+        duration: Duration::from_secs(2),
+        direction: Direction::Upload,
+        random_payload: false,
+        zerocopy: ZerocopyMode::Off,
+        ..Default::default()
+    };
+
+    let udp_client = Client::new(udp_config);
+    let quic_client = Client::new(quic_config);
+    let (udp_result, quic_result) = tokio::join!(
+        timeout(Duration::from_secs(20), udp_client.run(None)),
+        timeout(Duration::from_secs(20), quic_client.run(None)),
+    );
+
+    let udp_result = udp_result
+        .expect("UDP test should complete")
+        .expect("UDP test should succeed alongside QUIC");
+    assert!(udp_result.duration_ms > 0);
+    assert_eq!(udp_result.streams.len(), 2);
+
+    let quic_result = quic_result
+        .expect("QUIC test should complete")
+        .expect("QUIC test should succeed with the tee in place");
+    assert!(
+        quic_result.bytes_total > 0,
+        "QUIC must still move data through the shared socket"
+    );
+}
+
+/// Single-port UDP download: server-sent data must flow over the
+/// connected same-port socket and the client's receiver-truth overlay
+/// (issue #81) must still populate loss/jitter stats.
+#[tokio::test]
+async fn test_single_port_udp_download_stats() {
+    let port = get_test_port();
+    let _server = start_test_server(port).await;
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    let config = ClientConfig {
+        host: "127.0.0.1".to_string(),
+        port,
+        protocol: Protocol::Udp,
+        streams: 1,
+        duration: Duration::from_secs(2),
+        direction: Direction::Download,
+        bitrate: Some(50_000_000),
+        random_payload: false,
+        zerocopy: ZerocopyMode::Off,
+        ..Default::default()
+    };
+
+    let client = Client::new(config);
+    let result = timeout(Duration::from_secs(20), client.run(None))
+        .await
+        .expect("download should complete")
+        .expect("download should succeed");
+    assert!(result.duration_ms > 0);
+    assert!(
+        result.bytes_total > 0,
+        "client must have received data over the connected socket"
+    );
+    assert!(
+        result.udp_stats.is_some(),
+        "download summary must carry receiver-side loss/jitter stats"
+    );
+}


### PR DESCRIPTION
Closes #63. Implements the design from [the design comment](https://github.com/lance0/xfr/issues/63#issuecomment-4683039560).

All UDP test traffic now flows through the server's main port. Mid-test with `-P 4`, the server's socket table is the whole story: one wildcard `*:5201` (QUIC + hello lane) plus one **connected socket per stream, all bound to 5201** — zero ephemeral data ports. Firewalls need exactly one UDP port open.

**How it works** (per the issue's design comment):
- Client gets a 16-byte random token in `TestAck` (wire-additive `udp_token`), sends a 24-byte hello per stream to the main port, and starts data only after the per-stream ack — eliminating any data-before-routing race.
- The server's hello dispatcher validates token → control-IP → stream bounds, creates a connected same-port socket (`SO_REUSEPORT`), and acks **from** it. The kernel routes the established 4-tuple to the connected socket from then on; line-rate data never touches the shared socket. Lost acks recover via retried hellos, which arrive on the connected socket and get re-acked from whichever task owns it (receive loop, download responder, or probe responder).
- QUIC coexistence: the quinn endpoint's socket is wrapped in a tee (`Endpoint::new_with_abstract_socket`, delegating to the runtime's quinn-udp socket so GSO/GRO/ECN are untouched). The first-byte classifier (00-space xfr magic / `0x80` long header / `0x40` short header) is sound because the server now sets `EndpointConfig::grease_quic_bit(false)`. `--no-quic` servers get the same feature via a plain shared socket.
- `single_port_udp_v1` is advertised only when a startup self-test proves the kernel's connected-socket precedence (two checks: connected socket wins its 4-tuple, *and* an unrelated source still reaches the wildcard). Failed self-test, non-unix, or an old peer → legacy ephemeral ports, unchanged. Single-port is the default when both sides advertise.

**Token note:** hellos are authenticated by a per-test CSPRNG token + control-IP match, which incidentally implements data-plane authentication for UDP (a roadmap security item) — stray or spoofed hellos can't attach sockets to someone else's test.

**Verification:** 294 tests green (the existing UDP upload/download/bidir/multi-stream/probe integration tests now exercise the single-port path by default on Linux, plus new coexistence/fallback/shape tests); socket-table inspection during a live 4-stream run shows only main-port sockets; QUIC at 7.67 Gbps against the same server instance; `--probe-mtu` works through the new plane.

**Follow-ups noted:** client-side `grease_quic_bit(false)` hardening (optional — the client socket never demuxes QUIC), Windows fails closed to legacy ports (no `SO_REUSEPORT`), GRO-coalesced hellos classify as stray (unreachable at the 100ms retry cadence).