### PR TITLE
fix: LAN-161 pause channel closure busy-loop and unawaited QUIC tasks

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1899,6 +1899,9 @@ impl Client {
         *self.pause_tx.lock() = Some(pause_tx.clone());
         *self.pause_request_tx.lock() = Some(pause_request_tx);
 
+        let mut quic_handles: Vec<tokio::task::JoinHandle<()>> =
+            Vec::with_capacity(self.config.streams as usize);
+
         // Spawn data streams based on direction
         for i in 0..self.config.streams {
             let stream_stats = stats.streams[i as usize].clone();
@@ -1908,7 +1911,7 @@ impl Client {
             let direction = self.config.direction;
             let conn = connection.clone();
 
-            tokio::spawn(async move {
+            quic_handles.push(tokio::spawn(async move {
                 match direction {
                     Direction::Upload => {
                         // Open unidirectional stream for sending
@@ -1980,117 +1983,153 @@ impl Client {
                         }
                     }
                 }
-            });
+            }));
         }
 
         // Read interval updates and final result
-        // For infinite duration, use 1 year timeout (effectively no timeout)
-        let timeout_duration = if self.config.duration == Duration::ZERO {
-            Duration::from_secs(365 * 24 * 3600) // 1 year
-        } else {
-            self.config.duration + Duration::from_secs(30)
-        };
-        let mut deadline = tokio::time::Instant::now() + timeout_duration;
+        let test_result: anyhow::Result<TestResult> = 'control: {
+            // For infinite duration, use 1 year timeout (effectively no timeout)
+            let timeout_duration = if self.config.duration == Duration::ZERO {
+                Duration::from_secs(365 * 24 * 3600) // 1 year
+            } else {
+                self.config.duration + Duration::from_secs(30)
+            };
+            let mut deadline = tokio::time::Instant::now() + timeout_duration;
 
-        loop {
-            tokio::select! {
-                read_result = tokio::time::timeout_at(deadline, read_bounded_line(&mut ctrl_reader, &mut line)) => {
-                    match read_result {
-                        Ok(Ok(0)) => break,
-                        Ok(Ok(_)) => {}
-                        Ok(Err(e)) => {
+            loop {
+                tokio::select! {
+                    read_result = tokio::time::timeout_at(deadline, read_bounded_line(&mut ctrl_reader, &mut line)) => {
+                        match read_result {
+                            Ok(Ok(0)) => break,
+                            Ok(Ok(_)) => {}
+                            Ok(Err(e)) => {
+                                let _ = cancel_tx.send(true);
+                                break 'control Err(e);
+                            }
+                            Err(_) => {
+                                let _ = cancel_tx.send(true);
+                                break 'control Err(anyhow::anyhow!("Timeout waiting for server response"));
+                            }
+                        }
+                    }
+                    _ = cancel_request_rx.changed() => {
+                        if *cancel_request_rx.borrow() {
+                            let cancel_msg = ControlMessage::Cancel {
+                                id: test_id.clone(),
+                                reason: "User requested cancellation".to_string(),
+                            };
+                            let _ = ctrl_send.write_all(format!("{}\n", cancel_msg.serialize()?).as_bytes()).await;
                             let _ = cancel_tx.send(true);
-                            return Err(e);
-                        }
-                        Err(_) => {
-                            let _ = cancel_tx.send(true);
-                            return Err(anyhow::anyhow!("Timeout waiting for server response"));
                         }
                     }
-                }
-                _ = cancel_request_rx.changed() => {
-                    if *cancel_request_rx.borrow() {
-                        let cancel_msg = ControlMessage::Cancel {
-                            id: test_id.clone(),
-                            reason: "User requested cancellation".to_string(),
-                        };
-                        let _ = ctrl_send.write_all(format!("{}\n", cancel_msg.serialize()?).as_bytes()).await;
-                        let _ = cancel_tx.send(true);
-                    }
-                }
-                _ = pause_request_rx.changed() => {
-                    let paused = *pause_request_rx.borrow();
-                    let _ = pause_tx.send(paused);
-                    if supports_pause {
-                        let msg = if paused {
-                            ControlMessage::Pause { id: test_id.clone() }
-                        } else {
-                            ControlMessage::Resume { id: test_id.clone() }
-                        };
-                        if ctrl_send.write_all(format!("{}\n", msg.serialize()?).as_bytes()).await.is_err() {
-                            warn!("Failed to send pause/resume to server");
+                    _ = pause_request_rx.changed() => {
+                        let paused = *pause_request_rx.borrow();
+                        let _ = pause_tx.send(paused);
+                        if supports_pause {
+                            let msg = if paused {
+                                ControlMessage::Pause { id: test_id.clone() }
+                            } else {
+                                ControlMessage::Resume { id: test_id.clone() }
+                            };
+                            if ctrl_send.write_all(format!("{}\n", msg.serialize()?).as_bytes()).await.is_err() {
+                                warn!("Failed to send pause/resume to server");
+                            }
                         }
                     }
                 }
-            }
 
-            if line.is_empty() {
-                continue;
-            }
-
-            let msg: ControlMessage = ControlMessage::deserialize(line.trim())?;
-
-            match msg {
-                ControlMessage::Interval {
-                    elapsed_ms,
-                    streams,
-                    aggregate,
-                    ..
-                } => {
-                    if let Some(ref tx) = progress_tx {
-                        let _ = tx
-                            .send(TestProgress {
-                                elapsed_ms,
-                                total_bytes: aggregate.bytes,
-                                throughput_mbps: aggregate.throughput_mbps,
-                                rtt_us: aggregate.rtt_us,
-                                cwnd: aggregate.cwnd,
-                                total_retransmits: None,
-                                streams,
-                                bytes_sent: aggregate.bytes_sent,
-                                bytes_received: aggregate.bytes_received,
-                                throughput_send_mbps: aggregate.throughput_send_mbps,
-                                throughput_recv_mbps: aggregate.throughput_recv_mbps,
-                                udp_progress: aggregate.udp_progress,
-                                udp_feedback_only: false,
-                            })
-                            .await;
-                    }
-                }
-                ControlMessage::Result(result) => {
-                    let _ = cancel_tx.send(true);
-                    endpoint.close(0u32.into(), b"done");
-                    return Ok(result);
-                }
-                ControlMessage::Error { message } => {
-                    let _ = cancel_tx.send(true);
-                    return Err(anyhow::anyhow!("Server error: {}", message));
-                }
-                ControlMessage::Cancelled { .. } => {
-                    // Server acknowledged cancel — it will send Result next.
-                    // Tighten deadline to wait briefly for the final result.
-                    let _ = cancel_tx.send(true);
-                    deadline = tokio::time::Instant::now() + Duration::from_secs(3);
-                    line.clear();
+                if line.is_empty() {
                     continue;
                 }
-                _ => {
-                    debug!("Unexpected message: {:?}", msg);
+
+                let msg: ControlMessage = ControlMessage::deserialize(line.trim())?;
+
+                match msg {
+                    ControlMessage::Interval {
+                        elapsed_ms,
+                        streams,
+                        aggregate,
+                        ..
+                    } => {
+                        if let Some(ref tx) = progress_tx {
+                            let _ = tx
+                                .send(TestProgress {
+                                    elapsed_ms,
+                                    total_bytes: aggregate.bytes,
+                                    throughput_mbps: aggregate.throughput_mbps,
+                                    rtt_us: aggregate.rtt_us,
+                                    cwnd: aggregate.cwnd,
+                                    total_retransmits: None,
+                                    streams,
+                                    bytes_sent: aggregate.bytes_sent,
+                                    bytes_received: aggregate.bytes_received,
+                                    throughput_send_mbps: aggregate.throughput_send_mbps,
+                                    throughput_recv_mbps: aggregate.throughput_recv_mbps,
+                                    udp_progress: aggregate.udp_progress,
+                                    udp_feedback_only: false,
+                                })
+                                .await;
+                        }
+                    }
+                    ControlMessage::Result(result) => {
+                        let _ = cancel_tx.send(true);
+                        endpoint.close(0u32.into(), b"done");
+                        break 'control Ok(result);
+                    }
+                    ControlMessage::Error { message } => {
+                        let _ = cancel_tx.send(true);
+                        break 'control Err(anyhow::anyhow!("Server error: {}", message));
+                    }
+                    ControlMessage::Cancelled { .. } => {
+                        // Server acknowledged cancel — it will send Result next.
+                        // Tighten deadline to wait briefly for the final result.
+                        let _ = cancel_tx.send(true);
+                        deadline = tokio::time::Instant::now() + Duration::from_secs(3);
+                        line.clear();
+                        continue;
+                    }
+                    _ => {
+                        debug!("Unexpected message: {:?}", msg);
+                    }
+                }
+            }
+
+            break 'control Err(anyhow::anyhow!("Connection closed without result"));
+        };
+
+        // Cancel any stream work that may still be in flight
+        let _ = cancel_tx.send(true);
+
+        // Wait for QUIC data streams to finish (mirrors TCP/UDP path)
+        let join_timeout = stream_join_timeout(self.config.streams);
+        match tokio::time::timeout(
+            join_timeout,
+            futures::future::join_all(quic_handles.iter_mut()),
+        )
+        .await
+        {
+            Ok(results) => {
+                for result in results {
+                    if let Err(e) = result
+                        && e.is_panic()
+                    {
+                        error!("QUIC stream task panicked: {:?}", e);
+                    }
+                }
+            }
+            Err(_) => {
+                warn!(
+                    "Timed out waiting {:?} for {} QUIC streams to stop; aborting remaining tasks",
+                    join_timeout,
+                    quic_handles.len()
+                );
+                for handle in &quic_handles {
+                    handle.abort();
                 }
             }
         }
 
-        Err(anyhow::anyhow!("Connection closed without result"))
+        test_result
     }
 
     /// Cancel a running test.

--- a/src/client.rs
+++ b/src/client.rs
@@ -1997,6 +1997,7 @@ impl Client {
             let mut deadline = tokio::time::Instant::now() + timeout_duration;
 
             loop {
+                line.clear();
                 tokio::select! {
                     read_result = tokio::time::timeout_at(deadline, read_bounded_line(&mut ctrl_reader, &mut line)) => {
                         match read_result {
@@ -2018,7 +2019,14 @@ impl Client {
                                 id: test_id.clone(),
                                 reason: "User requested cancellation".to_string(),
                             };
-                            let _ = ctrl_send.write_all(format!("{}\n", cancel_msg.serialize()?).as_bytes()).await;
+                            let serialized = match cancel_msg.serialize() {
+                                Ok(v) => v,
+                                Err(e) => {
+                                    let _ = cancel_tx.send(true);
+                                    break 'control Err(e);
+                                }
+                            };
+                            let _ = ctrl_send.write_all(format!("{}\n", serialized).as_bytes()).await;
                             let _ = cancel_tx.send(true);
                         }
                     }
@@ -2031,7 +2039,14 @@ impl Client {
                             } else {
                                 ControlMessage::Resume { id: test_id.clone() }
                             };
-                            if ctrl_send.write_all(format!("{}\n", msg.serialize()?).as_bytes()).await.is_err() {
+                            let serialized = match msg.serialize() {
+                                Ok(v) => v,
+                                Err(e) => {
+                                    let _ = cancel_tx.send(true);
+                                    break 'control Err(e);
+                                }
+                            };
+                            if ctrl_send.write_all(format!("{}\n", serialized).as_bytes()).await.is_err() {
                                 warn!("Failed to send pause/resume to server");
                             }
                         }
@@ -2042,7 +2057,13 @@ impl Client {
                     continue;
                 }
 
-                let msg: ControlMessage = ControlMessage::deserialize(line.trim())?;
+                let msg: ControlMessage = match ControlMessage::deserialize(line.trim()) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        let _ = cancel_tx.send(true);
+                        break 'control Err(e);
+                    }
+                };
 
                 match msg {
                     ControlMessage::Interval {

--- a/src/client.rs
+++ b/src/client.rs
@@ -2125,7 +2125,7 @@ impl Client {
         let join_timeout = stream_join_timeout(self.config.streams);
         match tokio::time::timeout(
             join_timeout,
-            futures::future::join_all(quic_handles.iter_mut()),
+            futures::future::join_all(quic_handles.iter_mut()), // iter_mut(), not into_iter() — we need handles for .abort() on timeout
         )
         .await
         {

--- a/src/pause.rs
+++ b/src/pause.rs
@@ -1,5 +1,13 @@
 use tokio::sync::watch;
 
+/// `watch::Receiver::has_changed` returns `Err(RecvError::Closed)` once all
+/// senders have dropped. It returns `Ok(_)` (either `true` or `false`) while at
+/// least one sender is alive, so callers that only care about channel closure
+/// should ignore the inner boolean and just check `is_ok()`.
+pub(crate) fn channel_is_open(pause: &watch::Receiver<bool>) -> bool {
+    pause.has_changed().is_ok()
+}
+
 /// Returns `true` when the stream is currently paused.
 ///
 /// Once the pause sender has been dropped, the `watch` channel is closed.
@@ -9,7 +17,7 @@ use tokio::sync::watch;
 /// closed pause channel as "not paused" so the stream resumes and is governed
 /// by cancel/deadline instead.
 pub(crate) fn is_paused(pause: &watch::Receiver<bool>) -> bool {
-    *pause.borrow() && pause.has_changed().is_ok()
+    *pause.borrow() && channel_is_open(pause)
 }
 
 /// Wait while paused, returns true if cancelled during wait.
@@ -27,7 +35,7 @@ pub(crate) async fn wait_while_paused(
             result = cancel.changed() => {
                 if result.is_err() || *cancel.borrow() { return true; }
             }
-            result = pause.changed(), if pause.has_changed().is_ok() => {
+            result = pause.changed() => {
                 if result.is_err() { return false; }
             }
         }
@@ -55,7 +63,23 @@ mod tests {
         );
     }
 
-    #[tokio::test(start_paused = true)]
+    #[tokio::test]
+    async fn channel_is_open_ignores_observed_change_state() {
+        let (tx, mut rx) = watch::channel(false);
+        tx.send(true).unwrap();
+        rx.changed().await.unwrap();
+
+        assert!(
+            !rx.has_changed().unwrap(),
+            "test setup should mark the latest value as observed"
+        );
+        assert!(
+            channel_is_open(&rx),
+            "Ok(false) means open with no unseen value, not closed"
+        );
+    }
+
+    #[tokio::test]
     async fn wait_while_paused_returns_when_sender_dropped() {
         let (pause_tx, mut pause_rx) = watch::channel(true);
         let (_cancel_tx, mut cancel_rx) = watch::channel(false);
@@ -65,7 +89,7 @@ mod tests {
 
         // Give the task a chance to start; with a paused=true + open sender
         // it should still be blocked.
-        tokio::time::advance(Duration::from_millis(10)).await;
+        tokio::time::sleep(Duration::from_millis(10)).await;
         assert!(!task.is_finished());
 
         // Dropping the sender must make the wait return promptly and without

--- a/src/pause.rs
+++ b/src/pause.rs
@@ -1,20 +1,83 @@
 use tokio::sync::watch;
 
-/// Wait while paused, returns true if cancelled during wait
+/// Returns `true` when the stream is currently paused.
+///
+/// Once the pause sender has been dropped, the `watch` channel is closed.
+/// `*pause.borrow()` would keep reporting the last value forever (possibly
+/// `true`), which would make any caller that keeps checking the receiver
+/// busy-loop because `pause.changed()` becomes immediately ready. Treat a
+/// closed pause channel as "not paused" so the stream resumes and is governed
+/// by cancel/deadline instead.
+pub(crate) fn is_paused(pause: &watch::Receiver<bool>) -> bool {
+    *pause.borrow() && pause.has_changed().is_ok()
+}
+
+/// Wait while paused, returns true if cancelled during wait.
+///
+/// If the pause sender is dropped while paused, this treats the stream as
+/// resumed (returns `false`) rather than spinning forever, matching the
+/// `is_paused` semantics.
 pub(crate) async fn wait_while_paused(
     pause: &mut watch::Receiver<bool>,
     cancel: &mut watch::Receiver<bool>,
 ) -> bool {
-    while *pause.borrow() {
+    while is_paused(pause) {
         tokio::select! {
             biased;
             result = cancel.changed() => {
                 if result.is_err() || *cancel.borrow() { return true; }
             }
-            result = pause.changed() => {
+            result = pause.changed(), if pause.has_changed().is_ok() => {
                 if result.is_err() { return false; }
             }
         }
     }
     false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn is_paused_treats_closed_channel_as_not_paused() {
+        let (tx, rx) = watch::channel(false);
+        assert!(!is_paused(&rx));
+
+        tx.send(true).unwrap();
+        assert!(is_paused(&rx));
+
+        drop(tx);
+        assert!(
+            !is_paused(&rx),
+            "closed pause channel should be treated as not paused"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn wait_while_paused_returns_when_sender_dropped() {
+        let (pause_tx, mut pause_rx) = watch::channel(true);
+        let (_cancel_tx, mut cancel_rx) = watch::channel(false);
+
+        let task =
+            tokio::spawn(async move { wait_while_paused(&mut pause_rx, &mut cancel_rx).await });
+
+        // Give the task a chance to start; with a paused=true + open sender
+        // it should still be blocked.
+        tokio::time::advance(Duration::from_millis(10)).await;
+        assert!(!task.is_finished());
+
+        // Dropping the sender must make the wait return promptly and without
+        // treating the event as a cancellation.
+        drop(pause_tx);
+        let result = tokio::time::timeout(Duration::from_secs(1), task)
+            .await
+            .expect("wait_while_paused should not hang after sender is dropped")
+            .expect("spawned task should not panic");
+        assert!(
+            !result,
+            "dropped pause sender should be treated as resumed, not cancelled"
+        );
+    }
 }

--- a/src/quic.rs
+++ b/src/quic.rs
@@ -350,7 +350,7 @@ pub async fn send_quic_data(
             break;
         }
 
-        if *pause.borrow() {
+        if crate::pause::is_paused(&pause) {
             if crate::pause::wait_while_paused(&mut pause, &mut cancel).await {
                 break;
             }

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -478,7 +478,7 @@ pub async fn send_data(
             break;
         }
 
-        if *pause.borrow() {
+        if crate::pause::is_paused(&pause) {
             if crate::pause::wait_while_paused(&mut pause, &mut cancel).await {
                 break;
             }
@@ -551,7 +551,7 @@ pub async fn send_data(
                                 debug!("Send cancelled during pacing sleep for stream {}", stats.stream_id);
                                 break;
                             }
-                            _ = pause.changed() => {} // will check pause at top of next loop
+                            _ = pause.changed(), if pause.has_changed().is_ok() => {}
                             _ = tokio::time::sleep(overshoot) => {}
                         }
                     }
@@ -812,7 +812,7 @@ pub async fn send_data_half(
             break;
         }
 
-        if *pause.borrow() {
+        if crate::pause::is_paused(&pause) {
             if crate::pause::wait_while_paused(&mut pause, &mut cancel).await {
                 break;
             }

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -551,7 +551,7 @@ pub async fn send_data(
                                 debug!("Send cancelled during pacing sleep for stream {}", stats.stream_id);
                                 break;
                             }
-                            _ = pause.changed(), if pause.has_changed().is_ok() => {}
+                            _ = pause.changed(), if crate::pause::channel_is_open(&pause) => {}
                             _ = tokio::time::sleep(overshoot) => {}
                         }
                     }
@@ -878,7 +878,7 @@ pub async fn send_data_half(
                                 debug!("Send cancelled during pacing sleep for stream {}", stats.stream_id);
                                 break;
                             }
-                            _ = pause.changed() => {}
+                            _ = pause.changed(), if crate::pause::channel_is_open(&pause) => {}
                             _ = tokio::time::sleep(overshoot) => {}
                         }
                     }

--- a/src/udp.rs
+++ b/src/udp.rs
@@ -608,7 +608,7 @@ pub async fn send_udp_paced(
             break;
         }
 
-        if *pause.borrow() {
+        if crate::pause::is_paused(&pause) {
             if crate::pause::wait_while_paused(&mut pause, &mut cancel).await {
                 break;
             }
@@ -622,7 +622,7 @@ pub async fn send_udp_paced(
                 if *cancel.borrow() { break; }
                 continue;
             }
-            _ = pause.changed() => { continue; } // re-check at top
+            _ = pause.changed(), if pause.has_changed().is_ok() => { continue; } // re-check at top
             _ = ticker.tick() => {}
         }
 
@@ -633,7 +633,7 @@ pub async fn send_udp_paced(
 
         // Send packets_per_tick packets in this burst
         for _ in 0..packets_per_tick {
-            if *cancel.borrow() || *pause.borrow() {
+            if *cancel.borrow() || crate::pause::is_paused(&pause) {
                 break;
             }
             if !is_infinite && Instant::now() >= deadline {
@@ -701,7 +701,7 @@ async fn send_udp_unlimited(
             break;
         }
 
-        if *pause.borrow() {
+        if crate::pause::is_paused(&pause) {
             if crate::pause::wait_while_paused(&mut pause, &mut cancel).await {
                 break;
             }
@@ -715,7 +715,7 @@ async fn send_udp_unlimited(
 
         // Send a burst of packets before yielding
         for _ in 0..BURST_SIZE {
-            if *cancel.borrow() || *pause.borrow() {
+            if *cancel.borrow() || crate::pause::is_paused(&pause) {
                 break;
             }
             if !is_infinite && Instant::now() >= deadline {
@@ -802,7 +802,7 @@ pub async fn receive_udp(
             break;
         }
 
-        if *pause.borrow() {
+        if crate::pause::is_paused(&pause) {
             if crate::pause::wait_while_paused(&mut pause, &mut cancel).await {
                 break;
             }

--- a/src/udp.rs
+++ b/src/udp.rs
@@ -622,7 +622,7 @@ pub async fn send_udp_paced(
                 if *cancel.borrow() { break; }
                 continue;
             }
-            _ = pause.changed(), if pause.has_changed().is_ok() => { continue; } // re-check at top
+            _ = pause.changed(), if crate::pause::channel_is_open(&pause) => { continue; } // re-check at top
             _ = ticker.tick() => {}
         }
 


### PR DESCRIPTION
## Fixes LAN-161

### Pause channel busy loop after a dropped sender

- Adds `pause::is_paused` so closed pause channels are treated as not paused instead of preserving a stale `true` value.
- Adds `pause::channel_is_open` for select guards that should ignore closed pause channels without starving timer branches.
- Updates TCP, UDP, and QUIC pause checks to use the helper instead of reading the raw watch value.
- Updates `wait_while_paused` so a sender drop between the loop check and `select!` wakes the waiter instead of hanging.

### QUIC stream task cleanup

- Tracks QUIC stream task handles in `Client::run_quic` instead of fire-and-forgetting them.
- Routes all control-loop exits through cancellation and `join_all`, using the existing stream join timeout and abort path.
- Replaces fallible `?` exits inside the cleanup block with explicit `break 'control Err(e)` so serialization/deserialization errors cannot bypass cleanup.
- Clears the reused control-line buffer before each `select!` iteration so pause/cancel events cannot reprocess a stale server message.

### Tests

- Adds pause-channel regression coverage for closed-channel state, open-channel observed state, and dropped-sender wakeup behavior.
- Keeps the dropped-sender async test on real time so a regression cannot hang under Tokio paused time.

### Local validation

- `cargo fmt --check`
- `cargo test --lib pause::tests --all-features`
- `cargo test --lib client::tests --all-features`
- `cargo test --all-features` — 369 passed, 1 ignored
- `cargo clippy --all-features -- -D warnings`
- `cargo clippy --all-targets --features prometheus -- -D warnings`
- `cargo check --no-default-features`
- `cargo clippy --no-default-features -- -D warnings`
- `git diff --check`