### PR TITLE
feature: make Settings → Test "Apply & Restart" actually restart the test

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1527,7 +1527,7 @@ async fn run_client_tui(
 
 async fn run_tui_loop(
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
-    config: ClientConfig,
+    mut config: ClientConfig,
     timestamp_format: TimestampFormat,
     mut prefs: xfr::prefs::Prefs,
 ) -> Result<(Option<xfr::protocol::TestResult>, xfr::prefs::Prefs, bool)> {
@@ -1554,7 +1554,7 @@ async fn run_tui_loop(
     // Track if we've received the update check result
     let mut update_check_done = false;
 
-    let client = Arc::new(Client::new(config));
+    let mut client = Arc::new(Client::new(config.clone()));
     let (progress_tx, mut progress_rx) = mpsc::channel::<TestProgress>(100);
 
     // Create a macro to spawn the test so it can be reused on restart
@@ -1657,12 +1657,31 @@ async fn run_tui_loop(
                             let action = app.settings.on_enter();
                             match action {
                                 SettingsAction::Restart => {
-                                    // Cancel current test and signal restart
+                                    // Cancel the in-flight test, rebuild the
+                                    // client with the freshly chosen params,
+                                    // and restart the run loop.
                                     let _ = client.cancel();
                                     prefs.theme = Some(app.theme_name().to_string());
-                                    // TODO: Return restart signal with new params
-                                    // For now, just close - restart requires refactoring
-                                    app.log("Settings changed. Restart not yet implemented.");
+
+                                    config.streams = app.settings.streams;
+                                    config.protocol = app.settings.protocol;
+                                    config.duration =
+                                        Duration::from_secs(app.settings.duration_secs);
+                                    config.direction = app.settings.direction;
+                                    config.bitrate = app.settings.bitrate;
+
+                                    client = Arc::new(Client::new(config.clone()));
+
+                                    app.apply_test_params(
+                                        config.protocol,
+                                        config.direction,
+                                        config.streams,
+                                        config.duration,
+                                        config.bitrate,
+                                    );
+                                    app.reset();
+                                    cancel_deadline = None;
+                                    continue 'test_restart_loop;
                                 }
                                 SettingsAction::Close => {}
                                 SettingsAction::None => {}
@@ -1819,7 +1838,32 @@ async fn run_tui_loop(
                                             app.settings.switch_tab();
                                         }
                                         KeyCode::Enter => {
-                                            let _ = app.settings.on_enter();
+                                            let action = app.settings.on_enter();
+                                            if let SettingsAction::Restart = action {
+                                                // Rebuild the client with the
+                                                // newly chosen params and restart.
+                                                prefs.theme = Some(app.theme_name().to_string());
+
+                                                config.streams = app.settings.streams;
+                                                config.protocol = app.settings.protocol;
+                                                config.duration =
+                                                    Duration::from_secs(app.settings.duration_secs);
+                                                config.direction = app.settings.direction;
+                                                config.bitrate = app.settings.bitrate;
+
+                                                client = Arc::new(Client::new(config.clone()));
+
+                                                app.apply_test_params(
+                                                    config.protocol,
+                                                    config.direction,
+                                                    config.streams,
+                                                    config.duration,
+                                                    config.bitrate,
+                                                );
+                                                app.reset();
+                                                cancel_deadline = None;
+                                                continue 'test_restart_loop;
+                                            }
                                         }
                                         _ => {}
                                     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1555,335 +1555,355 @@ async fn run_tui_loop(
     let mut update_check_done = false;
 
     let client = Arc::new(Client::new(config));
-    let client_for_task = client.clone();
     let (progress_tx, mut progress_rx) = mpsc::channel::<TestProgress>(100);
 
-    // Start the test
-    let test_handle = tokio::spawn(async move { client_for_task.run(Some(progress_tx)).await });
-
-    app.on_connected();
+    // Create a macro to spawn the test so it can be reused on restart
+    macro_rules! spawn_test {
+        () => {{
+            let client_for_task = client.clone();
+            let progress_tx = progress_tx.clone();
+            tokio::spawn(async move { client_for_task.run(Some(progress_tx)).await })
+        }};
+    }
 
     // Track cancel state: when user presses 'q' or Ctrl+C during a running test,
     // we cancel and wait briefly for the server Result before exiting.
     let mut cancel_deadline: Option<std::time::Instant> = None;
 
-    loop {
-        // If we're waiting for cancel result and deadline expired, exit now
-        if let Some(deadline) = cancel_deadline
-            && deadline.elapsed() > Duration::ZERO
-        {
-            return Ok((app.result, prefs, print_json_on_exit));
-        }
+    'test_restart_loop: loop {
+        let test_handle = spawn_test!();
 
-        // Check for update result if not already received
-        if !update_check_done {
-            match update_rx.try_recv() {
-                Ok(Some(version)) => {
-                    app.update_available = Some(version);
-                    update_check_done = true;
-                }
-                Ok(None) => {
-                    // No update available
-                    update_check_done = true;
-                }
-                Err(std::sync::mpsc::TryRecvError::Empty) => {
-                    // Still checking, will try again next loop
-                }
-                Err(std::sync::mpsc::TryRecvError::Disconnected) => {
-                    // Channel closed, stop checking
-                    update_check_done = true;
+        app.on_connected();
+
+        loop {
+            // If we're waiting for cancel result and deadline expired, exit now
+            if let Some(deadline) = cancel_deadline
+                && deadline.elapsed() > Duration::ZERO
+            {
+                return Ok((app.result, prefs, print_json_on_exit));
+            }
+
+            // Check for update result if not already received
+            if !update_check_done {
+                match update_rx.try_recv() {
+                    Ok(Some(version)) => {
+                        app.update_available = Some(version);
+                        update_check_done = true;
+                    }
+                    Ok(None) => {
+                        // No update available
+                        update_check_done = true;
+                    }
+                    Err(std::sync::mpsc::TryRecvError::Empty) => {
+                        // Still checking, will try again next loop
+                    }
+                    Err(std::sync::mpsc::TryRecvError::Disconnected) => {
+                        // Channel closed, stop checking
+                        update_check_done = true;
+                    }
                 }
             }
-        }
 
-        // Refresh the wall-clock-driven parts of app state (elapsed counter) so
-        // the UI stays live even when the server's Interval progress messages
-        // are delayed by packet loss. Fixes issue #62.
-        app.tick();
+            // Refresh the wall-clock-driven parts of app state (elapsed counter) so
+            // the UI stays live even when the server's Interval progress messages
+            // are delayed by packet loss. Fixes issue #62.
+            app.tick();
 
-        // Capture the server's advertised version once it shows up. The
-        // ServerHello races the TUI loop start; we poll rather than add a new
-        // channel since this is a one-time one-line copy.
-        if app.server_version.is_none()
-            && let Some(v) = client.server_version()
-        {
-            // Route through `set_server_version` so the string is sanitized —
-            // it comes from the peer and lands in the terminal.
-            app.set_server_version(v);
-        }
+            // Capture the server's advertised version once it shows up. The
+            // ServerHello races the TUI loop start; we poll rather than add a new
+            // channel since this is a one-time one-line copy.
+            if app.server_version.is_none()
+                && let Some(v) = client.server_version()
+            {
+                // Route through `set_server_version` so the string is sanitized —
+                // it comes from the peer and lands in the terminal.
+                app.set_server_version(v);
+            }
 
-        // Draw UI
-        terminal.draw(|f| draw(f, &app))?;
+            // Draw UI
+            terminal.draw(|f| draw(f, &app))?;
 
-        // Handle events with timeout
-        if event::poll(Duration::from_millis(50))?
-            && let Event::Key(key) = event::read()?
-            && key.kind == KeyEventKind::Press
-        {
-            // Settings modal takes priority when visible
-            if app.settings.visible {
-                match key.code {
-                    KeyCode::Esc | KeyCode::Char('s') => {
-                        app.settings.close();
-                    }
-                    KeyCode::Up | KeyCode::Char('k') => {
-                        app.settings.move_up();
-                    }
-                    KeyCode::Down | KeyCode::Char('j') => {
-                        app.settings.move_down();
-                    }
-                    KeyCode::Left | KeyCode::Char('h') => {
-                        app.settings.value_prev();
-                        // Apply theme change immediately
-                        app.set_theme_index(app.settings.theme_index);
-                    }
-                    KeyCode::Right | KeyCode::Char('l') => {
-                        app.settings.value_next();
-                        // Apply theme change immediately
-                        app.set_theme_index(app.settings.theme_index);
-                    }
-                    KeyCode::Tab => {
-                        app.settings.switch_tab();
-                    }
-                    KeyCode::Enter => {
-                        let action = app.settings.on_enter();
-                        match action {
-                            SettingsAction::Restart => {
-                                // Cancel current test and signal restart
-                                let _ = client.cancel();
-                                prefs.theme = Some(app.theme_name().to_string());
-                                // TODO: Return restart signal with new params
-                                // For now, just close - restart requires refactoring
-                                app.log("Settings changed. Restart not yet implemented.");
-                            }
-                            SettingsAction::Close => {}
-                            SettingsAction::None => {}
+            // Handle events with timeout
+            if event::poll(Duration::from_millis(50))?
+                && let Event::Key(key) = event::read()?
+                && key.kind == KeyEventKind::Press
+            {
+                // Settings modal takes priority when visible
+                if app.settings.visible {
+                    match key.code {
+                        KeyCode::Esc | KeyCode::Char('s') => {
+                            app.settings.close();
                         }
-                    }
-                    _ => {}
-                }
-                continue;
-            }
-
-            // Ctrl+C or 'q': cancel and wait for server Result
-            let is_quit = key.code == KeyCode::Char('q')
-                || (key.code == KeyCode::Char('c')
-                    && key.modifiers.contains(KeyModifiers::CONTROL));
-            if is_quit {
-                if app.state == AppState::Completed || cancel_deadline.is_some() {
-                    // Already completed or already cancelling — exit immediately
-                    prefs.theme = Some(app.theme_name().to_string());
-                    return Ok((app.result, prefs, print_json_on_exit));
-                }
-                let _ = client.cancel();
-                cancel_deadline = Some(std::time::Instant::now() + Duration::from_secs(3));
-                app.log("Cancelling, waiting for summary...");
-                continue;
-            }
-
-            match key.code {
-                KeyCode::Char('p') => {
-                    match client.pause() {
-                        PauseResult::Applied => {
-                            app.toggle_pause();
+                        KeyCode::Up | KeyCode::Char('k') => {
+                            app.settings.move_up();
                         }
-                        PauseResult::Unsupported => {
-                            // UI-only: server doesn't support pause/resume
-                            match app.state {
-                                AppState::Running => {
-                                    app.state = AppState::Paused;
-                                    app.log(
-                                        "Display paused (server does not support pause/resume)",
-                                    );
+                        KeyCode::Down | KeyCode::Char('j') => {
+                            app.settings.move_down();
+                        }
+                        KeyCode::Left | KeyCode::Char('h') => {
+                            app.settings.value_prev();
+                            // Apply theme change immediately
+                            app.set_theme_index(app.settings.theme_index);
+                        }
+                        KeyCode::Right | KeyCode::Char('l') => {
+                            app.settings.value_next();
+                            // Apply theme change immediately
+                            app.set_theme_index(app.settings.theme_index);
+                        }
+                        KeyCode::Tab => {
+                            app.settings.switch_tab();
+                        }
+                        KeyCode::Enter => {
+                            let action = app.settings.on_enter();
+                            match action {
+                                SettingsAction::Restart => {
+                                    // Cancel current test and signal restart
+                                    let _ = client.cancel();
+                                    prefs.theme = Some(app.theme_name().to_string());
+                                    // TODO: Return restart signal with new params
+                                    // For now, just close - restart requires refactoring
+                                    app.log("Settings changed. Restart not yet implemented.");
                                 }
-                                AppState::Paused => {
-                                    app.state = AppState::Running;
-                                    app.log(
-                                        "Display resumed (server does not support pause/resume)",
-                                    );
-                                }
-                                _ => {}
+                                SettingsAction::Close => {}
+                                SettingsAction::None => {}
                             }
                         }
-                        PauseResult::NotReady => {
-                            // Test not running yet or already finished — ignore
-                        }
+                        _ => {}
                     }
+                    continue;
                 }
-                KeyCode::Char('t') => {
-                    app.cycle_theme();
-                }
-                KeyCode::Char('s') => {
-                    app.settings.toggle();
-                }
-                KeyCode::Char('?') | KeyCode::F(1) => {
-                    app.toggle_help();
-                }
-                KeyCode::Char('d') => {
-                    app.toggle_streams();
-                }
-                KeyCode::Esc if app.show_help => {
-                    app.show_help = false;
-                }
-                KeyCode::Char('j') if app.result.is_some() => {
-                    // Set flag to print JSON after TUI closes
-                    print_json_on_exit = true;
-                    app.log("JSON output queued for display on exit.");
-                }
-                KeyCode::Char('u') if app.update_available.is_some() => {
-                    // Dismiss update notification
-                    app.update_available = None;
-                }
-                _ => {}
-            }
-        }
 
-        // Check for progress updates
-        while let Ok(progress) = progress_rx.try_recv() {
-            app.on_progress(progress);
-        }
-
-        // Check if test completed
-        if test_handle.is_finished() {
-            match test_handle.await? {
-                Ok(result) => {
-                    app.on_result(result);
-
-                    // If we were waiting for cancel to complete, exit now with result
-                    if cancel_deadline.is_some() {
+                // Ctrl+C or 'q': cancel and wait for server Result
+                let is_quit = key.code == KeyCode::Char('q')
+                    || (key.code == KeyCode::Char('c')
+                        && key.modifiers.contains(KeyModifiers::CONTROL));
+                if is_quit {
+                    if app.state == AppState::Completed || cancel_deadline.is_some() {
+                        // Already completed or already cancelling — exit immediately
                         prefs.theme = Some(app.theme_name().to_string());
                         return Ok((app.result, prefs, print_json_on_exit));
                     }
+                    let _ = client.cancel();
+                    cancel_deadline = Some(std::time::Instant::now() + Duration::from_secs(3));
+                    app.log("Cancelling, waiting for summary...");
+                    continue;
+                }
 
-                    // Show final result for a moment
-                    terminal.draw(|f| draw(f, &app))?;
-
-                    // Wait for quit
-                    loop {
-                        // Check for update result if not already received
-                        if !update_check_done {
-                            match update_rx.try_recv() {
-                                Ok(Some(version)) => {
-                                    app.update_available = Some(version);
-                                    update_check_done = true;
-                                }
-                                Ok(None) => update_check_done = true,
-                                Err(std::sync::mpsc::TryRecvError::Empty) => {}
-                                Err(std::sync::mpsc::TryRecvError::Disconnected) => {
-                                    update_check_done = true;
-                                }
+                match key.code {
+                    KeyCode::Char('p') => {
+                        match client.pause() {
+                            PauseResult::Applied => {
+                                app.toggle_pause();
                             }
-                        }
-
-                        terminal.draw(|f| draw(f, &app))?;
-
-                        if event::poll(Duration::from_millis(100))?
-                            && let Event::Key(key) = event::read()?
-                            && key.kind == KeyEventKind::Press
-                        {
-                            // Settings modal handling
-                            if app.settings.visible {
-                                match key.code {
-                                    KeyCode::Esc | KeyCode::Char('s') => {
-                                        app.settings.close();
+                            PauseResult::Unsupported => {
+                                // UI-only: server doesn't support pause/resume
+                                match app.state {
+                                    AppState::Running => {
+                                        app.state = AppState::Paused;
+                                        app.log(
+                                            "Display paused (server does not support pause/resume)",
+                                        );
                                     }
-                                    KeyCode::Up | KeyCode::Char('k') => {
-                                        app.settings.move_up();
-                                    }
-                                    KeyCode::Down | KeyCode::Char('j') => {
-                                        app.settings.move_down();
-                                    }
-                                    KeyCode::Left | KeyCode::Char('h') => {
-                                        app.settings.value_prev();
-                                        app.set_theme_index(app.settings.theme_index);
-                                    }
-                                    KeyCode::Right | KeyCode::Char('l') => {
-                                        app.settings.value_next();
-                                        app.set_theme_index(app.settings.theme_index);
-                                    }
-                                    KeyCode::Tab => {
-                                        app.settings.switch_tab();
-                                    }
-                                    KeyCode::Enter => {
-                                        let _ = app.settings.on_enter();
+                                    AppState::Paused => {
+                                        app.state = AppState::Running;
+                                        app.log(
+                                        "Display resumed (server does not support pause/resume)",
+                                    );
                                     }
                                     _ => {}
                                 }
-                                continue;
                             }
-
-                            // Ctrl+C in completed state: exit
-                            if key.code == KeyCode::Char('c')
-                                && key.modifiers.contains(KeyModifiers::CONTROL)
-                            {
-                                prefs.theme = Some(app.theme_name().to_string());
-                                return Ok((app.result, prefs, print_json_on_exit));
-                            }
-
-                            match key.code {
-                                KeyCode::Char('q') => {
-                                    prefs.theme = Some(app.theme_name().to_string());
-                                    return Ok((app.result, prefs, print_json_on_exit));
-                                }
-                                KeyCode::Esc => {
-                                    if app.show_help {
-                                        app.show_help = false;
-                                    } else {
-                                        prefs.theme = Some(app.theme_name().to_string());
-                                        return Ok((app.result, prefs, print_json_on_exit));
-                                    }
-                                }
-                                KeyCode::Char('t') => {
-                                    app.cycle_theme();
-                                }
-                                KeyCode::Char('s') => {
-                                    app.settings.toggle();
-                                }
-                                KeyCode::Char('?') | KeyCode::F(1) => {
-                                    app.toggle_help();
-                                }
-                                KeyCode::Char('d') => {
-                                    app.toggle_streams();
-                                }
-                                KeyCode::Char('j') => {
-                                    print_json_on_exit = true;
-                                    app.log("JSON output queued for display on exit.");
-                                }
-                                KeyCode::Char('u') if app.update_available.is_some() => {
-                                    app.update_available = None;
-                                }
-                                _ => {}
+                            PauseResult::NotReady => {
+                                // Test not running yet or already finished — ignore
                             }
                         }
                     }
-                }
-                Err(e) => {
-                    // If we were waiting for cancel to complete, just exit
-                    if cancel_deadline.is_some() {
-                        prefs.theme = Some(app.theme_name().to_string());
-                        return Ok((app.result, prefs, print_json_on_exit));
+                    KeyCode::Char('t') => {
+                        app.cycle_theme();
                     }
+                    KeyCode::Char('s') => {
+                        app.settings.toggle();
+                    }
+                    KeyCode::Char('?') | KeyCode::F(1) => {
+                        app.toggle_help();
+                    }
+                    KeyCode::Char('d') => {
+                        app.toggle_streams();
+                    }
+                    KeyCode::Esc if app.show_help => {
+                        app.show_help = false;
+                    }
+                    KeyCode::Char('j') if app.result.is_some() => {
+                        // Set flag to print JSON after TUI closes
+                        print_json_on_exit = true;
+                        app.log("JSON output queued for display on exit.");
+                    }
+                    KeyCode::Char('u') if app.update_available.is_some() => {
+                        // Dismiss update notification
+                        app.update_available = None;
+                    }
+                    KeyCode::Char('r') => {
+                        // 'r' key during running test: cancel and restart
+                        let _ = client.cancel();
+                        app.reset();
+                        continue 'test_restart_loop;
+                    }
+                    _ => {}
+                }
+            }
 
-                    app.on_error(e.to_string());
-                    terminal.draw(|f| draw(f, &app))?;
+            // Check for progress updates
+            while let Ok(progress) = progress_rx.try_recv() {
+                app.on_progress(progress);
+            }
 
-                    // Wait for quit
-                    loop {
-                        if event::poll(Duration::from_millis(100))?
-                            && let Event::Key(key) = event::read()?
-                            && key.kind == KeyEventKind::Press
-                            && (key.code == KeyCode::Char('q')
-                                || (key.code == KeyCode::Char('c')
-                                    && key.modifiers.contains(KeyModifiers::CONTROL)))
-                        {
+            // Check if test completed
+            if test_handle.is_finished() {
+                match test_handle.await? {
+                    Ok(result) => {
+                        app.on_result(result);
+
+                        // If we were waiting for cancel to complete, exit now with result
+                        if cancel_deadline.is_some() {
                             prefs.theme = Some(app.theme_name().to_string());
-                            return Err(anyhow::anyhow!(app.error.unwrap_or_default()));
+                            return Ok((app.result, prefs, print_json_on_exit));
+                        }
+
+                        // Show final result for a moment
+                        terminal.draw(|f| draw(f, &app))?;
+
+                        // Wait for quit or restart command
+                        loop {
+                            // Check for update result if not already received
+                            if !update_check_done {
+                                match update_rx.try_recv() {
+                                    Ok(Some(version)) => {
+                                        app.update_available = Some(version);
+                                        update_check_done = true;
+                                    }
+                                    Ok(None) => update_check_done = true,
+                                    Err(std::sync::mpsc::TryRecvError::Empty) => {}
+                                    Err(std::sync::mpsc::TryRecvError::Disconnected) => {
+                                        update_check_done = true;
+                                    }
+                                }
+                            }
+
+                            terminal.draw(|f| draw(f, &app))?;
+
+                            if event::poll(Duration::from_millis(100))?
+                                && let Event::Key(key) = event::read()?
+                                && key.kind == KeyEventKind::Press
+                            {
+                                // Settings modal handling
+                                if app.settings.visible {
+                                    match key.code {
+                                        KeyCode::Esc | KeyCode::Char('s') => {
+                                            app.settings.close();
+                                        }
+                                        KeyCode::Up | KeyCode::Char('k') => {
+                                            app.settings.move_up();
+                                        }
+                                        KeyCode::Down | KeyCode::Char('j') => {
+                                            app.settings.move_down();
+                                        }
+                                        KeyCode::Left | KeyCode::Char('h') => {
+                                            app.settings.value_prev();
+                                            app.set_theme_index(app.settings.theme_index);
+                                        }
+                                        KeyCode::Right | KeyCode::Char('l') => {
+                                            app.settings.value_next();
+                                            app.set_theme_index(app.settings.theme_index);
+                                        }
+                                        KeyCode::Tab => {
+                                            app.settings.switch_tab();
+                                        }
+                                        KeyCode::Enter => {
+                                            let _ = app.settings.on_enter();
+                                        }
+                                        _ => {}
+                                    }
+                                    continue;
+                                }
+
+                                // Ctrl+C in completed state: exit
+                                if key.code == KeyCode::Char('c')
+                                    && key.modifiers.contains(KeyModifiers::CONTROL)
+                                {
+                                    prefs.theme = Some(app.theme_name().to_string());
+                                    return Ok((app.result, prefs, print_json_on_exit));
+                                }
+
+                                match key.code {
+                                    KeyCode::Char('q') => {
+                                        prefs.theme = Some(app.theme_name().to_string());
+                                        return Ok((app.result, prefs, print_json_on_exit));
+                                    }
+                                    KeyCode::Char('r') => {
+                                        // Reset app state and restart
+                                        app.reset();
+                                        continue 'test_restart_loop;
+                                    }
+                                    KeyCode::Esc => {
+                                        if app.show_help {
+                                            app.show_help = false;
+                                        } else {
+                                            prefs.theme = Some(app.theme_name().to_string());
+                                            return Ok((app.result, prefs, print_json_on_exit));
+                                        }
+                                    }
+                                    KeyCode::Char('t') => {
+                                        app.cycle_theme();
+                                    }
+                                    KeyCode::Char('s') => {
+                                        app.settings.toggle();
+                                    }
+                                    KeyCode::Char('?') | KeyCode::F(1) => {
+                                        app.toggle_help();
+                                    }
+                                    KeyCode::Char('d') => {
+                                        app.toggle_streams();
+                                    }
+                                    KeyCode::Char('j') => {
+                                        print_json_on_exit = true;
+                                        app.log("JSON output queued for display on exit.");
+                                    }
+                                    KeyCode::Char('u') if app.update_available.is_some() => {
+                                        app.update_available = None;
+                                    }
+                                    _ => {}
+                                }
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        // If we were waiting for cancel to complete, just exit
+                        if cancel_deadline.is_some() {
+                            prefs.theme = Some(app.theme_name().to_string());
+                            return Ok((app.result, prefs, print_json_on_exit));
+                        }
+
+                        app.on_error(e.to_string());
+                        terminal.draw(|f| draw(f, &app))?;
+
+                        // Wait for quit
+                        loop {
+                            if event::poll(Duration::from_millis(100))?
+                                && let Event::Key(key) = event::read()?
+                                && key.kind == KeyEventKind::Press
+                                && (key.code == KeyCode::Char('q')
+                                    || (key.code == KeyCode::Char('c')
+                                        && key.modifiers.contains(KeyModifiers::CONTROL)))
+                            {
+                                prefs.theme = Some(app.theme_name().to_string());
+                                return Err(anyhow::anyhow!(app.error.unwrap_or_default()));
+                            }
                         }
                     }
                 }
             }
-        }
-    }
+        } // close test_running_loop
+    } // close test_restart_loop
 }
 
 async fn run_server_tui(mut config: ServerConfig) -> Result<()> {

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -346,6 +346,57 @@ impl App {
         self.log("Connected to server.");
     }
 
+    /// Reset the app state for a new test run, clearing all results and metrics
+    /// but preserving configuration (host, port, protocol, etc.)
+    pub fn reset(&mut self) {
+        self.state = AppState::Connecting;
+        self.elapsed = Duration::ZERO;
+        self.total_bytes = 0;
+        self.current_throughput_mbps = 0.0;
+        self.throughput_history.clear();
+        self.jitter_history.clear();
+        self.streams.iter_mut().for_each(|s| {
+            s.bytes = 0;
+            s.throughput_mbps = 0.0;
+            s.retransmits = 0;
+            s.jitter_ms = None;
+        });
+
+        self.bidir_bytes_sent = 0;
+        self.bidir_bytes_received = 0;
+        self.throughput_send_mbps = 0.0;
+        self.throughput_recv_mbps = 0.0;
+
+        self.total_retransmits = 0;
+        self.rtt_us = 0;
+        self.cwnd = 0;
+
+        self.udp_jitter_ms = 0.0;
+        self.udp_lost_percent = None;
+        self.udp_packets_sent = 0;
+        self.udp_packets_lost = 0;
+
+        self.result = None;
+        self.error = None;
+
+        self.start_time = None;
+        self.show_help = false;
+        self.show_streams = false;
+        self.peak_throughput_mbps = 0.0;
+        self.prev_retransmits = 0;
+        self.prev_udp_lost = 0;
+        self.prev_udp_progress = None;
+        self.latest_udp_progress = None;
+        self.last_bar_at = None;
+        self.pause_started_at = None;
+
+        self.average_throughput_mbps = 0.0;
+        self.throughput_sum = 0.0;
+        self.throughput_count = 0;
+
+        self.log("Test restarting...");
+    }
+
     /// Refresh `elapsed` from the local wall clock. Called from the TUI loop
     /// once per iteration so the counter stays live even when server
     /// `Interval` progress messages are delayed (e.g. packet-drop bursts on
@@ -672,9 +723,10 @@ impl App {
             self.throughput_recv_mbps = tr;
         }
         self.result = Some(result);
+        let wall_clock = chrono::Local::now().format("%I:%M:%S %p");
         self.log(format!(
-            "Test completed. Avg: {:.0} Mbps.",
-            self.average_throughput_mbps
+            "Test completed. Avg: {:.0} Mbps. [{}]",
+            self.average_throughput_mbps, wall_clock
         ));
     }
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -237,7 +237,7 @@ impl App {
             theme,
             theme_index: 0,
 
-            settings: SettingsState::new(0, streams, protocol, duration, direction),
+            settings: SettingsState::new(0, streams, protocol, duration, direction, bitrate),
 
             history: VecDeque::with_capacity(LOG_HISTORY),
             average_throughput_mbps: 0.0,
@@ -344,6 +344,35 @@ impl App {
         self.state = AppState::Running;
         self.start_time = Some(Instant::now());
         self.log("Connected to server.");
+    }
+
+    /// Apply new test parameters chosen in the settings modal. Updates the
+    /// displayed configuration and rebuilds the per-stream table to match the
+    /// new stream count. The caller is responsible for rebuilding the client
+    /// and re-spawning the test; this only refreshes UI-facing state.
+    pub fn apply_test_params(
+        &mut self,
+        protocol: crate::protocol::Protocol,
+        direction: crate::protocol::Direction,
+        streams: u8,
+        duration: Duration,
+        bitrate: Option<u64>,
+    ) {
+        self.protocol = protocol;
+        self.direction = direction;
+        self.streams_count = streams;
+        self.duration = duration;
+        self.bitrate = bitrate;
+        self.streams = (0..streams)
+            .map(|id| StreamData {
+                id,
+                bytes: 0,
+                throughput_mbps: 0.0,
+                retransmits: 0,
+                jitter_ms: None,
+            })
+            .collect();
+        self.settings.mark_applied();
     }
 
     /// Reset the app state for a new test run, clearing all results and metrics

--- a/src/tui/settings.rs
+++ b/src/tui/settings.rs
@@ -117,12 +117,15 @@ pub struct SettingsState {
     pub protocol: Protocol,
     pub duration_secs: u64,
     pub direction: Direction,
+    /// Target bitrate in bits/sec (`None` = unlimited). Primarily for UDP.
+    pub bitrate: Option<u64>,
 
     // Original values to detect changes
     original_streams: u8,
     original_protocol: Protocol,
     original_duration_secs: u64,
     original_direction: Direction,
+    original_bitrate: Option<u64>,
 }
 
 impl Default for SettingsState {
@@ -142,11 +145,13 @@ impl Default for SettingsState {
             protocol: Protocol::Tcp,
             duration_secs: 10,
             direction: Direction::Upload,
+            bitrate: None,
 
             original_streams: 1,
             original_protocol: Protocol::Tcp,
             original_duration_secs: 10,
             original_direction: Direction::Upload,
+            original_bitrate: None,
         }
     }
 }
@@ -159,6 +164,7 @@ impl SettingsState {
         protocol: Protocol,
         duration: Duration,
         direction: Direction,
+        bitrate: Option<u64>,
     ) -> Self {
         let duration_secs = duration.as_secs();
         Self {
@@ -176,12 +182,26 @@ impl SettingsState {
             protocol,
             duration_secs,
             direction,
+            bitrate,
 
             original_streams: streams,
             original_protocol: protocol,
             original_duration_secs: duration_secs,
             original_direction: direction,
+            original_bitrate: bitrate,
         }
+    }
+
+    /// Commit the current test parameters as the new baseline so that
+    /// [`test_params_dirty`](Self::test_params_dirty) returns false until the
+    /// user changes something again. Call this right after a settings-driven
+    /// restart has applied the new values.
+    pub fn mark_applied(&mut self) {
+        self.original_streams = self.streams;
+        self.original_protocol = self.protocol;
+        self.original_duration_secs = self.duration_secs;
+        self.original_direction = self.direction;
+        self.original_bitrate = self.bitrate;
     }
 
     /// Toggle visibility
@@ -205,13 +225,14 @@ impl SettingsState {
             || self.protocol != self.original_protocol
             || self.duration_secs != self.original_duration_secs
             || self.direction != self.original_direction
+            || self.bitrate != self.original_bitrate
     }
 
     /// Number of items in current category
     fn items_in_category(&self) -> usize {
         match self.category {
             SettingsCategory::Display => 3, // Theme, Timestamp, Units
-            SettingsCategory::Test => 4,    // Streams, Protocol, Duration, Direction
+            SettingsCategory::Test => 5,    // Streams, Protocol, Duration, Direction, Bitrate
         }
     }
 
@@ -274,8 +295,9 @@ impl SettingsState {
             SettingsCategory::Test => match self.selected_index {
                 0 => self.streams = self.streams.saturating_add(1).min(128),
                 1 => self.protocol = self.protocol.next(),
-                2 => self.duration_secs = self.duration_secs.saturating_add(5).min(3600),
+                2 => self.duration_secs = duration_next(self.duration_secs),
                 3 => self.direction = self.direction.next(),
+                4 => self.bitrate = bitrate_next(self.bitrate),
                 _ => {}
             },
         }
@@ -309,8 +331,9 @@ impl SettingsState {
             SettingsCategory::Test => match self.selected_index {
                 0 => self.streams = self.streams.saturating_sub(1).max(1),
                 1 => self.protocol = self.protocol.prev(),
-                2 => self.duration_secs = self.duration_secs.saturating_sub(5).max(1),
+                2 => self.duration_secs = duration_prev(self.duration_secs),
                 3 => self.direction = self.direction.prev(),
+                4 => self.bitrate = bitrate_prev(self.bitrate),
                 _ => {}
             },
         }
@@ -361,6 +384,19 @@ pub enum SettingsAction {
     Restart,
 }
 
+/// Step duration up by 5s, snapping to a clean multiple of 5 (min 5s, max 3600s).
+fn duration_next(secs: u64) -> u64 {
+    let next = (secs / 5 + 1) * 5;
+    next.min(3600)
+}
+
+/// Step duration down by 5s, snapping to a clean multiple of 5 (min 5s).
+fn duration_prev(secs: u64) -> u64 {
+    // Round down to the previous multiple of 5 below the current value.
+    let prev = secs.saturating_sub(1) / 5 * 5;
+    prev.max(5)
+}
+
 /// Result of TUI loop - either exit or restart with new params
 #[derive(Debug, Clone)]
 #[allow(clippy::large_enum_variant)] // Exit carries the full TestResult; Restart is rare.
@@ -375,8 +411,55 @@ pub enum TuiLoopResult {
         protocol: Protocol,
         duration: Duration,
         direction: Direction,
+        bitrate: Option<u64>,
         prefs: crate::prefs::Prefs,
     },
+}
+
+/// Discrete bitrate steps cycled in the settings modal (bits/sec). `None`
+/// means unlimited (no rate cap).
+const BITRATE_STEPS: [Option<u64>; 6] = [
+    None,
+    Some(1_000_000),
+    Some(10_000_000),
+    Some(100_000_000),
+    Some(1_000_000_000),
+    Some(10_000_000_000),
+];
+
+fn bitrate_index(current: Option<u64>) -> usize {
+    BITRATE_STEPS
+        .iter()
+        .position(|&b| b == current)
+        .unwrap_or(0)
+}
+
+/// Cycle to the next (higher) bitrate step, wrapping around to unlimited.
+pub fn bitrate_next(current: Option<u64>) -> Option<u64> {
+    let i = bitrate_index(current);
+    BITRATE_STEPS[(i + 1) % BITRATE_STEPS.len()]
+}
+
+/// Cycle to the previous (lower) bitrate step, wrapping around to the top.
+pub fn bitrate_prev(current: Option<u64>) -> Option<u64> {
+    let i = bitrate_index(current);
+    let prev = if i == 0 {
+        BITRATE_STEPS.len() - 1
+    } else {
+        i - 1
+    };
+    BITRATE_STEPS[prev]
+}
+
+/// Human-readable label for a bitrate value used in the settings modal.
+pub fn bitrate_display(bitrate: Option<u64>) -> String {
+    match bitrate {
+        None => "unlimited".to_string(),
+        Some(bps) if bps % 1_000_000_000 == 0 => format!("{} Gbps", bps / 1_000_000_000),
+        Some(bps) if bps % 1_000_000 == 0 => format!("{} Mbps", bps / 1_000_000),
+        Some(bps) if bps % 1_000 == 0 => format!("{} Kbps", bps / 1_000),
+        Some(bps) => format!("{} bps", bps),
+    }
 }
 
 // Add helper methods to Protocol and Direction for cycling

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -552,6 +552,8 @@ fn draw_footer(frame: &mut Frame, app: &App, theme: &Theme, area: Rect) {
         Span::styled("] Quit | [", Style::default().fg(theme.text_dim)),
         Span::styled("p", Style::default().fg(theme.accent)),
         Span::styled("] Pause | [", Style::default().fg(theme.text_dim)),
+        Span::styled("r", Style::default().fg(theme.accent)),
+        Span::styled("] Restart | [", Style::default().fg(theme.text_dim)),
         Span::styled("s", Style::default().fg(theme.accent)),
         Span::styled("] Settings | [", Style::default().fg(theme.text_dim)),
         Span::styled("?", Style::default().fg(theme.accent)),
@@ -592,8 +594,8 @@ fn draw_footer(frame: &mut Frame, app: &App, theme: &Theme, area: Rect) {
 }
 
 fn draw_help_overlay(frame: &mut Frame, theme: &Theme, area: Rect) {
-    let help_width = 36;
-    let help_height = 14;
+    let help_width = 40;
+    let help_height = 16;
     let help_area = Rect {
         x: (area.width.saturating_sub(help_width)) / 2,
         y: (area.height.saturating_sub(help_height)) / 2,
@@ -606,6 +608,10 @@ fn draw_help_overlay(frame: &mut Frame, theme: &Theme, area: Rect) {
         Line::from(vec![
             Span::styled("  q", Style::default().fg(theme.accent)),
             Span::styled("  quit", Style::default().fg(theme.text_dim)),
+        ]),
+        Line::from(vec![
+            Span::styled("  r", Style::default().fg(theme.accent)),
+            Span::styled("  restart/cancel", Style::default().fg(theme.text_dim)),
         ]),
         Line::from(vec![
             Span::styled("  p", Style::default().fg(theme.accent)),

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -697,7 +697,7 @@ fn draw_settings_modal(frame: &mut Frame, app: &App, theme: &Theme, area: Rect) 
 
     // Modal dimensions
     let modal_width = 58u16;
-    let modal_height = 18u16;
+    let modal_height = 19u16;
     let modal_area = Rect {
         x: area.width.saturating_sub(modal_width) / 2,
         y: area.height.saturating_sub(modal_height) / 2,
@@ -840,6 +840,10 @@ fn draw_test_settings(
         ("Protocol:", format!("{}", settings.protocol)),
         ("Duration:", format!("{}s", settings.duration_secs)),
         ("Direction:", format!("{:?}", settings.direction)),
+        (
+            "Bitrate:",
+            super::settings::bitrate_display(settings.bitrate),
+        ),
     ];
 
     draw_setting_items(


### PR DESCRIPTION
Builds on #101 (restart key).

The Settings → Test tab already existed in the TUI, but "Apply & Restart" was
a stub that only logged "Restart not yet implemented" and changed nothing.

This wires it up so changing test parameters in the settings modal actually
rebuilds the client and restarts the run in place — in both the running and
completed states (the completed-state handler previously discarded the action
entirely).

What now works:
- Change streams, protocol, duration, and direction live, then Apply & Restart
- New UDP bitrate/bandwidth setting (unlimited → 1M..10G)
- Duration cycles in clean 5s steps (was 1s, 6s, 11s…)
- Stream count refreshes on restart so the `[d] Streams` footer hint appears

Note: stacked on #101 (restart key); please merge that first, or review only
the second commit (`a60c635`). Once #101 lands, this diff collapses to just
the settings commit.