### PR TITLE
fix(server,stats,diff): aggregate final TCP info, round RTT averages, flag zero-baseline regressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Server final TCP_INFO now aggregates all TCP streams** — previously the server's final `TestResult.tcp_info` was built from the last snapshot stored in the legacy `TestStats.tcp_info` vector, which could reflect a single stream or a pre-test snapshot. The server now saves each data socket's final `TcpInfoSnapshot` on its per-stream `StreamStats` and uses `TestStats::final_local_tcp_info()` for the final result, matching the client path. (LAN-155)
+- **TCP RTT averages no longer truncate fractional microseconds** — `TestStats::poll_local_tcp_info()` and `TestStats::final_local_tcp_info()` computed RTT averages with integer division, silently dropping fractional microseconds. They now use floating-point division with `.round()`, so e.g. averaging 100 µs and 101 µs reports 101 µs instead of 100 µs. (LAN-164)
+- **Diff zero baselines now register as regressions** — when the baseline reported zero retransmits or zero RTT and the current run reported a nonzero value, `xfr --diff` returned a 0.0 % change and `Verdict: OK`, masking a real regression. The change percent is now `+inf%`, `is_regression` now considers retransmit and RTT increases against the configured threshold, and the plain-text summary flags the line as `[FAIL]`/`[WARN]`. (LAN-162)
+
 ## [0.9.20] - 2026-06-23
 
 ### Security

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -105,6 +105,7 @@ pub fn compare(baseline: TestResult, current: TestResult, config: &DiffConfig) -
         (Some(b), Some(c)) if b.retransmits > 0 => {
             ((c.retransmits as f64 - b.retransmits as f64) / b.retransmits as f64) * 100.0
         }
+        (Some(b), Some(c)) if b.retransmits == 0 && c.retransmits > 0 => f64::INFINITY,
         _ => 0.0,
     };
 
@@ -112,10 +113,13 @@ pub fn compare(baseline: TestResult, current: TestResult, config: &DiffConfig) -
         (Some(b), Some(c)) if b.rtt_us > 0 => {
             ((c.rtt_us as f64 - b.rtt_us as f64) / b.rtt_us as f64) * 100.0
         }
+        (Some(b), Some(c)) if b.rtt_us == 0 && c.rtt_us > 0 => f64::INFINITY,
         _ => 0.0,
     };
 
-    let is_regression = throughput_change_percent < -config.threshold_percent;
+    let is_regression = throughput_change_percent < -config.threshold_percent
+        || retransmit_change_percent > config.threshold_percent
+        || rtt_change_percent > config.threshold_percent;
 
     DiffResult {
         baseline,
@@ -201,5 +205,61 @@ mod tests {
         );
         assert!(diff.is_regression);
         assert!(diff.throughput_change_percent < -10.0);
+    }
+
+    #[test]
+    fn test_zero_baseline_retransmits_flagged() {
+        let baseline = make_result(1000.0, 0, 1000);
+        let current = make_result(1000.0, 20, 1000);
+
+        let diff = compare(
+            baseline,
+            current,
+            &DiffConfig {
+                threshold_percent: 5.0,
+            },
+        );
+        assert!(diff.is_regression);
+        assert!(diff.retransmit_change_percent.is_infinite());
+        assert!(diff.retransmit_change_percent.is_sign_positive());
+        let output = diff.format_plain();
+        assert!(
+            output.contains("+inf%"),
+            "expected +inf% output, got: {}",
+            output
+        );
+        assert!(
+            output.contains("[FAIL]"),
+            "expected [FAIL] for retransmits, got: {}",
+            output
+        );
+    }
+
+    #[test]
+    fn test_zero_baseline_rtt_flagged() {
+        let baseline = make_result(1000.0, 10, 0);
+        let current = make_result(1000.0, 10, 500);
+
+        let diff = compare(
+            baseline,
+            current,
+            &DiffConfig {
+                threshold_percent: 5.0,
+            },
+        );
+        assert!(diff.is_regression);
+        assert!(diff.rtt_change_percent.is_infinite());
+        assert!(diff.rtt_change_percent.is_sign_positive());
+        let output = diff.format_plain();
+        assert!(
+            output.contains("+inf%"),
+            "expected +inf% output, got: {}",
+            output
+        );
+        assert!(
+            output.contains("[WARN]"),
+            "expected [WARN] for rtt, got: {}",
+            output
+        );
     }
 }

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -2637,7 +2637,7 @@ async fn run_test(
         duration_ms,
         throughput_mbps,
         streams: stream_results,
-        tcp_info: stats.get_tcp_info(),
+        tcp_info: stats.final_local_tcp_info(),
         udp_stats: stats.aggregate_udp_stats(),
         bytes_sent,
         bytes_received,
@@ -2799,7 +2799,10 @@ async fn spawn_tcp_handlers(
                 Direction::Upload => {
                     // Server receives data
                     match tcp::receive_data(stream, stream_stats.clone(), cancel, config).await {
-                        Ok(Some(info)) => test_stats.add_tcp_info(info),
+                        Ok(Some(info)) => {
+                            stream_stats.set_final_tcp_info(info.clone());
+                            test_stats.add_tcp_info(info);
+                        }
                         Ok(None) => {}
                         Err(e) => tracing::warn!("Stream {} receive error: {}", i, e),
                     }
@@ -2817,7 +2820,10 @@ async fn spawn_tcp_handlers(
                     )
                     .await
                     {
-                        Ok(Some(info)) => test_stats.add_tcp_info(info),
+                        Ok(Some(info)) => {
+                            stream_stats.set_final_tcp_info(info.clone());
+                            test_stats.add_tcp_info(info);
+                        }
                         Ok(None) => {}
                         Err(e) => tracing::warn!("Stream {} send error: {}", i, e),
                     }
@@ -2876,6 +2882,7 @@ async fn spawn_tcp_handlers(
                     {
                         if let Some(info) = send_tcp_info {
                             final_stats.add_retransmits(info.retransmits);
+                            stream_stats.set_final_tcp_info(info.clone());
                             test_stats.add_tcp_info(info);
                         }
                         let _ = read_half.reunite(write_half);
@@ -3007,7 +3014,10 @@ async fn spawn_tcp_stream_handlers(
                             match tcp::receive_data(stream, stream_stats.clone(), cancel, config)
                                 .await
                             {
-                                Ok(Some(info)) => test_stats.add_tcp_info(info),
+                                Ok(Some(info)) => {
+                                    stream_stats.set_final_tcp_info(info.clone());
+                                    test_stats.add_tcp_info(info);
+                                }
                                 Ok(None) => {}
                                 Err(e) => tracing::warn!("Stream {} receive error: {}", i, e),
                             }
@@ -3024,7 +3034,10 @@ async fn spawn_tcp_stream_handlers(
                             )
                             .await
                             {
-                                Ok(Some(info)) => test_stats.add_tcp_info(info),
+                                Ok(Some(info)) => {
+                                    stream_stats.set_final_tcp_info(info.clone());
+                                    test_stats.add_tcp_info(info);
+                                }
                                 Ok(None) => {}
                                 Err(e) => tracing::warn!("Stream {} send error: {}", i, e),
                             }
@@ -3075,6 +3088,7 @@ async fn spawn_tcp_stream_handlers(
                             {
                                 if let Some(info) = send_tcp_info {
                                     final_stats.add_retransmits(info.retransmits);
+                                    stream_stats.set_final_tcp_info(info.clone());
                                     test_stats.add_tcp_info(info);
                                 }
                                 let _ = read_half.reunite(write_half);

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -483,10 +483,8 @@ impl TestStats {
         let avg_rtt = if rtt_values.is_empty() {
             None
         } else {
-            Some(
-                (rtt_values.iter().map(|&r| r as u64).sum::<u64>() / rtt_values.len() as u64)
-                    as u32,
-            )
+            let rtt_sum = rtt_values.iter().map(|&r| r as u64).sum::<u64>();
+            Some((rtt_sum as f64 / rtt_values.len() as f64).round() as u32)
         };
 
         // Sum cwnd across streams (total sending capacity)
@@ -563,7 +561,10 @@ impl TestStats {
                 count += 1;
             }
         }
-        (rtt_sum.checked_div(count)).map(|avg_rtt| (avg_rtt as u32, retransmits, cwnd))
+        (count > 0).then(|| {
+            let avg_rtt = (rtt_sum as f64 / count as f64).round() as u32;
+            (avg_rtt, retransmits, cwnd)
+        })
     }
 
     /// Get final TCP_INFO across all streams, using saved snapshots from completed tasks.
@@ -589,12 +590,15 @@ impl TestStats {
                 count += 1;
             }
         }
-        rtt_sum.checked_div(count).map(|avg_rtt| {
-            let avg_rtt_var = rtt_var_sum / count; // safe: checked_div confirmed count > 0
+        rtt_sum.checked_div(count).map(|_| {
+            // Use float division and round so fractional microseconds are not
+            // silently truncated by integer division (e.g. avg of 100 and 101).
+            let avg_rtt = (rtt_sum as f64 / count as f64).round() as u32;
+            let avg_rtt_var = (rtt_var_sum as f64 / count as f64).round() as u32;
             TcpInfoSnapshot {
                 retransmits,
-                rtt_us: avg_rtt as u32,
-                rtt_var_us: avg_rtt_var as u32,
+                rtt_us: avg_rtt,
+                rtt_var_us: avg_rtt_var,
                 cwnd,
                 bytes_acked: if any_bytes_acked {
                     Some(bytes_acked_sum)
@@ -722,6 +726,100 @@ mod tests {
         assert_eq!(info.rtt_us, 2000);
         assert_eq!(info.rtt_var_us, 400);
         assert_eq!(info.cwnd, 96 * 1024);
+    }
+
+    #[test]
+    fn test_final_local_tcp_info_uses_all_streams_not_last() {
+        let stats = TestStats::new("test".to_string(), 2);
+
+        stats.streams[0].set_final_tcp_info(TcpInfoSnapshot {
+            retransmits: 3,
+            rtt_us: 1000,
+            rtt_var_us: 200,
+            cwnd: 32 * 1024,
+            bytes_acked: None,
+        });
+        // Last stream has zero RTT/no retransmits - make sure the aggregate is not
+        // driven by this last snapshot.
+        stats.streams[1].set_final_tcp_info(TcpInfoSnapshot {
+            retransmits: 0,
+            rtt_us: 0,
+            rtt_var_us: 0,
+            cwnd: 64 * 1024,
+            bytes_acked: None,
+        });
+
+        let info = stats
+            .final_local_tcp_info()
+            .expect("missing aggregated final tcp info");
+        assert_eq!(info.retransmits, 3);
+        assert_eq!(info.rtt_us, 500);
+        assert_eq!(info.rtt_var_us, 100);
+    }
+
+    #[test]
+    fn test_final_local_tcp_info_rounds_fractional_averages() {
+        let stats = TestStats::new("test".to_string(), 2);
+
+        stats.streams[0].set_final_tcp_info(TcpInfoSnapshot {
+            retransmits: 0,
+            rtt_us: 100,
+            rtt_var_us: 201,
+            cwnd: 32 * 1024,
+            bytes_acked: None,
+        });
+        stats.streams[1].set_final_tcp_info(TcpInfoSnapshot {
+            retransmits: 0,
+            rtt_us: 101,
+            rtt_var_us: 201,
+            cwnd: 64 * 1024,
+            bytes_acked: None,
+        });
+
+        let info = stats
+            .final_local_tcp_info()
+            .expect("missing aggregated final tcp info");
+        assert_eq!(info.rtt_us, 101);
+        assert_eq!(info.rtt_var_us, 201);
+    }
+
+    #[test]
+    fn test_aggregate_interval_rtt_rounds_fractional_average() {
+        let stats = TestStats::new("test".to_string(), 2);
+        let now = Instant::now();
+        let intervals = vec![
+            IntervalStats {
+                timestamp: now,
+                bytes: 0,
+                throughput_mbps: 0.0,
+                retransmits: 0,
+                jitter_ms: 0.0,
+                lost: 0,
+                rtt_us: Some(100),
+                cwnd: Some(32 * 1024),
+                bytes_sent: 0,
+                bytes_received: 0,
+                cumulative_packets_received: 0,
+                cumulative_packets_lost: 0,
+            },
+            IntervalStats {
+                timestamp: now,
+                bytes: 0,
+                throughput_mbps: 0.0,
+                retransmits: 0,
+                jitter_ms: 0.0,
+                lost: 0,
+                rtt_us: Some(101),
+                cwnd: Some(64 * 1024),
+                bytes_sent: 0,
+                bytes_received: 0,
+                cumulative_packets_received: 0,
+                cumulative_packets_lost: 0,
+            },
+        ];
+
+        let aggregate = stats.to_aggregate(&intervals);
+        assert_eq!(aggregate.rtt_us, Some(101));
     }
 
     #[test]


### PR DESCRIPTION
Fixes three related result/stat-correctness bugs where server-side final TCP info, RTT averaging, and diff-mode zero-baseline handling produced misleading or wrong numbers.

## LAN-155: Server final `tcp_info` now aggregates per-stream snapshots

The server's final `TestResult.tcp_info` was built from `TestStats::get_tcp_info()`, which simply returns the last snapshot pushed into a shared vector. Depending on stream completion order and direction, this could be a pre-test snapshot, a single stream's snapshot, or an aggregated value from some streams -- but never consistently all of them.

Now every TCP data path (legacy multi-port, single-port, upload/download/bidirectional) saves the final `TcpInfoSnapshot` returned by the data functions onto its per-stream `StreamStats` via `set_final_tcp_info()`. The final `TestResult` is built with `TestStats::final_local_tcp_info()`, which averages saved snapshots across all streams. This matches the existing client-side path.

## LAN-164: RTT averages no longer truncate fractional microseconds

`TestStats::poll_local_tcp_info()` and `TestStats::final_local_tcp_info()` computed average RTT with integer division (`rtt_sum / count`). This silently discarded fractional microseconds, e.g. averaging 100 and 101 returned 100 instead of 101.

Both helpers now use floating-point division with `.round()` before casting back to `u32`.

## LAN-162: Diff mode now flags zero-baseline retransmit/RTT regressions

When the baseline reported zero retransmits or zero RTT and the current run reported a nonzero value, `xfr --diff` returned `0.0%` and `Verdict: OK`, completely masking a real regression.

`diff.rs` now emits `+inf%` for baseline-zero nonzero-current cases, includes retransmit and RTT increases in `is_regression`, and `format_plain()` flags the line with `[FAIL]`/`[WARN]` as appropriate.

## Tests

- Added tests for multi-stream final TCP info aggregation (last stream zero does not dominate the aggregate).
- Added tests for fractional RTT averaging rounding.
- Added tests for zero-baseline retransmit and RTT diff regressions, including `[FAIL]`/`[WARN]` flag verification.

Local verification:
- `cargo fmt --check`
- `cargo test --all-features` (320 passed, 1 ignored)
- `cargo clippy --all-features -- -D warnings`
- `cargo clippy --all-targets --features prometheus -- -D warnings`
