### PR TITLE
fix(auth,serve,cli): LAN-158 + LAN-171 security hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,6 +523,11 @@ xfr serve --psk "secretkey"
 xfr <host> -Q --psk "secretkey"
 ```
 
+> **Security note:** `--psk` and the `XFR_PSK` environment variable expose the
+> key through process metadata such as `ps`, shell history, and
+> `/proc/<pid>/environ`. For production deployments, store the key in a file
+> readable only by the owner and use `--psk-file` instead.
+
 ### Network Considerations
 
 - **Single-port TCP**: TCP uses single-port mode by default -- control and data connections share port 5201. Data connections are validated against the control connection's IP address, preventing unauthorized access.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -461,6 +461,10 @@ xfr <host> --psk mysecretkey
 
 Authentication uses HMAC-SHA256 challenge-response.
 
+> **Security note:** Values supplied via `--psk` or the `XFR_PSK` environment
+> variable are visible through process metadata (`ps`, `/proc/<pid>/environ`,
+> shell history). Prefer `--psk-file` with a file readable only by the owner.
+
 ### Duration Limits
 
 Limit maximum test duration server-side:

--- a/docs/SCRIPTING.md
+++ b/docs/SCRIPTING.md
@@ -465,6 +465,11 @@ export XFR_PUSH_GATEWAY=http://pushgateway:9091  # Push gateway URL (serve only)
 export XFR_TIMESTAMP_FORMAT=iso8601  # Timestamp format (--timestamp-format)
 ```
 
+> **Security note:** `XFR_PSK` is exported to the process environment and is
+> visible to other users through `/proc/<pid>/environ` and process listings.
+> Where possible, store the key in a file with owner-only permissions and use
+> `--psk-file` instead.
+
 ## Tips for Automation
 
 1. **Always use `--no-tui`** in scripts -- prevents terminal escape codes in output

--- a/docs/xfr.1
+++ b/docs/xfr.1
@@ -90,7 +90,7 @@ Log file path (e.g., ~/.config/xfr/xfr.log)
 Log level: error, warn, info, debug, trace
 .TP
 .BI \-\-psk " KEY"
-Pre-shared key for server authentication. Environment: XFR_PSK
+Pre-shared key for server authentication. Environment: XFR_PSK. Values supplied via \fB\-\-psk\fR or \fBXFR_PSK\fR may be visible through process metadata; prefer \fB\-\-psk\-file\fR.
 .TP
 .BI \-\-psk\-file " FILE"
 Read PSK from file
@@ -157,10 +157,13 @@ Log file path
 Log level: error, warn, info, debug, trace
 .TP
 .BI \-\-psk " KEY"
-Pre-shared key for authentication. Environment: XFR_PSK
+Pre-shared key for authentication. Environment: XFR_PSK. Values supplied via \fB\-\-psk\fR or \fBXFR_PSK\fR may be visible through process metadata; prefer \fB\-\-psk\-file\fR.
 .TP
 .BI \-\-psk\-file " FILE"
 Read PSK from file
+.TP
+.BI \-\-preset " NAME"
+Use a named server preset from the config file. Preset \fBallowed_clients\fR entries, if present, are enforced as an additional allowlist together with the normal ACL.
 .TP
 .BI \-\-rate\-limit " N"
 Max concurrent tests per IP

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -35,20 +35,46 @@ pub fn verify_response(nonce: &str, psk: &str, response: &str) -> bool {
     constant_time_eq(expected.as_bytes(), response.as_bytes())
 }
 
-/// Constant-time comparison to prevent timing attacks
+/// Constant-time comparison to prevent timing attacks.
+///
+/// Padding to the length of the longer input avoids the early-return that
+/// would otherwise leak whether the two slices have different lengths. The
+/// length difference is folded into the accumulator so that trailing zero
+/// bytes do not accidentally produce equality.
 fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
-    if a.len() != b.len() {
-        return false;
-    }
+    let len = a.len().max(b.len());
     let mut result = 0u8;
-    for (x, y) in a.iter().zip(b.iter()) {
+    for i in 0..len {
+        let x = a.get(i).unwrap_or(&0);
+        let y = b.get(i).unwrap_or(&0);
         result |= x ^ y;
     }
+    // Fold any length mismatch into the result so `b"x"` and `b"x\0"` are
+    // not reported as equal.
+    result |= (a.len() != b.len()) as u8;
     result == 0
 }
 
-/// Read PSK from file, trimming whitespace
+/// Read PSK from file, trimming whitespace.
+///
+/// On Unix, rejects files that are readable or writable by anyone other than
+/// the owner (mode bits for group/other are set), because such permissions
+/// would let other users on the host read the pre-shared key.
 pub fn read_psk_file(path: &std::path::Path) -> anyhow::Result<String> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        let metadata = std::fs::metadata(path)?;
+        let mode = metadata.mode() & 0o777;
+        if mode & 0o077 != 0 {
+            anyhow::bail!(
+                "PSK file {:?} has overly broad permissions ({:03o}): group/other access is not allowed",
+                path,
+                mode
+            );
+        }
+    }
+
     let content = std::fs::read_to_string(path)?;
     let psk = content.trim().to_string();
     validate_psk(&psk)?;
@@ -133,6 +159,49 @@ mod tests {
         assert!(constant_time_eq(b"hello", b"hello"));
         assert!(!constant_time_eq(b"hello", b"world"));
         assert!(!constant_time_eq(b"hello", b"hell"));
+
+        // Same value padded with a zero byte should compare unequal without
+        // short-circuiting on length.
+        let left = b"secret";
+        let mut right = b"secret".to_vec();
+        right.push(0);
+        assert!(!constant_time_eq(left, &right));
+
+        // Comparing an empty slice to a non-empty slice should return false.
+        assert!(!constant_time_eq(b"", b"x"));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_read_psk_file_rejects_group_or_other_readable() {
+        use std::fs;
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("leaky.psk");
+        fs::write(&path, "super-secret-key").unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o644)).unwrap();
+
+        let err = read_psk_file(&path).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("overly broad permissions"),
+            "error should flag permissions: {}",
+            msg
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_read_psk_file_accepts_owner_only_permissions() {
+        use std::fs;
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("secure.psk");
+        fs::write(&path, "owner-only-key\n").unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o600)).unwrap();
+
+        let psk = read_psk_file(&path).unwrap();
+        assert_eq!(psk, "owner-only-key");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ use crossterm::terminal::{
 use ratatui::Terminal;
 use ratatui::backend::CrosstermBackend;
 use tokio::sync::mpsc;
-use tracing::info;
+use tracing::{info, warn};
 use tracing_subscriber::EnvFilter;
 
 use xfr::client::{Client, ClientConfig, TestProgress, ZerocopyMode};
@@ -254,7 +254,11 @@ struct Cli {
     #[arg(long, env = "XFR_LOG_LEVEL")]
     log_level: Option<String>,
 
-    /// Pre-shared key for server authentication
+    /// Pre-shared key for authentication.
+    ///
+    /// WARNING: values supplied via `--psk` or the `XFR_PSK` environment
+    /// variable are visible to other users through process metadata such as
+    /// `ps`, shell history, and `/proc/<pid>/environ`. Prefer `--psk-file`.
     #[arg(long, env = "XFR_PSK")]
     psk: Option<String>,
 
@@ -357,13 +361,24 @@ enum Commands {
         #[arg(long, env = "XFR_LOG_LEVEL")]
         log_level: Option<String>,
 
-        /// Pre-shared key for authentication
+        /// Pre-shared key for authentication.
+        ///
+        /// WARNING: values supplied via `--psk` or the `XFR_PSK` environment
+        /// variable are visible to other users through process metadata such as
+        /// `ps`, shell history, and `/proc/<pid>/environ`. Prefer `--psk-file`.
         #[arg(long, env = "XFR_PSK")]
         psk: Option<String>,
 
         /// Read PSK from file
         #[arg(long)]
         psk_file: Option<PathBuf>,
+
+        /// Use a named server preset from the config file.
+        ///
+        /// Preset `allowed_clients` (if any) become an additional allowlist
+        /// enforced with the normal ACL. Unknown presets are rejected.
+        #[arg(long)]
+        preset: Option<String>,
 
         /// Max concurrent tests per IP (rate limiting)
         #[arg(long)]
@@ -774,6 +789,7 @@ async fn main() -> Result<()> {
             log_level: _serve_log_level,
             psk,
             psk_file,
+            preset,
             rate_limit,
             rate_limit_window,
             allow,
@@ -802,13 +818,35 @@ async fn main() -> Result<()> {
             let effective_psk = if let Some(psk_path) = psk_file {
                 Some(xfr::auth::read_psk_file(&psk_path)?)
             } else {
-                psk.or_else(|| file_config.server.psk.clone())
+                psk.as_ref()
+                    .cloned()
+                    .or_else(|| file_config.server.psk.clone())
             };
 
             // Validate PSK if provided
             if let Some(ref psk_value) = effective_psk {
                 xfr::auth::validate_psk(psk_value)?;
             }
+
+            // PSK supplied on the command line or through the environment leaks
+            // through process metadata; warn so users can migrate to --psk-file.
+            if psk.is_some() {
+                warn!(
+                    "Using --psk or XFR_PSK exposes the pre-shared key in process metadata (ps, /proc/<pid>/environ, shell history); prefer --psk-file"
+                );
+            }
+
+            // Resolve server preset
+            let preset = if let Some(name) = preset {
+                Some(
+                    file_config
+                        .get_preset(&name)
+                        .ok_or_else(|| anyhow::anyhow!("Unknown server preset: {name}"))?
+                        .clone(),
+                )
+            } else {
+                None
+            };
 
             // Build security configs
             let auth_config = xfr::auth::AuthConfig { psk: effective_psk };
@@ -883,6 +921,7 @@ async fn main() -> Result<()> {
                 tui_tx: None,
                 enable_quic: true,
                 no_mdns: server_no_mdns,
+                preset_allowed_clients: preset.and_then(|p| p.allowed_clients),
                 ..Default::default()
             };
 
@@ -1054,6 +1093,14 @@ async fn main() -> Result<()> {
             // Validate PSK if provided
             if let Some(ref psk_value) = client_psk {
                 xfr::auth::validate_psk(psk_value)?;
+            }
+
+            // PSK supplied on the command line or through the environment leaks
+            // through process metadata; warn so users can migrate to --psk-file.
+            if cli.psk.is_some() {
+                warn!(
+                    "Using --psk or XFR_PSK exposes the pre-shared key in process metadata (ps, /proc/<pid>/environ, shell history); prefer --psk-file"
+                );
             }
 
             // Determine address family

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -81,6 +81,9 @@ pub struct ServerConfig {
     pub max_concurrent: u32,
     /// Disable mDNS service registration
     pub no_mdns: bool,
+    /// Allowed client CIDRs from a selected server preset. The client IP must
+    /// pass both the preset allowlist (if set) and the configured ACL.
+    pub preset_allowed_clients: Option<Vec<String>>,
 }
 
 impl Default for ServerConfig {
@@ -101,7 +104,21 @@ impl Default for ServerConfig {
             enable_quic: true,
             max_concurrent: 100,
             no_mdns: false,
+            preset_allowed_clients: None,
         }
+    }
+}
+
+/// Build the optional preset ACL from configured allowed client CIDRs.
+fn build_preset_acl(allowed_clients: Option<&Vec<String>>) -> anyhow::Result<Option<Acl>> {
+    if let Some(clients) = allowed_clients {
+        if clients.is_empty() {
+            return Ok(None);
+        }
+        let acl = Acl::from_rules(clients.clone(), vec![])?;
+        Ok(Some(acl))
+    } else {
+        Ok(None)
     }
 }
 
@@ -109,6 +126,9 @@ impl Default for ServerConfig {
 struct SecurityContext {
     psk: Option<String>,
     acl: Acl,
+    /// Optional preset allowlist. Clients must satisfy the main ACL *and*
+    /// the preset ACL (if one is configured).
+    preset_acl: Option<Acl>,
     rate_limiter: Option<Arc<RateLimiter>>,
     address_family: AddressFamily,
     bind_addr: Option<IpAddr>,
@@ -534,6 +554,7 @@ impl Server {
 
         // Initialize security context
         let acl = self.config.acl.build()?;
+        let preset_acl = build_preset_acl(self.config.preset_allowed_clients.as_ref())?;
         let rate_limiter = self.config.rate_limit.build();
 
         if self.config.auth.psk.is_some() {
@@ -541,6 +562,9 @@ impl Server {
         }
         if acl.is_configured() {
             info!("ACL configured");
+        }
+        if preset_acl.is_some() {
+            info!("Preset ACL configured");
         }
         if rate_limiter.is_some() {
             info!(
@@ -552,6 +576,7 @@ impl Server {
         let security = Arc::new(SecurityContext {
             psk: self.config.auth.psk.clone(),
             acl,
+            preset_acl,
             rate_limiter: rate_limiter.clone(),
             address_family: self.config.address_family,
             bind_addr: self.config.bind_addr,
@@ -611,6 +636,20 @@ impl Server {
                     // Check ACL
                     if !quic_security.acl.is_allowed(peer_ip) {
                         warn!("QUIC connection rejected by ACL: {}", peer_addr);
+                        if let Some(tx) = &quic_security.tui_tx {
+                            let _ = tx.try_send(ServerEvent::ConnectionBlocked);
+                        }
+                        continue;
+                    }
+
+                    // Preset allowlist is an additional AND predicate
+                    if let Some(ref preset_acl) = quic_security.preset_acl
+                        && !preset_acl.is_allowed(peer_ip)
+                    {
+                        warn!(
+                            "QUIC connection rejected by preset allowlist ({} not in allowed_clients)",
+                            peer_addr
+                        );
                         if let Some(tx) = &quic_security.tui_tx {
                             let _ = tx.try_send(ServerEvent::ConnectionBlocked);
                         }
@@ -728,6 +767,21 @@ impl Server {
             // Check ACL (cheap, no state change)
             if !security.acl.is_allowed(peer_ip) {
                 warn!("Connection rejected by ACL: {}", peer_addr);
+                if let Some(tx) = &security.tui_tx {
+                    let _ = tx.try_send(ServerEvent::ConnectionBlocked);
+                }
+                drop(stream);
+                continue;
+            }
+
+            // Preset allowlist is an additional AND predicate
+            if let Some(ref preset_acl) = security.preset_acl
+                && !preset_acl.is_allowed(peer_ip)
+            {
+                warn!(
+                    "Connection rejected by preset allowlist ({} not in allowed_clients)",
+                    peer_addr
+                );
                 if let Some(tx) = &security.tui_tx {
                     let _ = tx.try_send(ServerEvent::ConnectionBlocked);
                 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -594,6 +594,36 @@ async fn start_secure_server(
     })
 }
 
+async fn start_preset_server(
+    port: u16,
+    preset_allowed_clients: Vec<String>,
+) -> tokio::task::JoinHandle<()> {
+    let config = ServerConfig {
+        port,
+        one_off: false,
+        max_duration: None,
+        #[cfg(feature = "prometheus")]
+        prometheus_port: None,
+        auth: AuthConfig { psk: None },
+        acl: AclConfig {
+            allow: vec![],
+            deny: vec![],
+            file: None,
+        },
+        rate_limit: RateLimitConfig {
+            max_per_ip: None,
+            window_secs: 60,
+        },
+        preset_allowed_clients: Some(preset_allowed_clients),
+        ..Default::default()
+    };
+
+    tokio::spawn(async move {
+        let server = Server::new(config);
+        let _ = server.run().await;
+    })
+}
+
 #[tokio::test]
 async fn test_psk_auth_success() {
     let port = get_test_port();
@@ -1100,6 +1130,96 @@ async fn test_acl_deny() {
     assert!(result.is_ok(), "Test should complete (not timeout)");
     let result = result.unwrap();
     assert!(result.is_err(), "Connection should be denied by ACL");
+}
+
+// ============================================================================
+// Server preset allowed_clients Tests
+// ============================================================================
+
+#[tokio::test]
+async fn test_preset_allowed_clients_allows_matching_ip() {
+    let port = get_test_port();
+    // Allow only localhost through the preset allowlist
+    let _server = start_preset_server(port, vec!["127.0.0.1/32".to_string()]).await;
+
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let config = ClientConfig {
+        host: "127.0.0.1".to_string(),
+        port,
+        protocol: Protocol::Tcp,
+        streams: 1,
+        duration: Duration::from_secs(2),
+        direction: Direction::Upload,
+        bitrate: None,
+        tcp_nodelay: false,
+        window_size: None,
+        tcp_congestion: None,
+        psk: None,
+        address_family: xfr::net::AddressFamily::default(),
+        bind_addr: None,
+        sequential_ports: false,
+        mptcp: false,
+        random_payload: false,
+        zerocopy: ZerocopyMode::Off,
+        dscp: None,
+        mtu_probe: false,
+        connect_timeout: None,
+    };
+
+    let client = Client::new(config);
+    let result = timeout(Duration::from_secs(10), client.run(None)).await;
+
+    assert!(result.is_ok(), "Test should complete");
+    let result = result.unwrap();
+    assert!(
+        result.is_ok(),
+        "Localhost should be allowed by preset: {:?}",
+        result
+    );
+}
+
+#[tokio::test]
+async fn test_preset_allowed_clients_denies_non_matching_ip() {
+    let port = get_test_port();
+    // Preset allowlist excludes localhost
+    let _server = start_preset_server(port, vec!["192.168.1.0/24".to_string()]).await;
+
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let config = ClientConfig {
+        host: "127.0.0.1".to_string(),
+        port,
+        protocol: Protocol::Tcp,
+        streams: 1,
+        duration: Duration::from_secs(2),
+        direction: Direction::Upload,
+        bitrate: None,
+        tcp_nodelay: false,
+        window_size: None,
+        tcp_congestion: None,
+        psk: None,
+        address_family: xfr::net::AddressFamily::default(),
+        bind_addr: None,
+        sequential_ports: false,
+        mptcp: false,
+        random_payload: false,
+        zerocopy: ZerocopyMode::Off,
+        dscp: None,
+        mtu_probe: false,
+        connect_timeout: None,
+    };
+
+    let client = Client::new(config);
+    let result = timeout(Duration::from_secs(5), client.run(None)).await;
+
+    // Connection should be dropped by preset allowlist without hanging
+    assert!(result.is_ok(), "Test should complete (not timeout)");
+    let result = result.unwrap();
+    assert!(
+        result.is_err(),
+        "Localhost should be denied by preset allowlist"
+    );
 }
 
 // ============================================================================


### PR DESCRIPTION
Security hardening batch, no wire-protocol changes.

## LAN-158: enforce `ServerPreset.allowed_clients`

- Adds a `--preset <NAME>` argument to `xfr serve`.
- If the named preset has `allowed_clients`, those CIDRs are parsed into an additional ACL that is enforced **together with** the normal ACL (`--allow`, `--deny`, config file ACLs).
- Enforcement happens at the existing connection accept points for TCP and QUIC, so preset-banned clients are dropped before auth/handshake/test allocation.
- Uses AND semantics: a client must pass both the regular ACL and the preset allowlist.
- Unknown preset names fail fast at startup.

## LAN-171: PSK hygiene cleanup

- `auth::constant_time_eq` no longer short-circuits on length mismatch. The comparison now pads to the length of the longer input and folds any length difference into the result, preventing both timing-of-length leaks and false-positive equality when one value is the other plus trailing zero bytes.
- On Unix, `auth::read_psk_file` now rejects PSK files with any group/other permissions set.
- Both `xfr serve` and the client path now emit a `warn!` when `--psk` (or the equivalent `XFR_PSK` environment value) is used, because these leak the key through `ps`, shell history, and `/proc/<pid>/environ`. `--psk-file` is preferred.
- Updated `--psk` help text on both server and client CLI.
- Added docs notes in `README.md`, `docs/FEATURES.md`, and `docs/SCRIPTING.md` recommending `--psk-file`.

## Tests

- `auth::tests::test_constant_time_eq` — covers same-value, different-value, different-length-with-trailing-zero, and empty-vs-non-empty cases.
- Unix-only PSK file permission tests for rejected `0o644` and accepted `0o600` files.
- `tests/integration.rs`: `test_preset_allowed_clients_allows_matching_ip` and `test_preset_allowed_clients_denies_non_matching_ip` exercise a preset allowlist with localhost.

Validation run:

```
cargo fmt --check
cargo test --all-features        # 331 passed
cargo clippy --all-features -- -D warnings
cargo clippy --all-targets --features prometheus -- -D warnings
```

Closes LAN-158, LAN-171.
