### PR TITLE
fix(misc): LAN-172 low-risk cleanups batch

### DIFF
--- a/src/discover.rs
+++ b/src/discover.rs
@@ -123,6 +123,10 @@ mod fallback {
         ))
     }
 
+    // Stub kept for API parity with the discovery-enabled build.
+    // Serve-mode callers are cfg-gated on the feature, so this is dead
+    // in a --no-default-features build.
+    #[allow(dead_code)]
     pub fn register_server(_port: u16) -> anyhow::Result<()> {
         Ok(())
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -161,8 +161,9 @@ struct Cli {
     port: u16,
 
     /// Test duration. Bare integers are seconds (`-t 10`), or use unit suffixes (`10s`, `1min`, `500ms`). Use 0 for infinite.
-    #[arg(short = 't', long, default_value = "10s", value_parser = parse_test_duration, env = "XFR_DURATION")]
-    time: Duration,
+    /// Defaults to 10s unless `--probe-mtu` is used without `-t`, in which case it defaults to 60s.
+    #[arg(short = 't', long, value_parser = parse_test_duration, env = "XFR_DURATION")]
+    time: Option<Duration>,
 
     /// UDP mode
     #[arg(short = 'u', long, conflicts_with = "quic")]
@@ -480,6 +481,28 @@ fn resolve_server_max_duration(
     preset: Option<&xfr::config::ServerPreset>,
 ) -> Option<Duration> {
     cli_max_duration.or_else(|| preset.and_then(|p| p.max_duration_secs.map(Duration::from_secs)))
+}
+
+/// Resolve the effective client test duration.
+/// - CLI `-t`/`--time` always wins when present.
+/// - `--probe-mtu` without an explicit duration extends to 60s.
+/// - Otherwise fall back to the config file, then the 10s default.
+fn resolve_client_duration(
+    cli_time: Option<Duration>,
+    probe_mtu: bool,
+    file_config: &xfr::config::Config,
+) -> Duration {
+    if let Some(duration) = cli_time {
+        duration
+    } else if probe_mtu {
+        Duration::from_secs(60)
+    } else {
+        file_config
+            .client
+            .duration_secs
+            .map(Duration::from_secs)
+            .unwrap_or(Duration::from_secs(10))
+    }
 }
 
 fn parse_bitrate(s: &str) -> Result<u64, String> {
@@ -1055,22 +1078,10 @@ async fn main() -> Result<()> {
                 xfr::net::validate_mptcp().map_err(|e| anyhow::anyhow!("{}", e))?;
             }
 
-            // Apply config file defaults where CLI didn't override
-            let duration = if cli.time != Duration::from_secs(10) {
-                cli.time
-            } else if cli.probe_mtu {
-                // Probe mode: the duration is only a server-side safety
-                // deadline (the client cancels as soon as the search
-                // converges, normally within seconds). The 10s default
-                // could truncate a slow search, so give it headroom.
-                Duration::from_secs(60)
-            } else {
-                file_config
-                    .client
-                    .duration_secs
-                    .map(Duration::from_secs)
-                    .unwrap_or(cli.time)
-            };
+            // Apply config file defaults where CLI didn't override.
+            // `--probe-mtu` without an explicit `-t` uses a longer default
+            // because the duration is only a server-side safety deadline.
+            let duration = resolve_client_duration(cli.time, cli.probe_mtu, &file_config);
 
             let streams = if cli.parallel != 1 {
                 cli.parallel
@@ -2158,6 +2169,59 @@ mod tests {
     #[test]
     fn resolve_server_max_duration_none_when_both_unset() {
         assert_eq!(resolve_server_max_duration(None, None), None);
+    }
+
+    #[test]
+    fn resolve_client_duration_explicit_time_wins() {
+        let cfg = xfr::config::Config::default();
+        assert_eq!(
+            resolve_client_duration(Some(Duration::from_secs(10)), true, &cfg),
+            Duration::from_secs(10)
+        );
+    }
+
+    #[test]
+    fn resolve_client_duration_probe_mtu_uses_long_default_when_unset() {
+        let cfg = xfr::config::Config::default();
+        assert_eq!(
+            resolve_client_duration(None, true, &cfg),
+            Duration::from_secs(60)
+        );
+    }
+
+    #[test]
+    fn resolve_client_duration_uses_config_file_default() {
+        let mut cfg = xfr::config::Config::default();
+        cfg.client.duration_secs = Some(25);
+        assert_eq!(
+            resolve_client_duration(None, false, &cfg),
+            Duration::from_secs(25)
+        );
+    }
+
+    #[test]
+    fn resolve_client_duration_falls_back_to_10s_default() {
+        let cfg = xfr::config::Config::default();
+        assert_eq!(
+            resolve_client_duration(None, false, &cfg),
+            Duration::from_secs(10)
+        );
+    }
+
+    #[test]
+    fn test_cli_probe_mtu_default_time_unset() {
+        use clap::Parser;
+        let cli = Cli::try_parse_from(["xfr", "host", "--probe-mtu"]).unwrap();
+        assert!(cli.probe_mtu);
+        assert!(cli.time.is_none());
+    }
+
+    #[test]
+    fn test_cli_probe_mtu_explicit_time_is_preserved() {
+        use clap::Parser;
+        let cli = Cli::try_parse_from(["xfr", "host", "--probe-mtu", "-t", "10s"]).unwrap();
+        assert!(cli.probe_mtu);
+        assert_eq!(cli.time, Some(Duration::from_secs(10)));
     }
 
     fn ctrl_c_key() -> crossterm::event::KeyEvent {

--- a/src/probe.rs
+++ b/src/probe.rs
@@ -32,10 +32,11 @@ pub const PROBE_VERSION: u8 = 1;
 /// Header bytes preceding the padding in `Probe`/`Echo` packets; also
 /// the full size of an `Ack`. Must stay below `MIN_PROBE_PAYLOAD`.
 pub const PROBE_HEADER_SIZE: usize = 16;
-/// Smallest trial payload. 576 is the classic IPv4 minimum-reassembly
-/// datagram; nothing real blocks below this, and the header has to fit.
+/// Smallest IPv4 trial payload. 576 is the classic IPv4 minimum-reassembly
+/// datagram; IPv6 uses its 1280-byte minimum MTU in [`size_ladder`].
 pub const MIN_PROBE_PAYLOAD: usize = 548; // 576 wire - 28 IPv4/UDP overhead
-/// Largest trial payload: 9216-byte jumbo wire MTU minus IPv4 overhead.
+/// Largest IPv4 trial payload: 9216-byte jumbo wire MTU minus IPv4 overhead.
+/// IPv6 subtracts its larger overhead in [`size_ladder`].
 pub const MAX_PROBE_PAYLOAD: usize = 9188;
 
 /// Packet kinds on the probe lane.
@@ -47,6 +48,14 @@ pub const PROBE_KIND_ECHO: u8 = 3;
 /// 20 (IPv4) or 40 (IPv6) IP header + 8 UDP header.
 pub fn ip_overhead(is_ipv6: bool) -> usize {
     if is_ipv6 { 48 } else { 28 }
+}
+
+fn min_probe_payload(is_ipv6: bool) -> usize {
+    if is_ipv6 {
+        1280usize - ip_overhead(true)
+    } else {
+        MIN_PROBE_PAYLOAD
+    }
 }
 
 /// A probe-lane packet.
@@ -183,19 +192,22 @@ pub struct MtuProbeReport {
 /// from wire MTUs seen in the wild: IPv4 minimum (576), IPv6 minimum
 /// (1280), PPPoE (1492), Ethernet (1500), FDDI (4352), jumbo (9000,
 /// 9216). Clamped to the valid probe range and deduplicated; always
-/// ends at `MAX_PROBE_PAYLOAD` so the search space is fully bracketed.
+/// ends at a family-aware max payload so the search space is fully bracketed.
 pub fn size_ladder(is_ipv6: bool) -> Vec<usize> {
     let overhead = ip_overhead(is_ipv6);
+    let min_payload = min_probe_payload(is_ipv6);
+    // Largest payload that still fits in a 9216-byte jumbo datagram.
+    let max_payload = 9216usize.saturating_sub(overhead);
     let mut ladder: Vec<usize> = [576usize, 1280, 1492, 1500, 4352, 9000, 9216]
         .iter()
         .map(|wire| wire.saturating_sub(overhead))
-        .filter(|&p| (MIN_PROBE_PAYLOAD..=MAX_PROBE_PAYLOAD).contains(&p))
+        .filter(|&p| (min_payload..=max_payload).contains(&p))
         .collect();
-    if ladder.first() != Some(&MIN_PROBE_PAYLOAD) {
-        ladder.insert(0, MIN_PROBE_PAYLOAD);
+    if ladder.first() != Some(&min_payload) {
+        ladder.insert(0, min_payload);
     }
-    if ladder.last() != Some(&MAX_PROBE_PAYLOAD) {
-        ladder.push(MAX_PROBE_PAYLOAD);
+    if ladder.last() != Some(&max_payload) {
+        ladder.push(max_payload);
     }
     ladder.dedup();
     ladder
@@ -619,10 +631,42 @@ mod tests {
     fn ladder_is_sorted_dedup_and_bracketed() {
         for ipv6 in [false, true] {
             let ladder = size_ladder(ipv6);
+            let overhead = ip_overhead(ipv6);
+            let expected_min = if ipv6 {
+                1280usize - overhead
+            } else {
+                576usize - overhead
+            };
+            let expected_max = 9216usize - overhead;
             assert!(ladder.windows(2).all(|w| w[0] < w[1]), "sorted+dedup");
-            assert_eq!(*ladder.first().unwrap(), MIN_PROBE_PAYLOAD);
-            assert_eq!(*ladder.last().unwrap(), MAX_PROBE_PAYLOAD);
+            assert_eq!(*ladder.first().unwrap(), expected_min);
+            assert_eq!(*ladder.last().unwrap(), expected_max);
         }
+    }
+
+    #[test]
+    fn ladder_bounds_account_for_ip_version_overhead() {
+        let v4 = size_ladder(false);
+        let v6 = size_ladder(true);
+        assert_eq!(*v4.first().unwrap(), 548);
+        assert_eq!(*v4.last().unwrap(), 9188);
+        assert_eq!(*v6.first().unwrap(), 1232);
+        assert_eq!(*v6.last().unwrap(), 9168);
+    }
+
+    #[test]
+    fn search_brackets_ipv6_max() {
+        let path_max = 9000usize; // below IPv6 jumbo payload max
+        let mut search = SizeSearch::new(true);
+        while let Some(size) = search.next_size() {
+            let verdict = if size <= path_max {
+                SizeVerdict::Pass
+            } else {
+                SizeVerdict::Fail
+            };
+            search.record(size, verdict);
+        }
+        assert_eq!(search.forward_max(), Some(path_max));
     }
 
     /// Simulate a path with a given max payload and verify the search

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -810,7 +810,7 @@ async fn test_rate_limit() {
         port,
         protocol: Protocol::Tcp,
         streams: 1,
-        duration: Duration::from_secs(3),
+        duration: Duration::from_secs(60),
         direction: Direction::Upload,
         bitrate: None,
         tcp_nodelay: false,
@@ -861,17 +861,18 @@ async fn test_rate_limit() {
     let client2 = Client::new(config2);
     let result2 = timeout(Duration::from_secs(5), client2.run(None)).await;
 
-    // Second connection should fail (rate limited - connection dropped)
-    // The server drops the connection before hello, so client gets connection error
-    if let Ok(inner) = result2 {
-        // Either fails or succeeds if timing allows
-        // We mainly verify we don't panic
-        let _ = inner;
-    }
+    // Second connection should be rejected (rate limited - connection dropped).
+    // The server drops the connection before hello, so the client either gets
+    // an error result or (if we waited too long) the outer timeout fires.
+    assert!(
+        matches!(result2, Ok(Err(_))),
+        "second concurrent connection should be rejected: {result2:?}"
+    );
 
-    // Wait for first client
+    // First client is still running; abort it rather than waiting 60s.
+    handle1.abort();
     let result1 = handle1.await;
-    assert!(result1.is_ok(), "First client task should complete");
+    assert!(result1.is_err(), "First client task should be aborted");
 }
 
 // ============================================================================


### PR DESCRIPTION
Low-risk LAN-172 cleanups batch. The MPTCP CI policy item is intentionally left out — it mixes runner-capability policy with code changes and would make standard GitHub runners noisy.

## Changes

1. **`src/discover.rs`**: suppress the `--no-default-features` dead-code warning on the mDNS fallback `register_server` stub.
2. **`tests/integration.rs`**: `test_rate_limit` now explicitly asserts the second concurrent connection is rejected, and aborts the long-running first client so the test stays fast.
3. **`src/main.rs`**: `-t`/`--time` is now `Option<Duration>`, so an explicit `--probe-mtu -t 10s` is no longer mistaken for the default. Added a `resolve_client_duration` helper with unit tests.
4. **`src/probe.rs`**: `size_ladder` now computes the max payload from the 9216-byte jumbo wire MTU minus the IP-version overhead, so IPv6 brackets at 9168 bytes instead of 9188.

## Validation

```
cargo fmt --check
cargo check --no-default-features
cargo test --all-features              # 354 passed
cargo clippy --all-features -- -D warnings
cargo clippy --all-targets --features prometheus -- -D warnings
cargo clippy --no-default-features -- -D warnings
```

Closes LAN-172 (low-risk items).
