### PR TITLE
Add safe TUI restart controls

### DIFF
--- a/benches/throughput.rs
+++ b/benches/throughput.rs
@@ -126,6 +126,8 @@ fn bench_protocol_serialize_test_start(c: &mut Criterion) {
         dscp: None,
         window_size: None,
         zerocopy: false,
+        mtu_probe: false,
+        tcp_nodelay: false,
     };
 
     c.bench_function("protocol_serialize_test_start", |b| {
@@ -229,6 +231,7 @@ fn bench_protocol_serialize_result(c: &mut Criterion) {
         bytes_received: None,
         throughput_send_mbps: None,
         throughput_recv_mbps: None,
+        mtu_probe: None,
     };
     let msg = ControlMessage::Result(result);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1525,9 +1525,229 @@ async fn run_client_tui(
     }
 }
 
+struct TuiRun {
+    client: Arc<Client>,
+    handle: tokio::task::JoinHandle<Result<xfr::protocol::TestResult>>,
+    progress_rx: mpsc::Receiver<TestProgress>,
+}
+
+fn spawn_tui_run(config: &ClientConfig) -> TuiRun {
+    let client = Arc::new(Client::new(config.clone()));
+    let client_for_task = client.clone();
+    let (progress_tx, progress_rx) = mpsc::channel::<TestProgress>(100);
+    let handle = tokio::spawn(async move { client_for_task.run(Some(progress_tx)).await });
+    TuiRun {
+        client,
+        handle,
+        progress_rx,
+    }
+}
+
+async fn finish_tui_run(run: TuiRun) -> Result<xfr::protocol::TestResult> {
+    let TuiRun { handle, .. } = run;
+    handle.await?
+}
+
+async fn cancel_tui_run(
+    run: TuiRun,
+    timeout: Duration,
+) -> Option<Result<xfr::protocol::TestResult>> {
+    let _ = run.client.cancel();
+    let TuiRun { mut handle, .. } = run;
+    match tokio::time::timeout(timeout, &mut handle).await {
+        Ok(joined) => Some(joined.map_err(anyhow::Error::from).and_then(|inner| inner)),
+        Err(_) => {
+            handle.abort();
+            let _ = handle.await;
+            None
+        }
+    }
+}
+
+async fn abort_tui_run(run: TuiRun) {
+    let TuiRun { handle, .. } = run;
+    handle.abort();
+    let _ = handle.await;
+}
+
+fn poll_update_check(
+    app: &mut App,
+    update_rx: &std::sync::mpsc::Receiver<Option<String>>,
+    update_check_done: &mut bool,
+) {
+    if *update_check_done {
+        return;
+    }
+
+    match update_rx.try_recv() {
+        Ok(Some(version)) => {
+            app.update_available = Some(version);
+            *update_check_done = true;
+        }
+        Ok(None) => {
+            *update_check_done = true;
+        }
+        Err(std::sync::mpsc::TryRecvError::Empty) => {}
+        Err(std::sync::mpsc::TryRecvError::Disconnected) => {
+            *update_check_done = true;
+        }
+    }
+}
+
+fn handle_tui_settings_key(app: &mut App, key: crossterm::event::KeyEvent) -> SettingsAction {
+    match key.code {
+        KeyCode::Esc | KeyCode::Char('s') => {
+            app.settings.close();
+            SettingsAction::Close
+        }
+        KeyCode::Up | KeyCode::Char('k') => {
+            app.settings.move_up();
+            SettingsAction::None
+        }
+        KeyCode::Down | KeyCode::Char('j') => {
+            app.settings.move_down();
+            SettingsAction::None
+        }
+        KeyCode::Left | KeyCode::Char('h') => {
+            app.settings.value_prev();
+            app.set_theme_index(app.settings.theme_index);
+            SettingsAction::None
+        }
+        KeyCode::Right | KeyCode::Char('l') => {
+            app.settings.value_next();
+            app.set_theme_index(app.settings.theme_index);
+            SettingsAction::None
+        }
+        KeyCode::Tab => {
+            app.settings.switch_tab();
+            SettingsAction::None
+        }
+        KeyCode::Enter => app.settings.on_enter(),
+        _ => SettingsAction::None,
+    }
+}
+
+fn apply_tui_settings(config: &mut ClientConfig, app: &mut App) {
+    config.streams = app.settings.streams;
+    config.protocol = app.settings.protocol;
+    config.duration = Duration::from_secs(app.settings.duration_secs);
+    config.direction = app.settings.direction;
+    config.bitrate = app.settings.bitrate;
+
+    app.apply_test_params(
+        config.protocol,
+        config.direction,
+        config.streams,
+        config.duration,
+        config.bitrate,
+    );
+}
+
+fn log_tui_quic_ignored_options(app: &mut App, config: &ClientConfig) {
+    if config.protocol != Protocol::Quic {
+        return;
+    }
+
+    for (set, msg) in [
+        (
+            config.bitrate.is_some(),
+            "-b/--bitrate is ignored with QUIC (pacing is not implemented for QUIC)",
+        ),
+        (
+            config.window_size.is_some(),
+            "-w/--window is ignored with QUIC (QUIC flow control manages buffering)",
+        ),
+        (
+            config.tcp_congestion.is_some(),
+            "--congestion is ignored with QUIC (kernel TCP CC does not apply)",
+        ),
+        (
+            config.tcp_nodelay,
+            "--tcp-nodelay is ignored with QUIC (no Nagle on UDP transport)",
+        ),
+        (
+            config.dscp.is_some(),
+            "--dscp is ignored with QUIC (QUIC manages its own socket)",
+        ),
+    ] {
+        if set {
+            app.log(format!("Warning: {msg}"));
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TuiQuitAction {
+    Noop,
+    ExitOk,
+    ExitError,
+    StartCancel,
+    ForceExit,
+    Ignore,
+}
+
+fn tui_quit_action(
+    key: &crossterm::event::KeyEvent,
+    state: AppState,
+    cancel_pending: bool,
+    run_active: bool,
+) -> TuiQuitAction {
+    let is_ctrl_c = key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL);
+    let is_quit = key.code == KeyCode::Char('q') || is_ctrl_c;
+
+    if !is_quit {
+        return TuiQuitAction::Noop;
+    }
+
+    if state == AppState::Error {
+        return TuiQuitAction::ExitError;
+    }
+
+    if state == AppState::Completed || !run_active {
+        return TuiQuitAction::ExitOk;
+    }
+
+    if cancel_pending {
+        if is_ctrl_c {
+            TuiQuitAction::ForceExit
+        } else {
+            TuiQuitAction::Ignore
+        }
+    } else {
+        TuiQuitAction::StartCancel
+    }
+}
+
+async fn restart_tui_run(
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    app: &mut App,
+    run: &mut Option<TuiRun>,
+    config: &ClientConfig,
+) -> Result<()> {
+    if let Some(current) = run.take() {
+        app.log("Restarting, waiting for current test to stop...");
+        terminal.draw(|f| draw(f, app))?;
+        match cancel_tui_run(current, Duration::from_secs(3)).await {
+            Some(Ok(_)) => {}
+            Some(Err(e)) => {
+                app.log(format!("Previous test ended while restarting: {}", e));
+            }
+            None => {
+                app.log("Previous test did not stop in time; aborted.");
+            }
+        }
+    }
+
+    app.reset_for_restart();
+    log_tui_quic_ignored_options(app, config);
+    *run = Some(spawn_tui_run(config));
+    app.on_connected();
+    Ok(())
+}
+
 async fn run_tui_loop(
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
-    config: ClientConfig,
+    mut config: ClientConfig,
     timestamp_format: TimestampFormat,
     mut prefs: xfr::prefs::Prefs,
 ) -> Result<(Option<xfr::protocol::TestResult>, xfr::prefs::Prefs, bool)> {
@@ -1554,13 +1774,7 @@ async fn run_tui_loop(
     // Track if we've received the update check result
     let mut update_check_done = false;
 
-    let client = Arc::new(Client::new(config));
-    let client_for_task = client.clone();
-    let (progress_tx, mut progress_rx) = mpsc::channel::<TestProgress>(100);
-
-    // Start the test
-    let test_handle = tokio::spawn(async move { client_for_task.run(Some(progress_tx)).await });
-
+    let mut run = Some(spawn_tui_run(&config));
     app.on_connected();
 
     // Track cancel state: when user presses 'q' or Ctrl+C during a running test,
@@ -1572,29 +1786,13 @@ async fn run_tui_loop(
         if let Some(deadline) = cancel_deadline
             && deadline.elapsed() > Duration::ZERO
         {
+            if let Some(current) = run.take() {
+                abort_tui_run(current).await;
+            }
             return Ok((app.result, prefs, print_json_on_exit));
         }
 
-        // Check for update result if not already received
-        if !update_check_done {
-            match update_rx.try_recv() {
-                Ok(Some(version)) => {
-                    app.update_available = Some(version);
-                    update_check_done = true;
-                }
-                Ok(None) => {
-                    // No update available
-                    update_check_done = true;
-                }
-                Err(std::sync::mpsc::TryRecvError::Empty) => {
-                    // Still checking, will try again next loop
-                }
-                Err(std::sync::mpsc::TryRecvError::Disconnected) => {
-                    // Channel closed, stop checking
-                    update_check_done = true;
-                }
-            }
-        }
+        poll_update_check(&mut app, &update_rx, &mut update_check_done);
 
         // Refresh the wall-clock-driven parts of app state (elapsed counter) so
         // the UI stays live even when the server's Interval progress messages
@@ -1605,7 +1803,8 @@ async fn run_tui_loop(
         // ServerHello races the TUI loop start; we poll rather than add a new
         // channel since this is a one-time one-line copy.
         if app.server_version.is_none()
-            && let Some(v) = client.server_version()
+            && let Some(active) = run.as_ref()
+            && let Some(v) = active.client.server_version()
         {
             // Route through `set_server_version` so the string is sanitized —
             // it comes from the peer and lands in the terminal.
@@ -1622,93 +1821,81 @@ async fn run_tui_loop(
         {
             // Settings modal takes priority when visible
             if app.settings.visible {
-                match key.code {
-                    KeyCode::Esc | KeyCode::Char('s') => {
-                        app.settings.close();
-                    }
-                    KeyCode::Up | KeyCode::Char('k') => {
-                        app.settings.move_up();
-                    }
-                    KeyCode::Down | KeyCode::Char('j') => {
-                        app.settings.move_down();
-                    }
-                    KeyCode::Left | KeyCode::Char('h') => {
-                        app.settings.value_prev();
-                        // Apply theme change immediately
-                        app.set_theme_index(app.settings.theme_index);
-                    }
-                    KeyCode::Right | KeyCode::Char('l') => {
-                        app.settings.value_next();
-                        // Apply theme change immediately
-                        app.set_theme_index(app.settings.theme_index);
-                    }
-                    KeyCode::Tab => {
-                        app.settings.switch_tab();
-                    }
-                    KeyCode::Enter => {
-                        let action = app.settings.on_enter();
-                        match action {
-                            SettingsAction::Restart => {
-                                // Cancel current test and signal restart
-                                let _ = client.cancel();
-                                prefs.theme = Some(app.theme_name().to_string());
-                                // TODO: Return restart signal with new params
-                                // For now, just close - restart requires refactoring
-                                app.log("Settings changed. Restart not yet implemented.");
-                            }
-                            SettingsAction::Close => {}
-                            SettingsAction::None => {}
-                        }
-                    }
-                    _ => {}
+                if handle_tui_settings_key(&mut app, key) == SettingsAction::Restart {
+                    prefs.theme = Some(app.theme_name().to_string());
+                    apply_tui_settings(&mut config, &mut app);
+                    cancel_deadline = None;
+                    print_json_on_exit = false;
+                    restart_tui_run(terminal, &mut app, &mut run, &config).await?;
                 }
                 continue;
             }
 
-            // Ctrl+C or 'q': cancel and wait for server Result
-            let is_quit = key.code == KeyCode::Char('q')
-                || (key.code == KeyCode::Char('c')
-                    && key.modifiers.contains(KeyModifiers::CONTROL));
-            if is_quit {
-                if app.state == AppState::Completed || cancel_deadline.is_some() {
-                    // Already completed or already cancelling — exit immediately
+            match tui_quit_action(&key, app.state, cancel_deadline.is_some(), run.is_some()) {
+                TuiQuitAction::Noop => {}
+                TuiQuitAction::ExitError => {
+                    prefs.theme = Some(app.theme_name().to_string());
+                    return Err(anyhow::anyhow!(app.error.clone().unwrap_or_default()));
+                }
+                TuiQuitAction::ExitOk => {
                     prefs.theme = Some(app.theme_name().to_string());
                     return Ok((app.result, prefs, print_json_on_exit));
                 }
-                let _ = client.cancel();
-                cancel_deadline = Some(std::time::Instant::now() + Duration::from_secs(3));
-                app.log("Cancelling, waiting for summary...");
-                continue;
+                TuiQuitAction::ForceExit => {
+                    if let Some(current) = run.take() {
+                        abort_tui_run(current).await;
+                    }
+                    prefs.theme = Some(app.theme_name().to_string());
+                    return Ok((app.result, prefs, print_json_on_exit));
+                }
+                TuiQuitAction::Ignore => {
+                    continue;
+                }
+                TuiQuitAction::StartCancel => {
+                    if let Some(active) = run.as_ref() {
+                        let _ = active.client.cancel();
+                    }
+                    cancel_deadline = Some(std::time::Instant::now() + Duration::from_secs(3));
+                    app.log("Cancelling, waiting for summary...");
+                    continue;
+                }
             }
 
             match key.code {
                 KeyCode::Char('p') => {
-                    match client.pause() {
-                        PauseResult::Applied => {
-                            app.toggle_pause();
-                        }
-                        PauseResult::Unsupported => {
-                            // UI-only: server doesn't support pause/resume
-                            match app.state {
-                                AppState::Running => {
-                                    app.state = AppState::Paused;
-                                    app.log(
-                                        "Display paused (server does not support pause/resume)",
-                                    );
+                    if let Some(active) = run.as_ref() {
+                        match active.client.pause() {
+                            PauseResult::Applied => {
+                                app.toggle_pause();
+                            }
+                            PauseResult::Unsupported => {
+                                // UI-only: server doesn't support pause/resume
+                                match app.state {
+                                    AppState::Running => {
+                                        app.state = AppState::Paused;
+                                        app.log(
+                                            "Display paused (server does not support pause/resume)",
+                                        );
+                                    }
+                                    AppState::Paused => {
+                                        app.state = AppState::Running;
+                                        app.log(
+                                            "Display resumed (server does not support pause/resume)",
+                                        );
+                                    }
+                                    _ => {}
                                 }
-                                AppState::Paused => {
-                                    app.state = AppState::Running;
-                                    app.log(
-                                        "Display resumed (server does not support pause/resume)",
-                                    );
-                                }
-                                _ => {}
+                            }
+                            PauseResult::NotReady => {
+                                // Test not running yet or already finished — ignore
                             }
                         }
-                        PauseResult::NotReady => {
-                            // Test not running yet or already finished — ignore
-                        }
                     }
+                }
+                KeyCode::Char('r') => {
+                    cancel_deadline = None;
+                    print_json_on_exit = false;
+                    restart_tui_run(terminal, &mut app, &mut run, &config).await?;
                 }
                 KeyCode::Char('t') => {
                     app.cycle_theme();
@@ -1725,6 +1912,14 @@ async fn run_tui_loop(
                 KeyCode::Esc if app.show_help => {
                     app.show_help = false;
                 }
+                KeyCode::Esc if matches!(app.state, AppState::Completed) => {
+                    prefs.theme = Some(app.theme_name().to_string());
+                    return Ok((app.result, prefs, print_json_on_exit));
+                }
+                KeyCode::Esc if matches!(app.state, AppState::Error) => {
+                    prefs.theme = Some(app.theme_name().to_string());
+                    return Err(anyhow::anyhow!(app.error.clone().unwrap_or_default()));
+                }
                 KeyCode::Char('j') if app.result.is_some() => {
                     // Set flag to print JSON after TUI closes
                     print_json_on_exit = true;
@@ -1739,13 +1934,19 @@ async fn run_tui_loop(
         }
 
         // Check for progress updates
-        while let Ok(progress) = progress_rx.try_recv() {
-            app.on_progress(progress);
+        if let Some(active) = run.as_mut() {
+            while let Ok(progress) = active.progress_rx.try_recv() {
+                app.on_progress(progress);
+            }
         }
 
         // Check if test completed
-        if test_handle.is_finished() {
-            match test_handle.await? {
+        if run
+            .as_ref()
+            .is_some_and(|active| active.handle.is_finished())
+        {
+            let finished_run = run.take().expect("run exists after is_finished check");
+            match finish_tui_run(finished_run).await {
                 Ok(result) => {
                     app.on_result(result);
 
@@ -1757,105 +1958,6 @@ async fn run_tui_loop(
 
                     // Show final result for a moment
                     terminal.draw(|f| draw(f, &app))?;
-
-                    // Wait for quit
-                    loop {
-                        // Check for update result if not already received
-                        if !update_check_done {
-                            match update_rx.try_recv() {
-                                Ok(Some(version)) => {
-                                    app.update_available = Some(version);
-                                    update_check_done = true;
-                                }
-                                Ok(None) => update_check_done = true,
-                                Err(std::sync::mpsc::TryRecvError::Empty) => {}
-                                Err(std::sync::mpsc::TryRecvError::Disconnected) => {
-                                    update_check_done = true;
-                                }
-                            }
-                        }
-
-                        terminal.draw(|f| draw(f, &app))?;
-
-                        if event::poll(Duration::from_millis(100))?
-                            && let Event::Key(key) = event::read()?
-                            && key.kind == KeyEventKind::Press
-                        {
-                            // Settings modal handling
-                            if app.settings.visible {
-                                match key.code {
-                                    KeyCode::Esc | KeyCode::Char('s') => {
-                                        app.settings.close();
-                                    }
-                                    KeyCode::Up | KeyCode::Char('k') => {
-                                        app.settings.move_up();
-                                    }
-                                    KeyCode::Down | KeyCode::Char('j') => {
-                                        app.settings.move_down();
-                                    }
-                                    KeyCode::Left | KeyCode::Char('h') => {
-                                        app.settings.value_prev();
-                                        app.set_theme_index(app.settings.theme_index);
-                                    }
-                                    KeyCode::Right | KeyCode::Char('l') => {
-                                        app.settings.value_next();
-                                        app.set_theme_index(app.settings.theme_index);
-                                    }
-                                    KeyCode::Tab => {
-                                        app.settings.switch_tab();
-                                    }
-                                    KeyCode::Enter => {
-                                        let _ = app.settings.on_enter();
-                                    }
-                                    _ => {}
-                                }
-                                continue;
-                            }
-
-                            // Ctrl+C in completed state: exit
-                            if key.code == KeyCode::Char('c')
-                                && key.modifiers.contains(KeyModifiers::CONTROL)
-                            {
-                                prefs.theme = Some(app.theme_name().to_string());
-                                return Ok((app.result, prefs, print_json_on_exit));
-                            }
-
-                            match key.code {
-                                KeyCode::Char('q') => {
-                                    prefs.theme = Some(app.theme_name().to_string());
-                                    return Ok((app.result, prefs, print_json_on_exit));
-                                }
-                                KeyCode::Esc => {
-                                    if app.show_help {
-                                        app.show_help = false;
-                                    } else {
-                                        prefs.theme = Some(app.theme_name().to_string());
-                                        return Ok((app.result, prefs, print_json_on_exit));
-                                    }
-                                }
-                                KeyCode::Char('t') => {
-                                    app.cycle_theme();
-                                }
-                                KeyCode::Char('s') => {
-                                    app.settings.toggle();
-                                }
-                                KeyCode::Char('?') | KeyCode::F(1) => {
-                                    app.toggle_help();
-                                }
-                                KeyCode::Char('d') => {
-                                    app.toggle_streams();
-                                }
-                                KeyCode::Char('j') => {
-                                    print_json_on_exit = true;
-                                    app.log("JSON output queued for display on exit.");
-                                }
-                                KeyCode::Char('u') if app.update_available.is_some() => {
-                                    app.update_available = None;
-                                }
-                                _ => {}
-                            }
-                        }
-                    }
                 }
                 Err(e) => {
                     // If we were waiting for cancel to complete, just exit
@@ -1866,20 +1968,6 @@ async fn run_tui_loop(
 
                     app.on_error(e.to_string());
                     terminal.draw(|f| draw(f, &app))?;
-
-                    // Wait for quit
-                    loop {
-                        if event::poll(Duration::from_millis(100))?
-                            && let Event::Key(key) = event::read()?
-                            && key.kind == KeyEventKind::Press
-                            && (key.code == KeyCode::Char('q')
-                                || (key.code == KeyCode::Char('c')
-                                    && key.modifiers.contains(KeyModifiers::CONTROL)))
-                        {
-                            prefs.theme = Some(app.theme_name().to_string());
-                            return Err(anyhow::anyhow!(app.error.unwrap_or_default()));
-                        }
-                    }
                 }
             }
         }
@@ -1970,6 +2058,86 @@ async fn run_server_tui(mut config: ServerConfig) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn test_key(code: KeyCode) -> crossterm::event::KeyEvent {
+        crossterm::event::KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    fn ctrl_c_key() -> crossterm::event::KeyEvent {
+        crossterm::event::KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL)
+    }
+
+    #[test]
+    fn tui_quit_action_ignores_non_quit_keys() {
+        assert_eq!(
+            tui_quit_action(
+                &test_key(KeyCode::Char('r')),
+                AppState::Running,
+                false,
+                true
+            ),
+            TuiQuitAction::Noop
+        );
+    }
+
+    #[test]
+    fn tui_quit_action_starts_graceful_cancel_for_running_test() {
+        assert_eq!(
+            tui_quit_action(
+                &test_key(KeyCode::Char('q')),
+                AppState::Running,
+                false,
+                true
+            ),
+            TuiQuitAction::StartCancel
+        );
+        assert_eq!(
+            tui_quit_action(&ctrl_c_key(), AppState::Running, false, true),
+            TuiQuitAction::StartCancel
+        );
+    }
+
+    #[test]
+    fn tui_quit_action_keeps_repeated_q_graceful_while_cancel_pending() {
+        assert_eq!(
+            tui_quit_action(&test_key(KeyCode::Char('q')), AppState::Running, true, true),
+            TuiQuitAction::Ignore
+        );
+        assert_eq!(
+            tui_quit_action(&ctrl_c_key(), AppState::Running, true, true),
+            TuiQuitAction::ForceExit
+        );
+    }
+
+    #[test]
+    fn tui_quit_action_exits_when_run_is_done_or_missing() {
+        assert_eq!(
+            tui_quit_action(
+                &test_key(KeyCode::Char('q')),
+                AppState::Completed,
+                false,
+                true
+            ),
+            TuiQuitAction::ExitOk
+        );
+        assert_eq!(
+            tui_quit_action(
+                &test_key(KeyCode::Char('q')),
+                AppState::Running,
+                false,
+                false
+            ),
+            TuiQuitAction::ExitOk
+        );
+    }
+
+    #[test]
+    fn tui_quit_action_preserves_error_exit() {
+        assert_eq!(
+            tui_quit_action(&test_key(KeyCode::Char('q')), AppState::Error, false, true),
+            TuiQuitAction::ExitError
+        );
+    }
 
     #[test]
     fn test_parse_bitrate_basic() {

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -73,6 +73,8 @@ pub struct LogEntry {
 }
 
 pub struct App {
+    // `reset_for_restart` reuses one App across multiple TUI test runs. When
+    // adding run-specific fields, update that reset path as well.
     pub state: AppState,
     pub host: String,
     pub port: u16,
@@ -237,7 +239,7 @@ impl App {
             theme,
             theme_index: 0,
 
-            settings: SettingsState::new(0, streams, protocol, duration, direction),
+            settings: SettingsState::new(0, streams, protocol, duration, direction, bitrate),
 
             history: VecDeque::with_capacity(LOG_HISTORY),
             average_throughput_mbps: 0.0,
@@ -344,6 +346,84 @@ impl App {
         self.state = AppState::Running;
         self.start_time = Some(Instant::now());
         self.log("Connected to server.");
+    }
+
+    /// Apply new test parameters chosen in the settings modal. The caller is
+    /// responsible for rebuilding the client and spawning the replacement run.
+    pub fn apply_test_params(
+        &mut self,
+        protocol: Protocol,
+        direction: Direction,
+        streams: u8,
+        duration: Duration,
+        bitrate: Option<u64>,
+    ) {
+        self.protocol = protocol;
+        self.direction = direction;
+        self.streams_count = streams;
+        self.duration = duration;
+        self.bitrate = bitrate;
+        self.streams = (0..streams)
+            .map(|id| StreamData {
+                id,
+                bytes: 0,
+                throughput_mbps: 0.0,
+                retransmits: 0,
+                jitter_ms: None,
+            })
+            .collect();
+        self.settings.mark_applied();
+    }
+
+    /// Reset run-specific metrics before spawning a new test, preserving user
+    /// preferences, settings, update notifications, and history.
+    pub fn reset_for_restart(&mut self) {
+        self.state = AppState::Connecting;
+        self.elapsed = Duration::ZERO;
+        self.total_bytes = 0;
+        self.current_throughput_mbps = 0.0;
+        self.throughput_history.clear();
+        self.jitter_history.clear();
+        for stream in &mut self.streams {
+            stream.bytes = 0;
+            stream.throughput_mbps = 0.0;
+            stream.retransmits = 0;
+            stream.jitter_ms = None;
+        }
+
+        self.bidir_bytes_sent = 0;
+        self.bidir_bytes_received = 0;
+        self.throughput_send_mbps = 0.0;
+        self.throughput_recv_mbps = 0.0;
+
+        self.total_retransmits = 0;
+        self.rtt_us = 0;
+        self.cwnd = 0;
+
+        self.udp_jitter_ms = 0.0;
+        self.udp_lost_percent = None;
+        self.udp_packets_sent = 0;
+        self.udp_packets_lost = 0;
+
+        self.result = None;
+        self.error = None;
+        self.start_time = None;
+        self.show_help = false;
+        self.show_streams = false;
+        self.peak_throughput_mbps = 0.0;
+        self.prev_retransmits = 0;
+        self.prev_udp_lost = 0;
+        self.prev_udp_progress = None;
+        self.latest_udp_progress = None;
+        self.last_bar_at = None;
+        self.pause_started_at = None;
+        self.server_version = None;
+
+        self.average_throughput_mbps = 0.0;
+        self.throughput_sum = 0.0;
+        self.throughput_count = 0;
+
+        self.log("Test restarting...");
     }
 
     /// Refresh `elapsed` from the local wall clock. Called from the TUI loop
@@ -948,6 +1028,77 @@ mod tests {
         assert!(app.server_version.is_none());
         app.set_server_version("xfr/0.9.8".to_string());
         assert_eq!(app.server_version.as_deref(), Some("xfr/0.9.8"));
+    }
+
+    #[test]
+    fn apply_test_params_refreshes_displayed_config_and_settings_baseline() {
+        let mut app = App::default();
+        app.settings.streams = 4;
+        app.settings.protocol = Protocol::Udp;
+        app.settings.duration_secs = 15;
+        app.settings.direction = Direction::Download;
+        app.settings.bitrate = Some(100_000_000);
+        assert!(app.settings.test_params_dirty());
+
+        app.apply_test_params(
+            Protocol::Udp,
+            Direction::Download,
+            4,
+            Duration::from_secs(15),
+            Some(100_000_000),
+        );
+
+        assert_eq!(app.protocol, Protocol::Udp);
+        assert_eq!(app.direction, Direction::Download);
+        assert_eq!(app.streams_count, 4);
+        assert_eq!(app.duration, Duration::from_secs(15));
+        assert_eq!(app.bitrate, Some(100_000_000));
+        assert_eq!(app.streams.len(), 4);
+        assert!(!app.settings.test_params_dirty());
+    }
+
+    #[test]
+    fn reset_for_restart_clears_run_state_but_preserves_user_context() {
+        let mut app = App::default();
+        app.on_connected();
+        app.total_bytes = 1234;
+        app.current_throughput_mbps = 42.0;
+        app.throughput_history.push_back(ThroughputSample {
+            mbps: 42.0,
+            lost_packets: 1,
+            interval_packets: 10,
+        });
+        app.streams[0].bytes = 1234;
+        app.result = Some(TestResult {
+            id: "test".to_string(),
+            duration_ms: 1000,
+            bytes_total: 1234,
+            throughput_mbps: 42.0,
+            streams: vec![],
+            tcp_info: None,
+            udp_stats: None,
+            bytes_sent: None,
+            bytes_received: None,
+            throughput_send_mbps: None,
+            throughput_recv_mbps: None,
+            mtu_probe: None,
+        });
+        app.set_server_version("xfr/0.9.18".to_string());
+        app.update_available = Some("xfr/0.9.19".to_string());
+        let history_len = app.history.len();
+
+        app.reset_for_restart();
+
+        assert_eq!(app.state, AppState::Connecting);
+        assert_eq!(app.total_bytes, 0);
+        assert_eq!(app.current_throughput_mbps, 0.0);
+        assert!(app.throughput_history.is_empty());
+        assert_eq!(app.streams[0].bytes, 0);
+        assert!(app.result.is_none());
+        assert!(app.error.is_none());
+        assert!(app.server_version.is_none());
+        assert_eq!(app.update_available.as_deref(), Some("xfr/0.9.19"));
+        assert_eq!(app.history.len(), history_len + 1);
     }
 
     #[test]

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -7,6 +7,6 @@ pub mod widgets;
 
 pub use app::App;
 pub use server::{ActiveTestInfo, ServerApp};
-pub use settings::{SettingsAction, SettingsState, TuiLoopResult};
+pub use settings::{SettingsAction, SettingsState};
 pub use theme::Theme;
 pub use ui::draw;

--- a/src/tui/settings.rs
+++ b/src/tui/settings.rs
@@ -117,12 +117,15 @@ pub struct SettingsState {
     pub protocol: Protocol,
     pub duration_secs: u64,
     pub direction: Direction,
+    /// Target bitrate in bits/sec (`None` = unlimited).
+    pub bitrate: Option<u64>,
 
     // Original values to detect changes
     original_streams: u8,
     original_protocol: Protocol,
     original_duration_secs: u64,
     original_direction: Direction,
+    original_bitrate: Option<u64>,
 }
 
 impl Default for SettingsState {
@@ -142,11 +145,13 @@ impl Default for SettingsState {
             protocol: Protocol::Tcp,
             duration_secs: 10,
             direction: Direction::Upload,
+            bitrate: None,
 
             original_streams: 1,
             original_protocol: Protocol::Tcp,
             original_duration_secs: 10,
             original_direction: Direction::Upload,
+            original_bitrate: None,
         }
     }
 }
@@ -159,6 +164,7 @@ impl SettingsState {
         protocol: Protocol,
         duration: Duration,
         direction: Direction,
+        bitrate: Option<u64>,
     ) -> Self {
         let duration_secs = duration.as_secs();
         Self {
@@ -176,12 +182,23 @@ impl SettingsState {
             protocol,
             duration_secs,
             direction,
+            bitrate,
 
             original_streams: streams,
             original_protocol: protocol,
             original_duration_secs: duration_secs,
             original_direction: direction,
+            original_bitrate: bitrate,
         }
+    }
+
+    /// Commit the current test parameters as the new clean baseline.
+    pub fn mark_applied(&mut self) {
+        self.original_streams = self.streams;
+        self.original_protocol = self.protocol;
+        self.original_duration_secs = self.duration_secs;
+        self.original_direction = self.direction;
+        self.original_bitrate = self.bitrate;
     }
 
     /// Toggle visibility
@@ -205,13 +222,14 @@ impl SettingsState {
             || self.protocol != self.original_protocol
             || self.duration_secs != self.original_duration_secs
             || self.direction != self.original_direction
+            || self.bitrate != self.original_bitrate
     }
 
     /// Number of items in current category
     fn items_in_category(&self) -> usize {
         match self.category {
             SettingsCategory::Display => 3, // Theme, Timestamp, Units
-            SettingsCategory::Test => 4,    // Streams, Protocol, Duration, Direction
+            SettingsCategory::Test => 5,    // Streams, Protocol, Duration, Direction, Bitrate
         }
     }
 
@@ -274,8 +292,9 @@ impl SettingsState {
             SettingsCategory::Test => match self.selected_index {
                 0 => self.streams = self.streams.saturating_add(1).min(128),
                 1 => self.protocol = self.protocol.next(),
-                2 => self.duration_secs = self.duration_secs.saturating_add(5).min(3600),
+                2 => self.duration_secs = duration_next(self.duration_secs),
                 3 => self.direction = self.direction.next(),
+                4 => self.bitrate = bitrate_next(self.bitrate),
                 _ => {}
             },
         }
@@ -309,8 +328,9 @@ impl SettingsState {
             SettingsCategory::Test => match self.selected_index {
                 0 => self.streams = self.streams.saturating_sub(1).max(1),
                 1 => self.protocol = self.protocol.prev(),
-                2 => self.duration_secs = self.duration_secs.saturating_sub(5).max(1),
+                2 => self.duration_secs = duration_prev(self.duration_secs),
                 3 => self.direction = self.direction.prev(),
+                4 => self.bitrate = bitrate_prev(self.bitrate),
                 _ => {}
             },
         }
@@ -361,22 +381,57 @@ pub enum SettingsAction {
     Restart,
 }
 
-/// Result of TUI loop - either exit or restart with new params
-#[derive(Debug, Clone)]
-#[allow(clippy::large_enum_variant)] // Exit carries the full TestResult; Restart is rare.
-pub enum TuiLoopResult {
-    Exit {
-        result: Option<crate::protocol::TestResult>,
-        prefs: crate::prefs::Prefs,
-        print_json: bool,
-    },
-    Restart {
-        streams: u8,
-        protocol: Protocol,
-        duration: Duration,
-        direction: Direction,
-        prefs: crate::prefs::Prefs,
-    },
+/// Step duration up by 5s, snapping to a clean multiple of 5 (min 5s, max 3600s).
+fn duration_next(secs: u64) -> u64 {
+    ((secs / 5 + 1) * 5).min(3600)
+}
+
+/// Step duration down by 5s, snapping to a clean multiple of 5 (min 5s).
+fn duration_prev(secs: u64) -> u64 {
+    (secs.saturating_sub(1) / 5 * 5).max(5)
+}
+
+/// Discrete bitrate steps cycled in the settings modal (bits/sec). `None`
+/// means unlimited.
+const BITRATE_STEPS: [Option<u64>; 6] = [
+    None,
+    Some(1_000_000),
+    Some(10_000_000),
+    Some(100_000_000),
+    Some(1_000_000_000),
+    Some(10_000_000_000),
+];
+
+fn bitrate_index(current: Option<u64>) -> usize {
+    BITRATE_STEPS
+        .iter()
+        .position(|&step| step == current)
+        .unwrap_or(0)
+}
+
+pub fn bitrate_next(current: Option<u64>) -> Option<u64> {
+    let i = bitrate_index(current);
+    BITRATE_STEPS[(i + 1) % BITRATE_STEPS.len()]
+}
+
+pub fn bitrate_prev(current: Option<u64>) -> Option<u64> {
+    let i = bitrate_index(current);
+    let prev = if i == 0 {
+        BITRATE_STEPS.len() - 1
+    } else {
+        i - 1
+    };
+    BITRATE_STEPS[prev]
+}
+
+pub fn bitrate_display(bitrate: Option<u64>) -> String {
+    match bitrate {
+        None => "unlimited".to_string(),
+        Some(bps) if bps % 1_000_000_000 == 0 => format!("{} Gbps", bps / 1_000_000_000),
+        Some(bps) if bps % 1_000_000 == 0 => format!("{} Mbps", bps / 1_000_000),
+        Some(bps) if bps % 1_000 == 0 => format!("{} Kbps", bps / 1_000),
+        Some(bps) => format!("{} bps", bps),
+    }
 }
 
 // Add helper methods to Protocol and Direction for cycling
@@ -413,5 +468,57 @@ impl Direction {
             Self::Download => Self::Upload,
             Self::Bidir => Self::Download,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn duration_steps_snap_to_clean_five_second_boundaries() {
+        assert_eq!(duration_next(1), 5);
+        assert_eq!(duration_next(5), 10);
+        assert_eq!(duration_next(11), 15);
+        assert_eq!(duration_next(3599), 3600);
+        assert_eq!(duration_next(3600), 3600);
+
+        assert_eq!(duration_prev(1), 5);
+        assert_eq!(duration_prev(6), 5);
+        assert_eq!(duration_prev(11), 10);
+    }
+
+    #[test]
+    fn bitrate_steps_cycle_and_display() {
+        assert_eq!(bitrate_next(None), Some(1_000_000));
+        assert_eq!(bitrate_next(Some(1_000_000)), Some(10_000_000));
+        assert_eq!(bitrate_prev(None), Some(10_000_000_000));
+        assert_eq!(bitrate_prev(Some(10_000_000)), Some(1_000_000));
+
+        assert_eq!(bitrate_display(None), "unlimited");
+        assert_eq!(bitrate_display(Some(1_000_000)), "1 Mbps");
+        assert_eq!(bitrate_display(Some(10_000_000_000)), "10 Gbps");
+    }
+
+    #[test]
+    fn mark_applied_commits_test_settings_baseline() {
+        let mut settings = SettingsState::new(
+            0,
+            1,
+            Protocol::Tcp,
+            Duration::from_secs(10),
+            Direction::Upload,
+            None,
+        );
+
+        settings.streams = 4;
+        settings.protocol = Protocol::Udp;
+        settings.duration_secs = 15;
+        settings.direction = Direction::Download;
+        settings.bitrate = Some(100_000_000);
+        assert!(settings.test_params_dirty());
+
+        settings.mark_applied();
+        assert!(!settings.test_params_dirty());
     }
 }

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -552,6 +552,8 @@ fn draw_footer(frame: &mut Frame, app: &App, theme: &Theme, area: Rect) {
         Span::styled("] Quit | [", Style::default().fg(theme.text_dim)),
         Span::styled("p", Style::default().fg(theme.accent)),
         Span::styled("] Pause | [", Style::default().fg(theme.text_dim)),
+        Span::styled("r", Style::default().fg(theme.accent)),
+        Span::styled("] Restart | [", Style::default().fg(theme.text_dim)),
         Span::styled("s", Style::default().fg(theme.accent)),
         Span::styled("] Settings | [", Style::default().fg(theme.text_dim)),
         Span::styled("?", Style::default().fg(theme.accent)),
@@ -592,8 +594,8 @@ fn draw_footer(frame: &mut Frame, app: &App, theme: &Theme, area: Rect) {
 }
 
 fn draw_help_overlay(frame: &mut Frame, theme: &Theme, area: Rect) {
-    let help_width = 36;
-    let help_height = 14;
+    let help_width = 40;
+    let help_height = 16;
     let help_area = Rect {
         x: (area.width.saturating_sub(help_width)) / 2,
         y: (area.height.saturating_sub(help_height)) / 2,
@@ -606,6 +608,10 @@ fn draw_help_overlay(frame: &mut Frame, theme: &Theme, area: Rect) {
         Line::from(vec![
             Span::styled("  q", Style::default().fg(theme.accent)),
             Span::styled("  quit", Style::default().fg(theme.text_dim)),
+        ]),
+        Line::from(vec![
+            Span::styled("  r", Style::default().fg(theme.accent)),
+            Span::styled("  restart", Style::default().fg(theme.text_dim)),
         ]),
         Line::from(vec![
             Span::styled("  p", Style::default().fg(theme.accent)),
@@ -691,7 +697,7 @@ fn draw_settings_modal(frame: &mut Frame, app: &App, theme: &Theme, area: Rect) 
 
     // Modal dimensions
     let modal_width = 58u16;
-    let modal_height = 18u16;
+    let modal_height = 19u16;
     let modal_area = Rect {
         x: area.width.saturating_sub(modal_width) / 2,
         y: area.height.saturating_sub(modal_height) / 2,
@@ -834,6 +840,10 @@ fn draw_test_settings(
         ("Protocol:", format!("{}", settings.protocol)),
         ("Duration:", format!("{}s", settings.duration_secs)),
         ("Direction:", format!("{:?}", settings.direction)),
+        (
+            "Bitrate:",
+            super::settings::bitrate_display(settings.bitrate),
+        ),
     ];
 
     draw_setting_items(


### PR DESCRIPTION
## Summary
- add a safe TUI restart lifecycle for the `r` key and Settings -> Test `Apply & Restart`
- apply live test settings for streams, protocol, duration, direction, and bitrate before restarting
- isolate each restarted run with a fresh client task and progress channel after cancelling/draining the previous run
- surface QUIC ignored-option warnings in the TUI history when settings restarts select QUIC
- remove the unused `TuiLoopResult` type and fix benchmark protocol fixtures for all-targets clippy

## Credit
Based on the TUI restart/settings contribution in #101/#102 by @flotpg. The commit includes:

`Co-authored-by: Florian Obradovic <floriano@theprojectgroup.com>`

## Validation
- `cargo fmt --check`
- `cargo check --all-features`
- `cargo test --all-features`
- `cargo test --features discovery,prometheus`
- `cargo clippy --all-features -- -D warnings`
- `cargo clippy --all-targets -- -D warnings`
- `git diff --check`