### PR TITLE
fix(protocol,probe,net): LAN-167 + LAN-168 protocol/probe validation

### DIFF
--- a/src/net.rs
+++ b/src/net.rs
@@ -562,7 +562,17 @@ pub fn resolve_host(host: &str, port: u16, family: AddressFamily) -> io::Result<
         host
     };
 
-    let addr_str = format!("{}:{}", host_for_lookup, port);
+    // Wrap literal IPv6 addresses in brackets so `to_socket_addrs` parses
+    // "[::1]:5201" correctly instead of treating the colons as port separators.
+    let is_ipv6_literal = host_for_lookup
+        .parse::<IpAddr>()
+        .map(|ip| ip.is_ipv6())
+        .unwrap_or(false);
+    let addr_str = if is_ipv6_literal {
+        format!("[{}]:{}", host_for_lookup, port)
+    } else {
+        format!("{}:{}", host_for_lookup, port)
+    };
     let addrs: Vec<SocketAddr> = addr_str.to_socket_addrs()?.collect();
 
     if addrs.is_empty() {
@@ -1133,6 +1143,26 @@ mod tests {
         let bind: SocketAddr = "10.0.0.1:5300".parse().unwrap();
         let remote: SocketAddr = "[::1]:5201".parse().unwrap();
         assert_eq!(match_bind_family(bind, remote), bind);
+    }
+
+    #[test]
+    fn test_resolve_ipv6_literal_uses_brackets() {
+        let addrs = resolve_host("::1", 5201, AddressFamily::V6Only).unwrap();
+        assert!(!addrs.is_empty(), "::1 should resolve");
+        assert!(
+            addrs.iter().all(|a| a.is_ipv6() && a.port() == 5201),
+            "literal IPv6 address must be parsed with [addr]:port syntax"
+        );
+    }
+
+    #[test]
+    fn test_resolve_ipv4_literal_keeps_standard_formatting() {
+        let addrs = resolve_host("127.0.0.1", 5201, AddressFamily::V4Only).unwrap();
+        assert!(!addrs.is_empty(), "127.0.0.1 should resolve");
+        assert!(
+            addrs.iter().all(|a| a.is_ipv4() && a.port() == 5201),
+            "literal IPv4 address must be parsed as addr:port"
+        );
     }
 
     #[tokio::test]

--- a/src/probe.rs
+++ b/src/probe.rs
@@ -97,8 +97,9 @@ impl ProbePacket {
     }
 
     /// Decode a probe-lane packet. Returns `None` for wrong magic,
-    /// version, unknown kind, or a padded kind whose datagram is
-    /// shorter than its header. Padding content is ignored.
+    /// version, unknown kind, or a malformed padded kind (`Probe`/`Echo`)
+    /// whose declared size is smaller than the header or larger than the
+    /// received datagram. Padding content is ignored.
     pub fn decode(buffer: &[u8]) -> Option<Self> {
         if buffer.len() < PROBE_HEADER_SIZE || buffer[0..4] != PROBE_MAGIC {
             return None;
@@ -112,6 +113,16 @@ impl ProbePacket {
         }
         let seq = u32::from_be_bytes(buffer[8..12].try_into().ok()?);
         let declared_size = u16::from_be_bytes(buffer[12..14].try_into().ok()?);
+
+        // Padded kinds must declare a size that fits the header and the
+        // received datagram; otherwise the packet is malformed.
+        if matches!(kind, PROBE_KIND_PROBE | PROBE_KIND_ECHO) {
+            let declared = usize::from(declared_size);
+            if declared < PROBE_HEADER_SIZE || declared > buffer.len() {
+                return None;
+            }
+        }
+
         Some(Self {
             kind,
             seq,
@@ -357,14 +368,16 @@ pub async fn run_probe(
             }
 
             let (got_ack, got_echo) = collect_replies(socket, &mut recv_buf, seq, size).await;
-            if got_ack {
+            // An echo receipt proves the probe reached the server even when the
+            // ack was lost, so count it as a forward success too.
+            if got_ack || got_echo {
                 forward_ok += 1;
             }
             if got_echo {
                 reverse_ok += 1;
             }
-            // Both directions proven at this size; no need to keep going.
-            if got_ack && got_echo {
+            // Receiving the echo proves both directions; no need to keep going.
+            if got_echo {
                 break;
             }
         }
@@ -408,10 +421,10 @@ pub async fn run_probe(
     })
 }
 
-/// Wait up to [`PROBE_REPLY_TIMEOUT`] for the ack/echo pair belonging to
-/// `seq`, returning early once both arrive. Echo validity requires the
-/// datagram to actually be `size` bytes on the wire — the declared-size
-/// field alone would also match a truncated delivery.
+/// Wait up to [`PROBE_REPLY_TIMEOUT`] for replies belonging to `seq`,
+/// returning early once an echo arrives. Echo validity requires the datagram
+/// to actually be `size` bytes on the wire — the declared-size field alone
+/// would also match a truncated delivery.
 async fn collect_replies(
     socket: &tokio::net::UdpSocket,
     recv_buf: &mut [u8],
@@ -421,7 +434,7 @@ async fn collect_replies(
     let deadline = tokio::time::Instant::now() + PROBE_REPLY_TIMEOUT;
     let mut got_ack = false;
     let mut got_echo = false;
-    while !(got_ack && got_echo) {
+    while !got_echo {
         let now = tokio::time::Instant::now();
         if now >= deadline {
             break;
@@ -515,6 +528,91 @@ mod tests {
             declared_size: (PROBE_HEADER_SIZE - 1) as u16,
         };
         assert!(p.encode(&mut buf).is_none());
+    }
+
+    #[test]
+    fn probe_packet_decode_rejects_malformed_declared_size() {
+        // Declared size below the header size is impossible for padded kinds.
+        let mut short = vec![0u8; 64];
+        let p = ProbePacket {
+            kind: PROBE_KIND_PROBE,
+            seq: 1,
+            declared_size: PROBE_HEADER_SIZE as u16,
+        };
+        let n = p.encode(&mut short).unwrap();
+        // Mutate the declared_size to be below PROBE_HEADER_SIZE.
+        short[12..14].copy_from_slice(&((PROBE_HEADER_SIZE - 1) as u16).to_be_bytes());
+        assert!(ProbePacket::decode(&short[..n]).is_none());
+
+        // Declared size larger than the received datagram is malformed (truncated).
+        let mut long = vec![0u8; 1024];
+        let p = ProbePacket {
+            kind: PROBE_KIND_ECHO,
+            seq: 2,
+            declared_size: 1024,
+        };
+        let n = p.encode(&mut long).unwrap();
+        assert!(ProbePacket::decode(&long[..n - 1]).is_none());
+    }
+
+    #[test]
+    fn probe_packet_decode_accepts_ack_with_large_declared_size() {
+        // Acks carry the original probe size in declared_size but are not padded,
+        // so a declared size larger than the datagram is valid.
+        let mut buf = vec![0u8; PROBE_HEADER_SIZE];
+        let p = ProbePacket {
+            kind: PROBE_KIND_ACK,
+            seq: 3,
+            declared_size: 1500,
+        };
+        let n = p.encode(&mut buf).unwrap();
+        let decoded = ProbePacket::decode(&buf[..n]).expect("ack should decode");
+        assert_eq!(decoded.kind, PROBE_KIND_ACK);
+        assert_eq!(decoded.seq, 3);
+        assert_eq!(decoded.declared_size, 1500);
+    }
+
+    #[tokio::test]
+    async fn echo_only_proves_forward_path_when_ack_lost() {
+        // Fake responder that echoes every probe but never sends an Ack.
+        let responder = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let responder_addr = responder.local_addr().unwrap();
+        let client = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        client.connect(responder_addr).await.unwrap();
+
+        let resp_task = tokio::spawn(async move {
+            let mut buf = vec![0u8; MAX_PROBE_PAYLOAD];
+            loop {
+                let (n, from) = match responder.recv_from(&mut buf).await {
+                    Ok(v) => v,
+                    Err(_) => break,
+                };
+                let Some(pkt) = ProbePacket::decode(&buf[..n]) else {
+                    continue;
+                };
+                if pkt.kind != PROBE_KIND_PROBE {
+                    continue;
+                }
+                let echo = ProbePacket {
+                    kind: PROBE_KIND_ECHO,
+                    seq: pkt.seq,
+                    declared_size: pkt.declared_size,
+                };
+                let mut out = vec![0u8; usize::from(pkt.declared_size)];
+                let len = echo.encode(&mut out).expect("echo encode fits");
+                let _ = responder.send_to(&out[..len], from).await;
+            }
+        });
+
+        let report = run_probe(&client, false).await.unwrap();
+        resp_task.abort();
+        let _ = resp_task.await;
+
+        assert!(
+            report.forward_max_payload.is_some(),
+            "echo must prove forward path even without ack"
+        );
+        assert_eq!(report.forward_max_payload, report.reverse_max_payload);
     }
 
     #[test]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -592,7 +592,29 @@ impl ControlMessage {
     }
 
     pub fn deserialize(s: &str) -> anyhow::Result<Self> {
-        Ok(serde_json::from_str(s)?)
+        let msg: Self = serde_json::from_str(s)?;
+        msg.validate()?;
+        Ok(msg)
+    }
+}
+
+impl ControlMessage {
+    /// Post-deserialization validation for wire messages.
+    fn validate(&self) -> anyhow::Result<()> {
+        if let Self::TestAck {
+            data_ports,
+            udp_token,
+            ..
+        } = self
+        {
+            // Single-port UDP mode and legacy multi-port UDP are
+            // mutually exclusive: a token is only sent when no per-stream
+            // ports are allocated.
+            if udp_token.is_some() && !data_ports.is_empty() {
+                anyhow::bail!("TestAck cannot contain both udp_token and data_ports");
+            }
+        }
+        Ok(())
     }
 }
 
@@ -877,11 +899,41 @@ mod tests {
     }
 
     #[test]
-    fn test_supported_capabilities_without_filters_only_named_entry() {
+    fn test_supported_capabilities_single_port_udp() {
         let full = supported_capabilities();
         assert!(full.iter().any(|c| c == SINGLE_PORT_UDP_CAPABILITY));
         let filtered = supported_capabilities_without(SINGLE_PORT_UDP_CAPABILITY);
         assert!(!filtered.iter().any(|c| c == SINGLE_PORT_UDP_CAPABILITY));
         assert_eq!(filtered.len(), full.len() - 1);
+    }
+
+    #[test]
+    fn test_test_ack_rejects_udp_token_with_data_ports() {
+        let bad = r#"{"type":"test_ack","id":"x","data_ports":[5202],"udp_token":"00112233445566778899aabbccddeeff"}"#;
+        let result = ControlMessage::deserialize(bad);
+        assert!(
+            result.is_err(),
+            "TestAck with both udp_token and data_ports should be rejected"
+        );
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("udp_token") && err.contains("data_ports"),
+            "{}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_test_ack_accepts_data_ports_without_udp_token() {
+        let good = r#"{"type":"test_ack","id":"x","data_ports":[5202]}"#;
+        let result = ControlMessage::deserialize(good);
+        assert!(result.is_ok(), "legacy multi-port TestAck should parse");
+    }
+
+    #[test]
+    fn test_test_ack_accepts_udp_token_with_empty_data_ports() {
+        let good = r#"{"type":"test_ack","id":"x","data_ports":[],"udp_token":"00112233445566778899aabbccddeeff"}"#;
+        let result = ControlMessage::deserialize(good);
+        assert!(result.is_ok(), "single-port TestAck should parse");
     }
 }


### PR DESCRIPTION
Protocol/probe validation cleanup batch, no wire-protocol changes.

## LAN-167: TestAck UDP field validation

- Added post-deserialization validation to `ControlMessage`: `TestAck` now rejects any message that contains both `udp_token` and non-empty `data_ports`.
- `src/server.rs` and other callers already send only one of the two, so this protects against malformed/corrupt peers.

## LAN-167: Padded probe packet validation

- `ProbePacket::decode` now rejects malformed `Probe`/`Echo` packets where `declared_size < PROBE_HEADER_SIZE` or `declared_size > buffer.len()`.
- `Ack` packets are unaffected — they intentionally carry the original probe size in `declared_size` while remaining header-sized.

## LAN-168: MTU echo proves forward path

- `run_probe` now counts `got_echo` as forward-path success too.
- `collect_replies` returns early once an `Echo` is received, because that proves both directions, even if the smaller `Ack` was lost.
- Added an echo-only loopback responder regression test that confirms `forward_max_payload` passes when only echoes arrive.

## LAN-168: IPv6 literal formatting

- `resolve_host` now detects literal IPv6 addresses and wraps them in brackets (`[::1]:5201`) before passing them to `to_socket_addrs()`.
- Literal IPv4 addresses continue to use the usual `addr:port` form.
- Restored the concrete-IP mismatch case in the bind-family test to use an IPv6 remote.

## Tests

- `protocol::tests::test_test_ack_rejects_udp_token_with_data_ports` and positive parsing tests.
- `probe::tests::probe_packet_decode_rejects_malformed_declared_size`
- `probe::tests::probe_packet_decode_accepts_ack_with_large_declared_size`
- `probe::tests::echo_only_proves_forward_path_when_ack_lost`
- `net::tests::test_resolve_ipv6_literal_uses_brackets`
- `net::tests::test_resolve_ipv4_literal_keeps_standard_formatting`

Validation run:

```
cargo fmt --check
cargo test --all-features        # 339 passed
cargo clippy --all-features -- -D warnings
cargo clippy --all-targets --features prometheus -- -D warnings
```

Closes LAN-167, LAN-168.
