### PR TITLE
fix(tui,config,main): LAN-163 + LAN-173 TUI/preset polish

### DIFF
--- a/docs/xfr.1
+++ b/docs/xfr.1
@@ -163,7 +163,7 @@ Pre-shared key for authentication. Environment: XFR_PSK. Values supplied via \fB
 Read PSK from file
 .TP
 .BI \-\-preset " NAME"
-Use a named server preset from the config file. Preset \fBallowed_clients\fR entries, if present, are enforced as an additional allowlist together with the normal ACL.
+Use a named server preset from the config file. Preset \fBallowed_clients\fR entries, if present, are enforced as an additional allowlist together with the normal ACL. Preset \fBmax_duration_secs\fR, if present, is used only when \fB\-\-max-duration\fR is not also supplied on the command line. The \fBbandwidth_limit\fR field is reserved for future use and is not enforced today.
 .TP
 .BI \-\-rate\-limit " N"
 Max concurrent tests per IP

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -39,6 +39,7 @@ no_mdns = false
 # Server presets - use with: xfr serve --preset limited
 [[presets]]
 name = "limited"
+# bandwidth_limit is reserved for future use and is not enforced today.
 bandwidth_limit = "100M"
 max_duration_secs = 60
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -116,7 +116,8 @@ pub struct ServerPreset {
     /// Preset name (used with --preset flag)
     pub name: String,
 
-    /// Bandwidth limit (e.g., "100M", "1G")
+    /// Reserved bandwidth limit string (e.g., "100M", "1G").
+    /// Currently unused; present for forward/backward compatibility with config files.
     pub bandwidth_limit: Option<String>,
 
     /// Allowed client IP addresses/ranges
@@ -178,6 +179,7 @@ prometheus_port = 9090
 
 [[presets]]
 name = "limited"
+# Reserved for future use; not enforced today.
 bandwidth_limit = "100M"
 max_duration_secs = 60
 
@@ -238,5 +240,23 @@ bandwidth_limit = "10M"
         assert_eq!(slow.bandwidth_limit, Some("10M".to_string()));
 
         assert!(config.get_preset("nonexistent").is_none());
+    }
+
+    #[test]
+    fn test_preset_max_duration_secs_is_parsed() {
+        // `max_duration_secs` must round-trip through the config file so the
+        // server command can apply it as the default when `--max-duration` is
+        // not provided.
+        let toml = r#"
+[[presets]]
+name = "limited"
+bandwidth_limit = "100M"
+max_duration_secs = 300
+"#;
+        let config: Config = toml::from_str(toml).unwrap();
+        let preset = config.get_preset("limited").unwrap();
+        assert_eq!(preset.max_duration_secs, Some(300));
+        // `bandwidth_limit` is accepted for compatibility but not enforced.
+        assert_eq!(preset.bandwidth_limit, Some("100M".to_string()));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -376,7 +376,9 @@ enum Commands {
         /// Use a named server preset from the config file.
         ///
         /// Preset `allowed_clients` (if any) become an additional allowlist
-        /// enforced with the normal ACL. Unknown presets are rejected.
+        /// enforced with the normal ACL. Preset `max_duration_secs` (if any)
+        /// is applied only when `--max-duration` is not provided.
+        /// Unknown presets are rejected.
         #[arg(long)]
         preset: Option<String>,
 
@@ -468,6 +470,16 @@ fn parse_test_duration(s: &str) -> Result<Duration, String> {
         return Err("Minimum test duration is 1 second (use 0 for infinite)".to_string());
     }
     Ok(duration)
+}
+
+/// Resolve the effective server-side max test duration.
+/// CLI `--max-duration` always wins; otherwise a preset's
+/// `max_duration_secs` (if present) supplies the default.
+fn resolve_server_max_duration(
+    cli_max_duration: Option<Duration>,
+    preset: Option<&xfr::config::ServerPreset>,
+) -> Option<Duration> {
+    cli_max_duration.or_else(|| preset.and_then(|p| p.max_duration_secs.map(Duration::from_secs)))
 }
 
 fn parse_bitrate(s: &str) -> Result<u64, String> {
@@ -781,7 +793,7 @@ async fn main() -> Result<()> {
             port,
             one_off,
             tui: server_tui,
-            max_duration,
+            mut max_duration,
             #[cfg(feature = "prometheus")]
             prometheus,
             push_gateway,
@@ -905,6 +917,8 @@ async fn main() -> Result<()> {
             };
 
             let server_no_mdns = no_mdns || file_config.server.no_mdns.unwrap_or(false);
+
+            max_duration = resolve_server_max_duration(max_duration, preset.as_ref());
 
             let config = ServerConfig {
                 port: server_port,
@@ -2111,6 +2125,39 @@ mod tests {
 
     fn test_key(code: KeyCode) -> crossterm::event::KeyEvent {
         crossterm::event::KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    #[test]
+    fn resolve_server_max_duration_cli_overrides_preset() {
+        let preset = xfr::config::ServerPreset {
+            name: "limited".into(),
+            bandwidth_limit: None,
+            allowed_clients: None,
+            max_duration_secs: Some(60),
+        };
+        assert_eq!(
+            resolve_server_max_duration(Some(Duration::from_secs(120)), Some(&preset)),
+            Some(Duration::from_secs(120))
+        );
+    }
+
+    #[test]
+    fn resolve_server_max_duration_uses_preset_when_cli_unset() {
+        let preset = xfr::config::ServerPreset {
+            name: "limited".into(),
+            bandwidth_limit: None,
+            allowed_clients: None,
+            max_duration_secs: Some(300),
+        };
+        assert_eq!(
+            resolve_server_max_duration(None, Some(&preset)),
+            Some(Duration::from_secs(300))
+        );
+    }
+
+    #[test]
+    fn resolve_server_max_duration_none_when_both_unset() {
+        assert_eq!(resolve_server_max_duration(None, None), None);
     }
 
     fn ctrl_c_key() -> crossterm::event::KeyEvent {

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -639,11 +639,19 @@ impl App {
         // `tick()` doesn't synthesize a second bar for the same window.
         self.last_bar_at = Some(Instant::now());
 
-        // Use local TCP_INFO retransmits when available (sender-side), otherwise sum from server
+        // Use local TCP_INFO retransmits when available (sender-side).
+        // Otherwise accumulate per-stream interval deltas ourselves so the
+        // fallback stays cumulative instead of resetting to the last
+        // interval's value.
         if let Some(total) = progress.total_retransmits {
             self.total_retransmits = total;
         } else {
-            self.total_retransmits = self.streams.iter().map(|s| s.retransmits).sum();
+            let interval_total: u64 = progress
+                .streams
+                .iter()
+                .map(|s| s.retransmits.unwrap_or(0))
+                .sum();
+            self.total_retransmits = self.total_retransmits.saturating_add(interval_total);
         }
 
         // Update live TCP_INFO from interval data
@@ -679,12 +687,12 @@ impl App {
             self.udp_lost_percent = Some(p);
         }
 
-        // Track average throughput
-        if progress.throughput_mbps > 0.0 {
-            self.throughput_sum += progress.throughput_mbps;
-            self.throughput_count += 1;
-            self.average_throughput_mbps = self.throughput_sum / self.throughput_count as f64;
-        }
+        // Track average throughput across every full interval, including
+        // zero-throughput intervals so stalls and lossy periods reduce the
+        // average just like they do in the final result.
+        self.throughput_sum += progress.throughput_mbps;
+        self.throughput_count += 1;
+        self.average_throughput_mbps = self.throughput_sum / self.throughput_count as f64;
 
         // Log significant events
         self.detect_events(progress.throughput_mbps);
@@ -1554,5 +1562,82 @@ mod tests {
         let bar = app.throughput_history.back().copied().unwrap();
         assert_eq!(bar.lost_packets, 200);
         assert_eq!(bar.interval_packets, 1200);
+    }
+
+    #[test]
+    fn average_throughput_includes_zero_throughput_intervals() {
+        // Regression: zero-throughput intervals were previously skipped,
+        // inflating the average in lossy/stall periods.
+        let mut app = App::default();
+        app.state = AppState::Running;
+
+        app.on_progress(make_progress(100.0, None));
+        assert!((app.average_throughput_mbps - 100.0).abs() < f64::EPSILON);
+
+        app.on_progress(make_progress(0.0, None));
+        assert!((app.average_throughput_mbps - 50.0).abs() < f64::EPSILON);
+
+        app.on_progress(make_progress(100.0, None));
+        assert!((app.average_throughput_mbps - (200.0 / 3.0)).abs() < 1e-9);
+    }
+
+    #[test]
+    fn retransmit_fallback_is_cumulative_across_intervals() {
+        // When the server omits progress.total_retransmits, the TUI must
+        // accumulate per-stream interval deltas instead of resetting the
+        // display to each interval's value.
+        let mut app = App::default();
+        app.state = AppState::Running;
+
+        let mut p1 = make_progress(1.0, None);
+        p1.streams = vec![crate::protocol::StreamInterval {
+            id: 0,
+            bytes: 0,
+            retransmits: Some(5),
+            jitter_ms: None,
+            lost: None,
+            error: None,
+            rtt_us: None,
+            cwnd: None,
+        }];
+        app.on_progress(p1);
+        assert_eq!(app.total_retransmits, 5);
+
+        let mut p2 = make_progress(1.0, None);
+        p2.streams = vec![crate::protocol::StreamInterval {
+            id: 0,
+            bytes: 0,
+            retransmits: Some(3),
+            jitter_ms: None,
+            lost: None,
+            error: None,
+            rtt_us: None,
+            cwnd: None,
+        }];
+        app.on_progress(p2);
+        assert_eq!(app.total_retransmits, 8);
+    }
+
+    #[test]
+    fn total_retransmits_overrides_cumulative_fallback() {
+        // Servers that ship progress.total_retransmits use the authoritative
+        // cumulative count directly.
+        let mut app = App::default();
+        app.state = AppState::Running;
+
+        let mut p = make_progress(1.0, None);
+        p.total_retransmits = Some(42);
+        p.streams = vec![crate::protocol::StreamInterval {
+            id: 0,
+            bytes: 0,
+            retransmits: Some(5),
+            jitter_ms: None,
+            lost: None,
+            error: None,
+            rtt_us: None,
+            cwnd: None,
+        }];
+        app.on_progress(p);
+        assert_eq!(app.total_retransmits, 42);
     }
 }


### PR DESCRIPTION
TUI display and preset semantics cleanup batch.

## LAN-163: TUI display correctness

- **Average speed now counts zero-throughput intervals.** Previously `on_progress()` skipped intervals where `throughput_mbps == 0.0`, so stalls and lossy periods inflated the live average.
- **Retransmit fallback stays cumulative.** When the server omits `progress.total_retransmits`, the TUI now accumulates per-stream interval deltas instead of summing each interval's snapshot, which kept resetting to the latest interval's value.

## LAN-173: preset semantics and docs

- **`--preset` now applies `max_duration_secs`** from the selected preset, but only when `--max-duration` is not also supplied on the CLI.
- **`bandwidth_limit` is documented as reserved/unused** in `ServerPreset`, the example config, and the man page. It still parses for backward compatibility but carries no enforcement promise.
- Man page and `--preset` help text now describe both `allowed_clients` and `max_duration_secs` precedence.

## Validation

```
cargo fmt --check
cargo test --all-features              # 346 passed
cargo clippy --all-features -- -D warnings
cargo clippy --all-targets --features prometheus -- -D warnings
```

Closes LAN-163, LAN-173.
