### PR TITLE
fix(tcp): resume partial regular writes and zero-copy sends from correct offset

### DIFF
--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -150,10 +150,7 @@ fn configure_socket_buffers(stream: &TcpStream, buffer_size: usize) -> std::io::
         );
         if ret != 0 {
             let err = std::io::Error::last_os_error();
-            warn!(
-                "Failed to set SO_SNDBUF to {}: {}",
-                buffer_size, err
-            );
+            warn!("Failed to set SO_SNDBUF to {}: {}", buffer_size, err);
             return Err(err);
         }
 
@@ -166,10 +163,7 @@ fn configure_socket_buffers(stream: &TcpStream, buffer_size: usize) -> std::io::
         );
         if ret != 0 {
             let err = std::io::Error::last_os_error();
-            warn!(
-                "Failed to set SO_RCVBUF to {}: {}",
-                buffer_size, err
-            );
+            warn!("Failed to set SO_RCVBUF to {}: {}", buffer_size, err);
             return Err(err);
         }
     }
@@ -349,10 +343,11 @@ pub fn configure_control_stream(stream: &TcpStream) -> std::io::Result<()> {
 async fn write_chunk(
     stream: &TcpStream,
     buffer: &[u8],
+    offset: usize,
     zerocopy: Option<&ZerocopyPayload>,
 ) -> io::Result<usize> {
     if let Some(payload) = zerocopy {
-        return payload.send_chunk(stream).await;
+        return payload.send_chunk(stream, offset).await;
     }
     stream.writable().await?;
     match stream.try_write(buffer) {
@@ -501,7 +496,7 @@ pub async fn send_data(
                 debug!("Deadline reached during write for stream {}", stats.stream_id);
                 break;
             }
-            r = write_chunk(&stream, &buffer[chunk_offset..], zerocopy.as_ref()) => r,
+            r = write_chunk(&stream, &buffer[chunk_offset..], chunk_offset, zerocopy.as_ref()) => r,
         };
 
         match write_result {
@@ -812,7 +807,7 @@ pub async fn send_data_half(
                 debug!("Deadline reached during write for stream {}", stats.stream_id);
                 break;
             }
-            r = write_chunk(write_half.as_ref(), &buffer[chunk_offset..], zerocopy.as_ref()) => r,
+            r = write_chunk(write_half.as_ref(), &buffer[chunk_offset..], chunk_offset, zerocopy.as_ref()) => r,
         };
 
         match write_result {
@@ -1423,7 +1418,7 @@ mod tests {
         for _ in 0..COUNT {
             let mut chunk_offset = 0;
             while chunk_offset < BUF {
-                let n = write_chunk(&sender, &pattern[chunk_offset..], None)
+                let n = write_chunk(&sender, &pattern[chunk_offset..], chunk_offset, None)
                     .await
                     .expect("write_chunk should not error");
                 chunk_offset += n;
@@ -1432,7 +1427,9 @@ mod tests {
             sent_total += BUF;
         }
 
-        tokio::io::AsyncWriteExt::shutdown(&mut sender).await.unwrap();
+        tokio::io::AsyncWriteExt::shutdown(&mut sender)
+            .await
+            .unwrap();
 
         let received = recv_task.await.expect("receiver task panicked");
         assert_eq!(
@@ -1446,7 +1443,8 @@ mod tests {
         // Verify each chunk is exactly the pattern, with no prefix replay.
         for (i, chunk) in received.chunks_exact(BUF).enumerate() {
             assert_eq!(
-                chunk, pattern.as_slice(),
+                chunk,
+                pattern.as_slice(),
                 "chunk {} does not match pattern; short writes were not resumed correctly",
                 i
             );

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -113,7 +113,6 @@ impl Default for TcpConfig {
 #[cfg(unix)]
 fn configure_socket_buffers(stream: &TcpStream, buffer_size: usize) -> std::io::Result<()> {
     use std::os::unix::io::AsRawFd;
-    use tracing::debug;
 
     // setsockopt SO_SNDBUF/SO_RCVBUF takes a `c_int`. On 64-bit Unix that's i32,
     // so reject out-of-range requests up front — otherwise `as c_int` would wrap
@@ -150,11 +149,12 @@ fn configure_socket_buffers(stream: &TcpStream, buffer_size: usize) -> std::io::
             std::mem::size_of::<libc::c_int>() as libc::socklen_t,
         );
         if ret != 0 {
-            debug!(
+            let err = std::io::Error::last_os_error();
+            warn!(
                 "Failed to set SO_SNDBUF to {}: {}",
-                buffer_size,
-                std::io::Error::last_os_error()
+                buffer_size, err
             );
+            return Err(err);
         }
 
         let ret = libc::setsockopt(
@@ -165,11 +165,12 @@ fn configure_socket_buffers(stream: &TcpStream, buffer_size: usize) -> std::io::
             std::mem::size_of::<libc::c_int>() as libc::socklen_t,
         );
         if ret != 0 {
-            debug!(
+            let err = std::io::Error::last_os_error();
+            warn!(
                 "Failed to set SO_RCVBUF to {}: {}",
-                buffer_size,
-                std::io::Error::last_os_error()
+                buffer_size, err
             );
+            return Err(err);
         }
     }
 
@@ -353,13 +354,19 @@ async fn write_chunk(
     if let Some(payload) = zerocopy {
         return payload.send_chunk(stream).await;
     }
-    loop {
-        stream.writable().await?;
-        match stream.try_write(buffer) {
-            Ok(n) => return Ok(n),
-            Err(e) if e.kind() == io::ErrorKind::WouldBlock => continue,
-            Err(e) => return Err(e),
+    stream.writable().await?;
+    match stream.try_write(buffer) {
+        Ok(0) if !buffer.is_empty() => Err(io::Error::new(
+            io::ErrorKind::WriteZero,
+            "TcpStream::try_write returned 0 for a non-empty buffer",
+        )),
+        Ok(n) => Ok(n),
+        Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
+            // writable() signaled readiness but try_write returned WouldBlock;
+            // treat it as 0 bytes to let the caller retry the same slice.
+            Ok(0)
         }
+        Err(e) => Err(e),
     }
 }
 
@@ -442,6 +449,7 @@ pub async fn send_data(
     let is_infinite = duration == Duration::ZERO;
     let mut pace_start = start;
     let mut pace_bytes_offset: u64 = 0;
+    let mut chunk_offset: usize = 0;
     let mut suppressed_teardown_errors: u32 = 0;
 
     loop {
@@ -493,12 +501,16 @@ pub async fn send_data(
                 debug!("Deadline reached during write for stream {}", stats.stream_id);
                 break;
             }
-            r = write_chunk(&stream, &buffer, zerocopy.as_ref()) => r,
+            r = write_chunk(&stream, &buffer[chunk_offset..], zerocopy.as_ref()) => r,
         };
 
         match write_result {
             Ok(n) => {
                 stats.add_bytes_sent(n as u64);
+                chunk_offset += n;
+                if chunk_offset >= buffer.len() {
+                    chunk_offset = 0;
+                }
                 // Pace sends to target bitrate using byte-budget approach
                 // Skip userspace pacing when kernel pacing is active
                 if !kernel_pacing
@@ -578,7 +590,7 @@ pub async fn send_data(
 
     // Capture final TCP_INFO for retransmit count and RTT
     let tcp_info = get_stream_tcp_info(&stream);
-    if let Some(ref info) = tcp_info {
+    if let Some(info) = &tcp_info {
         stats.add_retransmits(info.retransmits);
         clamp_bytes_sent_to_acked(&stats, info);
     }
@@ -754,6 +766,7 @@ pub async fn send_data_half(
     let is_infinite = duration == Duration::ZERO;
     let mut pace_start = start;
     let mut pace_bytes_offset: u64 = 0;
+    let mut chunk_offset: usize = 0;
     let mut suppressed_teardown_errors: u32 = 0;
 
     loop {
@@ -799,12 +812,16 @@ pub async fn send_data_half(
                 debug!("Deadline reached during write for stream {}", stats.stream_id);
                 break;
             }
-            r = write_chunk(write_half.as_ref(), &buffer, zerocopy.as_ref()) => r,
+            r = write_chunk(write_half.as_ref(), &buffer[chunk_offset..], zerocopy.as_ref()) => r,
         };
 
         match write_result {
             Ok(n) => {
                 stats.add_bytes_sent(n as u64);
+                chunk_offset += n;
+                if chunk_offset >= buffer.len() {
+                    chunk_offset = 0;
+                }
                 // Pace sends to target bitrate using byte-budget approach
                 // Skip userspace pacing when kernel pacing is active
                 if !kernel_pacing
@@ -877,11 +894,13 @@ pub async fn send_data_half(
         }
     }
 
-    // Clamp bytes_sent to bytes_acked before abortive close (see send_data for rationale).
+    // Capture final TCP_INFO for retransmit count and clamp bytes_sent to
+    // bytes_acked before abortive close (see send_data for rationale).
     // Capture the snapshot so the caller can store it directly — a second post-reunite
     // read would see a later, larger bytes_acked that could exceed the clamped bytes_sent.
     let tcp_info = get_tcp_info(write_half.as_ref()).ok();
-    if let Some(ref info) = tcp_info {
+    if let Some(info) = &tcp_info {
+        stats.add_retransmits(info.retransmits);
         clamp_bytes_sent_to_acked(&stats, info);
     }
 
@@ -1357,5 +1376,87 @@ mod tests {
         assert!(result.is_err());
         let msg = result.unwrap_err();
         assert!(msg.contains("not available"), "unexpected error: {}", msg);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn write_chunk_resumes_short_writes_without_buffer_replay() {
+        // Regression test for the regular-write path: write_chunk returns short
+        // counts, so callers must offset into the buffer. Without that offset,
+        // a short write would cause the next call to replay the prefix and
+        // corrupt the byte stream.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let mut sender = tokio::net::TcpStream::connect(addr).await.unwrap();
+        let (receiver, _) = listener.accept().await.unwrap();
+        let (mut recv_read, _) = receiver.into_split();
+
+        // Force small send buffers so try_write can only queue a few bytes at a
+        // time; this reliably produces short writes on loopback.
+        #[cfg(unix)]
+        configure_socket_buffers(&sender, 512).unwrap();
+
+        const BUF: usize = 4096;
+        const HALF: usize = BUF / 2;
+        const COUNT: usize = 4;
+
+        // Two-tone pattern: first half zeros, second half 0xFF. Any replay of
+        // the zero-prefix would extend the first-half run beyond HALF bytes.
+        let pattern: Vec<u8> = (0..BUF)
+            .map(|i| if i < HALF { 0x00 } else { 0xFF })
+            .collect();
+
+        let recv_task = tokio::spawn(async move {
+            let mut received = Vec::with_capacity(COUNT * BUF);
+            let mut tmp = [0u8; 1024];
+            loop {
+                match recv_read.read(&mut tmp).await {
+                    Ok(0) => break,
+                    Ok(n) => received.extend_from_slice(&tmp[..n]),
+                    Err(_) => break,
+                }
+            }
+            received
+        });
+
+        let mut sent_total = 0;
+        for _ in 0..COUNT {
+            let mut chunk_offset = 0;
+            while chunk_offset < BUF {
+                let n = write_chunk(&sender, &pattern[chunk_offset..], None)
+                    .await
+                    .expect("write_chunk should not error");
+                chunk_offset += n;
+                assert!(chunk_offset <= BUF);
+            }
+            sent_total += BUF;
+        }
+
+        tokio::io::AsyncWriteExt::shutdown(&mut sender).await.unwrap();
+
+        let received = recv_task.await.expect("receiver task panicked");
+        assert_eq!(
+            received.len(),
+            sent_total,
+            "received {} bytes but sent {}",
+            received.len(),
+            sent_total
+        );
+
+        // Verify each chunk is exactly the pattern, with no prefix replay.
+        for (i, chunk) in received.chunks_exact(BUF).enumerate() {
+            assert_eq!(
+                chunk, pattern.as_slice(),
+                "chunk {} does not match pattern; short writes were not resumed correctly",
+                i
+            );
+        }
+
+        // Also ensure every byte boundary is a multiple of BUF.
+        assert_eq!(
+            received.len() % BUF,
+            0,
+            "received length is not a multiple of the buffer size"
+        );
     }
 }

--- a/src/zerocopy.rs
+++ b/src/zerocopy.rs
@@ -15,6 +15,8 @@
 //! `ErrorKind::Unsupported` and callers fall back to regular writes.
 
 use std::io;
+#[cfg(target_os = "linux")]
+use std::os::unix::io::AsRawFd;
 use tokio::net::TcpStream;
 
 /// A fixed payload backed by a memfd, sent repeatedly with `sendfile(2)`.
@@ -91,15 +93,28 @@ impl ZerocopyPayload {
         self.len == 0
     }
 
-    /// One non-blocking `sendfile(2)` of the payload from offset 0.
-    /// Partial sends are fine — the caller counts whatever was queued,
-    /// matching `write(2)` semantics on the regular path.
+    /// One non-blocking `sendfile(2)` starting from `offset`. Returns the
+    /// number of bytes queued by this call (not the new absolute offset).
+    /// `offset` is updated by the kernel to the next byte position.
     #[cfg(target_os = "linux")]
-    fn sendfile_once(&self, socket_fd: std::os::unix::io::RawFd) -> io::Result<usize> {
-        use std::os::unix::io::AsRawFd;
-
-        let mut offset: libc::off_t = 0;
-        let n = unsafe { libc::sendfile(socket_fd, self.file.as_raw_fd(), &mut offset, self.len) };
+    fn sendfile_once(
+        &self,
+        socket_fd: std::os::unix::io::RawFd,
+        offset: &mut libc::off_t,
+    ) -> io::Result<usize> {
+        let start = *offset as usize;
+        let remaining = self.len.saturating_sub(start);
+        if remaining == 0 {
+            return Ok(0);
+        }
+        let n = unsafe {
+            libc::sendfile(
+                socket_fd,
+                self.file.as_raw_fd(),
+                offset,
+                remaining,
+            )
+        };
         if n < 0 {
             Err(io::Error::last_os_error())
         } else {
@@ -107,19 +122,32 @@ impl ZerocopyPayload {
         }
     }
 
-    /// Send one payload chunk on `stream` via sendfile, awaiting socket
-    /// writability. Cancel-safe: dropping the future mid-await sends
-    /// nothing; a completed sendfile returns synchronously.
+    /// Send one whole payload chunk on `stream` via sendfile, awaiting socket
+    /// writability and resuming from partial sends so the caller always
+    /// transmits the full payload. Each call resets to offset 0, so repeated
+    /// calls send the same bytes — matching the regular path's reused buffer.
     #[cfg(target_os = "linux")]
     pub async fn send_chunk(&self, stream: &TcpStream) -> io::Result<usize> {
-        use std::os::unix::io::AsRawFd;
         use tokio::io::Interest;
 
         let socket_fd = stream.as_raw_fd();
+        let mut offset: libc::off_t = 0;
         loop {
             stream.writable().await?;
-            match stream.try_io(Interest::WRITABLE, || self.sendfile_once(socket_fd)) {
-                Ok(n) => return Ok(n),
+            match stream.try_io(Interest::WRITABLE, || {
+                let n = self.sendfile_once(socket_fd, &mut offset)?;
+                if n == 0 && (offset as usize) < self.len {
+                    // sendfile returned zero bytes while payload remains;
+                    // treat it as spurious readiness rather than spinning.
+                    return Err(io::Error::new(
+                        io::ErrorKind::WouldBlock,
+                        "sendfile returned zero bytes with payload remaining",
+                    ));
+                }
+                Ok(n)
+            }) {
+                Ok(_) if offset as usize >= self.len => return Ok(offset as usize),
+                Ok(_) => continue,
                 // Spurious readiness or send buffer refilled between
                 // writable() and sendfile — wait again.
                 Err(e) if e.kind() == io::ErrorKind::WouldBlock => continue,

--- a/src/zerocopy.rs
+++ b/src/zerocopy.rs
@@ -93,28 +93,20 @@ impl ZerocopyPayload {
         self.len == 0
     }
 
-    /// One non-blocking `sendfile(2)` starting from `offset`. Returns the
-    /// number of bytes queued by this call (not the new absolute offset).
-    /// `offset` is updated by the kernel to the next byte position.
+    /// One non-blocking `sendfile(2)` call starting from `offset`.
+    /// Returns the number of bytes queued by this call.
     #[cfg(target_os = "linux")]
     fn sendfile_once(
         &self,
         socket_fd: std::os::unix::io::RawFd,
-        offset: &mut libc::off_t,
+        offset: usize,
     ) -> io::Result<usize> {
-        let start = *offset as usize;
-        let remaining = self.len.saturating_sub(start);
+        let remaining = self.len.saturating_sub(offset);
         if remaining == 0 {
             return Ok(0);
         }
-        let n = unsafe {
-            libc::sendfile(
-                socket_fd,
-                self.file.as_raw_fd(),
-                offset,
-                remaining,
-            )
-        };
+        let mut off = offset as libc::off_t;
+        let n = unsafe { libc::sendfile(socket_fd, self.file.as_raw_fd(), &mut off, remaining) };
         if n < 0 {
             Err(io::Error::last_os_error())
         } else {
@@ -122,42 +114,25 @@ impl ZerocopyPayload {
         }
     }
 
-    /// Send one whole payload chunk on `stream` via sendfile, awaiting socket
-    /// writability and resuming from partial sends so the caller always
-    /// transmits the full payload. Each call resets to offset 0, so repeated
-    /// calls send the same bytes — matching the regular path's reused buffer.
+    /// Send one payload slice starting from `offset` on `stream` via sendfile,
+    /// awaiting socket writability. Returns the short count queued by the
+    /// kernel; the caller owns the offset and resumes from `offset + n`,
+    /// mirroring the regular `try_send` path.
     #[cfg(target_os = "linux")]
-    pub async fn send_chunk(&self, stream: &TcpStream) -> io::Result<usize> {
+    pub async fn send_chunk(&self, stream: &TcpStream, offset: usize) -> io::Result<usize> {
         use tokio::io::Interest;
 
         let socket_fd = stream.as_raw_fd();
-        let mut offset: libc::off_t = 0;
-        loop {
-            stream.writable().await?;
-            match stream.try_io(Interest::WRITABLE, || {
-                let n = self.sendfile_once(socket_fd, &mut offset)?;
-                if n == 0 && (offset as usize) < self.len {
-                    // sendfile returned zero bytes while payload remains;
-                    // treat it as spurious readiness rather than spinning.
-                    return Err(io::Error::new(
-                        io::ErrorKind::WouldBlock,
-                        "sendfile returned zero bytes with payload remaining",
-                    ));
-                }
-                Ok(n)
-            }) {
-                Ok(_) if offset as usize >= self.len => return Ok(offset as usize),
-                Ok(_) => continue,
-                // Spurious readiness or send buffer refilled between
-                // writable() and sendfile — wait again.
-                Err(e) if e.kind() == io::ErrorKind::WouldBlock => continue,
-                Err(e) => return Err(e),
-            }
+        stream.writable().await?;
+        match stream.try_io(Interest::WRITABLE, || self.sendfile_once(socket_fd, offset)) {
+            Ok(n) => Ok(n),
+            Err(e) if e.kind() == io::ErrorKind::WouldBlock => Ok(0),
+            Err(e) => Err(e),
         }
     }
 
     #[cfg(not(target_os = "linux"))]
-    pub async fn send_chunk(&self, _stream: &TcpStream) -> io::Result<usize> {
+    pub async fn send_chunk(&self, _stream: &TcpStream, _offset: usize) -> io::Result<usize> {
         Err(io::Error::new(
             io::ErrorKind::Unsupported,
             "zero-copy sends require Linux sendfile(2)",
@@ -198,8 +173,14 @@ mod tests {
 
         // Send the chunk twice to verify the offset resets per call.
         let mut queued = 0usize;
+        let mut chunk_offset = 0usize;
         while queued < pattern.len() * 2 {
-            queued += payload.send_chunk(&sender).await.unwrap();
+            let n = payload.send_chunk(&sender, chunk_offset).await.unwrap();
+            chunk_offset += n;
+            queued += n;
+            if chunk_offset >= pattern.len() {
+                chunk_offset = 0;
+            }
         }
         drop(sender);
 
@@ -227,8 +208,14 @@ mod tests {
         const TARGET: usize = 8 * 1024 * 1024; // well past any send buffer
         let send_task = tokio::spawn(async move {
             let mut queued = 0usize;
+            let mut chunk_offset = 0usize;
             while queued < TARGET {
-                queued += payload.send_chunk(&sender).await.unwrap();
+                let n = payload.send_chunk(&sender, chunk_offset).await.unwrap();
+                chunk_offset += n;
+                queued += n;
+                if chunk_offset >= pattern.len() {
+                    chunk_offset = 0;
+                }
             }
             queued
         });


### PR DESCRIPTION
## What changed

- **Regular TCP writes**: `write_chunk()` returns the short count from a single `try_write()`, and `send_data()` / `send_data_half()` now own a `chunk_offset` so partial sends resume where they left off instead of replaying the buffer prefix.
- **Zero-copy sends**: `ZerocopyPayload::send_chunk()` is now one-shot: it performs a single `sendfile(2)` from the caller-supplied offset and returns the bytes queued. The caller (the same `chunk_offset` logic) resumes from `offset + n`. This keeps cancellation/accounting consistent with the regular write path.
- **Socket buffer configuration**: `configure_socket_buffers()` now returns its `setsockopt` failures so callers can decide what to log, while still defaulting to kernel autotune.
- **Bidir stats**: `send_data_half()` now records final `tcp_info.retransmits`, matching `send_data()`.

## Regression tests

- Added `write_chunk_resumes_short_writes_without_buffer_replay` in `src/tcp.rs`. It forces small send buffers to produce short writes and verifies the receiver sees the exact buffer pattern repeated with no prefix duplication.
- Updated `src/zerocopy.rs` tests to track `chunk_offset` and reset per full payload, confirming one-shot zero-copy sends repeat correctly.

## Validation

```bash
cargo clippy --all-targets --features prometheus -- -D warnings
cargo test --features prometheus
```

- 314 tests passed, 1 ignored, clippy clean.
