### PR TITLE
fix: cancel/pause latency and UDP burst after resume (LAN-160)

### DIFF
--- a/src/serve.rs
+++ b/src/serve.rs
@@ -43,8 +43,6 @@ const INITIAL_READ_TIMEOUT_PER_STREAM_MS: u64 = 80;
 const INITIAL_READ_TIMEOUT_MAX: Duration = Duration::from_secs(20);
 /// Interval between progress/stats updates sent to the client
 const STATS_INTERVAL: Duration = Duration::from_secs(1);
-/// How often to check for cancellation in send/receive loops
-const CANCEL_CHECK_TIMEOUT: Duration = Duration::from_millis(10);
 /// Brief delay before sending final result to allow buffered writes to flush
 const RESULT_FLUSH_DELAY: Duration = Duration::from_millis(100);
 /// Timeout for accepting a data stream connection on per-stream listeners
@@ -1529,7 +1527,7 @@ async fn handle_client_with_first_message(
 
     // Continue with test handling
     handle_test_request(
-        &mut reader,
+        reader,
         &mut writer,
         peer_addr,
         active_tests,
@@ -1604,7 +1602,7 @@ async fn handle_client_with_auth(
     // Continue with normal test handling
     // Note: dead code path - assumes single-port capable client and UDP feedback support
     handle_test_request(
-        &mut reader,
+        reader,
         &mut writer,
         peer_addr,
         active_tests,
@@ -1678,7 +1676,7 @@ async fn perform_auth_handshake<W: tokio::io::AsyncWrite + Unpin>(
 /// Handle test request after authentication
 #[allow(clippy::too_many_arguments)]
 async fn handle_test_request(
-    reader: &mut BufReader<tokio::net::tcp::OwnedReadHalf>,
+    mut reader: BufReader<tokio::net::tcp::OwnedReadHalf>,
     writer: &mut tokio::net::tcp::OwnedWriteHalf,
     peer_addr: SocketAddr,
     active_tests: Arc<Mutex<HashMap<String, ActiveTest>>>,
@@ -1691,7 +1689,7 @@ async fn handle_test_request(
     let mut line = String::new();
 
     // Read test request (with timeout)
-    tokio::time::timeout(HANDSHAKE_TIMEOUT, read_bounded_line(reader, &mut line))
+    tokio::time::timeout(HANDSHAKE_TIMEOUT, read_bounded_line(&mut reader, &mut line))
         .await
         .map_err(|_| anyhow::anyhow!("Handshake timeout waiting for test start"))??;
     let msg: ControlMessage = ControlMessage::deserialize(line.trim())?;
@@ -1878,7 +1876,7 @@ fn directional_totals(
 #[allow(clippy::too_many_arguments)]
 async fn run_quic_test(
     connection: &quinn::Connection,
-    mut ctrl_reader: BufReader<quinn::RecvStream>,
+    ctrl_reader: BufReader<quinn::RecvStream>,
     mut ctrl_send: quinn::SendStream,
     id: &str,
     streams: u8,
@@ -2021,96 +2019,102 @@ async fn run_quic_test(
     // always remove the active test entry and tear down live metrics, even if
     // an error or cancellation exits early.
     let run_result: anyhow::Result<(u64, f64)> = async {
-        // Send interval updates
+        // Spawn control-reader task (LAN-160 #13: avoid up to 1s cancel
+        // latency; LAN-229: avoid read_bounded_line desync under select!).
+        let (mut cmd_rx, control_handle) =
+            spawn_control_reader(ctrl_reader, id.to_string());
+
         let mut interval_timer = tokio::time::interval(STATS_INTERVAL);
-        // Skip stale ticks rather than bursting them on unblock: if write_all stalls
-        // under back-pressure, Burst would emit several stale interval samples with
-        // fresh client-side arrival timestamps once the writer unblocks — both the
-        // timestamps and the throughput numbers attached to those samples are
-        // misleading. Skip drops them; cumulative state in StreamStats atomics still
-        // surfaces correctly on the next live tick and at end-of-test.
         interval_timer.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
         let start = std::time::Instant::now();
-        let mut line = String::new();
 
-    loop {
-        tokio::select! {
-            _ = interval_timer.tick() => {
-                // Duration::ZERO means infinite - only break if duration is set
-                if duration != Duration::ZERO && start.elapsed() >= duration {
-                    break;
-                }
+        let mut loop_err: Option<anyhow::Error> = None;
+        loop {
+            tokio::select! {
+                _ = interval_timer.tick() => {
+                    if duration != Duration::ZERO && start.elapsed() >= duration {
+                        break;
+                    }
 
-                let intervals = stats.record_intervals();
-                let stream_intervals: Vec<StreamInterval> = stats.streams.iter()
-                    .zip(intervals.iter())
-                    .map(|(s, i)| s.to_interval(i))
-                    .collect();
-                let aggregate = stats.to_aggregate_with_direction(&intervals, direction == Direction::Bidir);
+                    let intervals = stats.record_intervals();
+                    let stream_intervals: Vec<StreamInterval> = stats.streams.iter()
+                        .zip(intervals.iter())
+                        .map(|(s, i)| s.to_interval(i))
+                        .collect();
+                    let aggregate = stats.to_aggregate_with_direction(&intervals, direction == Direction::Bidir);
 
-                let interval_msg = ControlMessage::Interval {
-                    id: id.to_string(),
-                    elapsed_ms: stats.elapsed_ms(),
-                    streams: stream_intervals,
-                    aggregate: aggregate.clone(),
-                };
-
-                if let Some(tx) = &tui_tx {
-                    let _ = tx.try_send(ServerEvent::TestUpdated {
+                    let interval_msg = ControlMessage::Interval {
                         id: id.to_string(),
-                        bytes: aggregate.bytes,
-                        throughput_mbps: aggregate.throughput_mbps,
-                    });
-                }
+                        elapsed_ms: stats.elapsed_ms(),
+                        streams: stream_intervals,
+                        aggregate: aggregate.clone(),
+                    };
 
-                if ctrl_send.write_all(format!("{}\n", interval_msg.serialize()?).as_bytes()).await.is_err() {
-                    warn!("Failed to send interval");
-                    break;
+                    if let Some(tx) = &tui_tx {
+                        let _ = tx.try_send(ServerEvent::TestUpdated {
+                            id: id.to_string(),
+                            bytes: aggregate.bytes,
+                            throughput_mbps: aggregate.throughput_mbps,
+                        });
+                    }
+
+                    match interval_msg.serialize() {
+                        Ok(serialized) => {
+                            if ctrl_send.write_all(format!("{}\n", serialized).as_bytes()).await.is_err() {
+                                warn!("Failed to send interval");
+                                break;
+                            }
+                        }
+                        Err(e) => {
+                            loop_err = Some(e);
+                            break;
+                        }
+                    }
+                }
+                cmd = cmd_rx.recv() => {
+                    match cmd {
+                        Some(ControlCommand::Cancel) => {
+                            info!("QUIC test {} cancelled by client", id);
+                            if let Some(test) = active_tests.lock().await.get(id) {
+                                let _ = test.cancel_tx.send(true);
+                            }
+                            let cancelled = ControlMessage::Cancelled { id: id.to_string() };
+                            match cancelled.serialize() {
+                                Ok(serialized) => {
+                                    if let Err(e) = ctrl_send.write_all(format!("{}\n", serialized).as_bytes()).await {
+                                        loop_err = Some(e.into());
+                                    }
+                                }
+                                Err(e) => loop_err = Some(e),
+                            }
+                            break;
+                        }
+                        Some(ControlCommand::Pause) => {
+                            info!("QUIC test {} paused", id);
+                            if let Some(test) = active_tests.lock().await.get(id) {
+                                let _ = test.pause_tx.send(true);
+                            }
+                        }
+                        Some(ControlCommand::Resume) => {
+                            info!("QUIC test {} resumed", id);
+                            if let Some(test) = active_tests.lock().await.get(id) {
+                                let _ = test.pause_tx.send(false);
+                            }
+                        }
+                        None => {
+                            debug!("Control reader for QUIC test {} exited", id);
+                            break;
+                        }
+                    }
                 }
             }
         }
 
-        // Check for cancel message (non-blocking, bounded read)
-        let read_result = tokio::time::timeout(
-            CANCEL_CHECK_TIMEOUT,
-            read_bounded_line(&mut ctrl_reader, &mut line),
-        )
-        .await;
+        control_handle.abort();
 
-        if let Ok(Ok(n)) = read_result
-            && n > 0
-        {
-            match ControlMessage::deserialize(line.trim()) {
-                Ok(ControlMessage::Cancel {
-                    id: cancel_id,
-                    reason,
-                }) if cancel_id == id => {
-                    info!("QUIC test {} cancelled: {}", id, reason);
-                    if let Some(test) = active_tests.lock().await.get(id) {
-                        let _ = test.cancel_tx.send(true);
-                    }
-                    let cancelled = ControlMessage::Cancelled { id: id.to_string() };
-                    ctrl_send
-                        .write_all(format!("{}\n", cancelled.serialize()?).as_bytes())
-                        .await?;
-                    break;
-                }
-                Ok(ControlMessage::Pause { id: pause_id }) if pause_id == id => {
-                    info!("QUIC test {} paused", id);
-                    if let Some(test) = active_tests.lock().await.get(id) {
-                        let _ = test.pause_tx.send(true);
-                    }
-                }
-                Ok(ControlMessage::Resume { id: resume_id }) if resume_id == id => {
-                    info!("QUIC test {} resumed", id);
-                    if let Some(test) = active_tests.lock().await.get(id) {
-                        let _ = test.pause_tx.send(false);
-                    }
-                }
-                _ => {}
-            }
+        if let Some(e) = loop_err {
+            return Err(e);
         }
-    }
 
     // Signal handlers to stop
     if let Some(test) = active_tests.lock().await.get(id) {
@@ -2220,7 +2224,7 @@ async fn run_quic_test(
 /// Run the actual bandwidth test
 #[allow(clippy::too_many_arguments)]
 async fn run_test(
-    reader: &mut BufReader<tokio::net::tcp::OwnedReadHalf>,
+    reader: BufReader<tokio::net::tcp::OwnedReadHalf>,
     writer: &mut tokio::net::tcp::OwnedWriteHalf,
     id: &str,
     protocol: Protocol,
@@ -2244,8 +2248,6 @@ async fn run_test(
     mtu_probe: bool,
     tcp_nodelay: bool,
 ) -> anyhow::Result<(u64, u64, f64)> {
-    let mut line = String::new();
-
     // For TCP: single-port mode (data connections come on control port)
     // For UDP: single-port mode (hello-routed connected sockets on the
     // main port, issue #63) or legacy per-stream sockets
@@ -2540,11 +2542,21 @@ async fn run_test(
         }
     };
 
+    // Spawn a dedicated control-reader task that owns the reader.  This
+    // avoids the LAN-229 desync hazard: read_bounded_line must never be
+    // a select! branch because cancelling a partial read loses buffered
+    // bytes.  The reader task sends parsed ControlCommands over an mpsc
+    // channel; the stats loop selects on that channel + the interval
+    // tick, giving sub-millisecond cancel/pause latency instead of up
+    // to 1s (LAN-160 #13).
+    let (mut cmd_rx, control_handle) = spawn_control_reader(reader, id.to_string());
+
     // Start interval loop IMMEDIATELY (don't wait for TCP stream collection)
     let mut interval_timer = tokio::time::interval(STATS_INTERVAL);
     interval_timer.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     let start = std::time::Instant::now();
 
+    let mut loop_err: Option<anyhow::Error> = None;
     loop {
         tokio::select! {
             _ = interval_timer.tick() => {
@@ -2576,51 +2588,67 @@ async fn run_test(
                     });
                 }
 
-                if writer.write_all(format!("{}\n", interval_msg.serialize()?).as_bytes()).await.is_err() {
-                    warn!("Failed to send interval, client may have disconnected");
-                    break;
+                match interval_msg.serialize() {
+                    Ok(serialized) => {
+                        if writer.write_all(format!("{}\n", serialized).as_bytes()).await.is_err() {
+                            warn!("Failed to send interval, client may have disconnected");
+                            break;
+                        }
+                    }
+                    Err(e) => {
+                        loop_err = Some(e);
+                        break;
+                    }
                 }
             }
-        }
-
-        // Check for cancel/pause/resume messages (bounded read)
-        let read_result =
-            tokio::time::timeout(CANCEL_CHECK_TIMEOUT, read_bounded_line(reader, &mut line)).await;
-
-        if let Ok(Ok(n)) = read_result
-            && n > 0
-        {
-            match ControlMessage::deserialize(line.trim()) {
-                Ok(ControlMessage::Cancel {
-                    id: cancel_id,
-                    reason,
-                }) if cancel_id == id => {
-                    info!("Test {} cancelled: {}", id, reason);
-                    if let Some(test) = active_tests.lock().await.get(id) {
-                        let _ = test.cancel_tx.send(true);
+            cmd = cmd_rx.recv() => {
+                match cmd {
+                    Some(ControlCommand::Cancel) => {
+                        info!("Test {} cancelled by client", id);
+                        if let Some(test) = active_tests.lock().await.get(id) {
+                            let _ = test.cancel_tx.send(true);
+                        }
+                        let cancelled = ControlMessage::Cancelled { id: id.to_string() };
+                        match cancelled.serialize() {
+                            Ok(serialized) => {
+                                if let Err(e) = writer.write_all(format!("{}\n", serialized).as_bytes()).await {
+                                    loop_err = Some(e.into());
+                                }
+                            }
+                            Err(e) => loop_err = Some(e),
+                        }
+                        break;
                     }
-                    let cancelled = ControlMessage::Cancelled { id: id.to_string() };
-                    writer
-                        .write_all(format!("{}\n", cancelled.serialize()?).as_bytes())
-                        .await?;
-                    break;
-                }
-                Ok(ControlMessage::Pause { id: pause_id }) if pause_id == id => {
-                    info!("Test {} paused", id);
-                    if let Some(test) = active_tests.lock().await.get(id) {
-                        let _ = test.pause_tx.send(true);
+                    Some(ControlCommand::Pause) => {
+                        info!("Test {} paused", id);
+                        if let Some(test) = active_tests.lock().await.get(id) {
+                            let _ = test.pause_tx.send(true);
+                        }
+                    }
+                    Some(ControlCommand::Resume) => {
+                        info!("Test {} resumed", id);
+                        if let Some(test) = active_tests.lock().await.get(id) {
+                            let _ = test.pause_tx.send(false);
+                        }
+                    }
+                    None => {
+                        // Reader task exited (client disconnected or EOF)
+                        debug!("Control reader for test {} exited", id);
+                        break;
                     }
                 }
-                Ok(ControlMessage::Resume { id: resume_id }) if resume_id == id => {
-                    info!("Test {} resumed", id);
-                    if let Some(test) = active_tests.lock().await.get(id) {
-                        let _ = test.pause_tx.send(false);
-                    }
-                }
-                _ => {}
             }
         }
     }
+
+    // Abort the control-reader task so it doesn't outlive the test
+    // (it may be blocked in read_bounded_line on a slow-disconnecting peer).
+    control_handle.abort();
+
+    if let Some(e) = loop_err {
+        return Err(e);
+    }
+
 
     // Signal handlers to stop
     if let Some(test) = active_tests.lock().await.get(id) {
@@ -2785,6 +2813,62 @@ async fn read_bounded_line<R: tokio::io::AsyncBufRead + Unpin>(
         reader.consume(len);
         total += len;
     }
+}
+
+/// Parsed control message from the client during a test.
+/// Sent over an mpsc channel by the dedicated control-reader task.
+enum ControlCommand {
+    Cancel,
+    Pause,
+    Resume,
+}
+
+/// Spawn a dedicated task that owns the control reader and sends parsed
+/// `ControlCommand`s over an mpsc channel.  This avoids the LAN-229
+/// desync hazard: `read_bounded_line` must never be a `select!` branch
+/// because cancelling a partial read loses buffered bytes.  The reader
+/// task owns the stream for the lifetime of the test, so reads never
+/// get cancelled mid-line.
+///
+/// Only `Cancel`, `Pause`, and `Resume` (matching `id`) are forwarded;
+/// everything else is silently dropped — the post-auth control channel
+/// carries no other valid messages during a test.
+fn spawn_control_reader<R: tokio::io::AsyncBufRead + Unpin + Send + 'static>(
+    mut reader: R,
+    id: String,
+) -> (mpsc::Receiver<ControlCommand>, JoinHandle<()>) {
+    let (tx, rx) = mpsc::channel::<ControlCommand>(16);
+    let handle = tokio::spawn(async move {
+        let mut line = String::new();
+        loop {
+            line.clear();
+            match read_bounded_line(&mut reader, &mut line).await {
+                Ok(0) | Err(_) => break,
+                Ok(_) => {
+                    if let Ok(msg) = ControlMessage::deserialize(line.trim()) {
+                        let cmd = match msg {
+                            ControlMessage::Cancel { id: cid, .. } if cid == id => {
+                                Some(ControlCommand::Cancel)
+                            }
+                            ControlMessage::Pause { id: pid } if pid == id => {
+                                Some(ControlCommand::Pause)
+                            }
+                            ControlMessage::Resume { id: rid } if rid == id => {
+                                Some(ControlCommand::Resume)
+                            }
+                            _ => None,
+                        };
+                        if let Some(cmd) = cmd
+                            && tx.send(cmd).await.is_err()
+                        {
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+    });
+    (rx, handle)
 }
 
 /// Legacy multi-port TCP handler (kept for potential fallback)

--- a/src/udp.rs
+++ b/src/udp.rs
@@ -593,6 +593,8 @@ pub async fn send_udp_paced(
 
     let mut sequence: u64 = 0;
     let mut ticker = interval(pacing_interval);
+    // Skip missed ticks during pause so we don't burst on resume (LAN-160 #14).
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     let start = Instant::now();
     let deadline = start + duration;
     let is_infinite = duration == Duration::ZERO;
@@ -612,6 +614,9 @@ pub async fn send_udp_paced(
             if crate::pause::wait_while_paused(&mut pause, &mut cancel).await {
                 break;
             }
+            // Reset the pacing baseline after resume so the first post-pause
+            // tick fires a full interval from now, not immediately (LAN-160 #14).
+            ticker.reset();
             continue;
         }
 
@@ -1523,5 +1528,85 @@ mod tests {
         // Out of order
         tracker.record(3);
         assert_eq!(tracker.out_of_order.load(Ordering::Relaxed), 1);
+    }
+
+    /// Regression for LAN-160 #14: after resume from pause, the paced
+    /// sender must not burst queued ticks.  With `MissedTickBehavior::Burst`
+    /// (the old default), ticks accumulated during pause fire all at once
+    /// on resume.  With `Skip` + `ticker.reset()`, the first post-resume
+    /// tick fires a full interval from resume.
+    ///
+    /// We send at 80 kbps (~7 packets/s, ~140ms interval), receive one
+    /// packet to confirm pacing is live, pause for 500ms (≈3 missed
+    /// ticks), then resume.  We assert no packet arrives in the first
+    /// half-interval (70ms) after resume — with Burst, queued ticks
+    /// would fire immediately.  Then we assert a packet does arrive
+    /// within 2× interval (280ms) — confirming the sender resumed.
+    #[tokio::test]
+    async fn test_udp_paced_no_burst_after_resume() {
+        let sender = Arc::new(UdpSocket::bind("127.0.0.1:0").await.unwrap());
+        let receiver = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let recv_addr = receiver.local_addr().unwrap();
+        sender.connect(recv_addr).await.unwrap();
+
+        // 80 kbps → ~7.1 packets/s → ~140ms interval (1 packet/tick).
+        let bitrate = 80_000;
+        let interval = Duration::from_millis(140);
+        let duration = Duration::from_secs(10);
+        let stats = Arc::new(StreamStats::new(0));
+        let (cancel_tx, cancel_rx) = watch::channel(false);
+        let (pause_tx, pause_rx) = watch::channel(false);
+
+        let send_socket = sender.clone();
+        let send_stats = stats.clone();
+        let send_handle = tokio::spawn(async move {
+            let _ = send_udp_paced(
+                send_socket,
+                None, // connected socket — send uses socket.send()
+                bitrate,
+                duration,
+                send_stats,
+                cancel_rx,
+                pause_rx,
+                false,
+            )
+            .await;
+        });
+
+        let mut buf = vec![0u8; 2048];
+
+        // 1. Receive one packet to confirm the sender is live and pacing.
+        tokio::time::timeout(Duration::from_secs(2), receiver.recv_from(&mut buf))
+            .await
+            .expect("should receive first packet within 2s")
+            .expect("recv_from failed");
+
+        // 2. Pause for 500ms (≈3 missed ticks with Burst).
+        let _ = pause_tx.send(true);
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        let _ = pause_tx.send(false);
+
+        // 3. Assert NO packet arrives in the first half-interval (70ms).
+        //    With Burst, ≥3 queued ticks would fire immediately, sending
+        //    packets that arrive well within 70ms.  With Skip + reset,
+        //    the next tick is a full interval (~140ms) away.
+        match tokio::time::timeout(interval / 2, receiver.recv_from(&mut buf)).await {
+            Ok(Ok(_)) => {
+                panic!("packet arrived within half-interval after resume — burst detected")
+            }
+            Ok(Err(_)) => panic!("recv_from error after resume"),
+            Err(_) => {} // timeout = no burst — expected
+        }
+
+        // 4. Assert a packet DOES arrive within 2× interval (280ms).
+        //    This confirms the sender resumed and pacing continued.
+        tokio::time::timeout(interval * 2, receiver.recv_from(&mut buf))
+            .await
+            .expect("should receive a packet within 2× interval after resume")
+            .expect("recv_from failed");
+
+        // Clean up.
+        let _ = cancel_tx.send(true);
+        let _ = send_handle.await;
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2959,3 +2959,173 @@ async fn test_single_port_udp_download_stats() {
         "download summary must carry receiver-side loss/jitter stats"
     );
 }
+
+// ============================================================================
+// LAN-160 regression tests: cancel latency and UDP post-resume burst
+// ============================================================================
+
+/// Regression for LAN-160 #13: cancel must reach the server and produce a
+/// result within sub-second latency, not after the 1s stats tick.  The old
+/// code only polled control messages after each interval tick, so a cancel
+/// sent at t=200ms wouldn't be seen until t>1s.
+///
+/// We cancel at 200ms and assert the client receives a result within 800ms
+/// of the cancel — well under the old worst-case ~2s (1s tick + 10ms read
+/// timeout + propagation).
+#[tokio::test]
+async fn test_tcp_cancel_latency_before_first_tick() {
+    let port = get_test_port();
+    let _server = start_test_server(port).await;
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let config = ClientConfig {
+        host: "127.0.0.1".to_string(),
+        port,
+        protocol: Protocol::Tcp,
+        streams: 1,
+        duration: Duration::from_secs(60), // Long; we cancel early
+        direction: Direction::Upload,
+        bitrate: None,
+        tcp_nodelay: false,
+        window_size: None,
+        tcp_congestion: None,
+        psk: None,
+        address_family: xfr::net::AddressFamily::default(),
+        bind_addr: None,
+        sequential_ports: false,
+        mptcp: false,
+        random_payload: false,
+        zerocopy: ZerocopyMode::Off,
+        dscp: None,
+        mtu_probe: false,
+        connect_timeout: None,
+    };
+
+    let client = Client::new(config);
+
+    // Drive the test future concurrently with a timer that cancels at
+    // 200ms.  The select! polls both futures, so run_future makes
+    // progress (handshake, data start) while we wait to cancel.
+    let run_future = client.run(None);
+    tokio::pin!(run_future);
+
+    let control = async {
+        // 200ms — before the first 1s stats tick.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        // Poll cancel() until the control loop is ready.
+        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        loop {
+            if client.cancel().is_ok() {
+                return;
+            }
+            if std::time::Instant::now() > deadline {
+                panic!("cancel() never became ready within 2s");
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    };
+
+    // Race: run completes (unexpected for 60s test) vs control fires cancel.
+    tokio::select! {
+        r = &mut run_future => {
+            panic!("60s test should not complete before cancel: {:?}", r);
+        }
+        _ = control => {}
+    }
+
+    // After cancel fires, the server should respond promptly via the
+    // mpsc channel — well under 1s with the fix.  The old serialized
+    // loop would need >1s (waiting for the next interval tick).
+    let result = timeout(Duration::from_millis(800), &mut run_future)
+        .await
+        .expect("cancel should produce a result within 800ms");
+
+    assert!(
+        result.is_ok(),
+        "cancel should produce a prompt result: {:?}",
+        result
+    );
+}
+
+/// Smoke test for LAN-160 #14: verifies the UDP pause/resume path with
+/// `MissedTickBehavior::Skip` + `ticker.reset()` doesn't deadlock, panic,
+/// or produce errors.  The actual burst-prevention assertion is in
+/// `src/udp.rs:test_udp_paced_no_burst_after_resume` which directly
+/// observes packet timing after resume.
+#[tokio::test]
+async fn test_udp_pause_resume_no_burst() {
+    let port = get_test_port();
+    let _server = start_test_server(port).await;
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let config = ClientConfig {
+        host: "127.0.0.1".to_string(),
+        port,
+        protocol: Protocol::Udp,
+        streams: 1,
+        duration: Duration::from_secs(3),
+        direction: Direction::Upload,
+        bitrate: Some(1_000_000), // 1 Mbps — low rate so burst would be visible
+        tcp_nodelay: false,
+        window_size: None,
+        tcp_congestion: None,
+        psk: None,
+        address_family: xfr::net::AddressFamily::default(),
+        bind_addr: None,
+        sequential_ports: false,
+        mptcp: false,
+        random_payload: false,
+        zerocopy: ZerocopyMode::Off,
+        dscp: None,
+        mtu_probe: false,
+        connect_timeout: None,
+    };
+
+    let client = Client::new(config);
+
+    // Drive the test concurrently with a pause/resume control sequence.
+    let run_future = client.run(None);
+    tokio::pin!(run_future);
+
+    let control = async {
+        // Wait for pause to become ready (capability negotiation), then
+        // pause, then resume after 500ms.
+        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        loop {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            if client.pause() == xfr::client::PauseResult::Applied {
+                break;
+            }
+            if std::time::Instant::now() > deadline {
+                panic!("pause() never became ready within 2s");
+            }
+        }
+        // Resume after 500ms of pause.
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        let _ = client.pause(); // toggle back to resume
+    };
+
+    // Race: run completes (expected at 3s) vs control finishes resume.
+    tokio::select! {
+        r = &mut run_future => {
+            // Test finished before pause/resume — acceptable on fast
+            // machines, but assert it succeeded.
+            assert!(r.is_ok(), "UDP test should succeed: {:?}", r);
+            return;
+        }
+        _ = control => {}
+    }
+
+    // After resume, the test should complete within 10s (3s duration
+    // + pause overhead).  Key assertion: no deadlock, no panic, no
+    // error from the pause/resume + Skip path.
+    let result = timeout(Duration::from_secs(10), &mut run_future)
+        .await
+        .expect("UDP pause/resume test should complete within 10s");
+
+    assert!(
+        result.is_ok(),
+        "UDP test should succeed after pause/resume: {:?}",
+        result
+    );
+}


### PR DESCRIPTION
## Summary

Two lifecycle bugs fixed (LAN-160 #13 + #14):

### #13: Cancel/pause serialized behind 1s interval tick

Server test loops (TCP + QUIC) used `select!` with only the 1s interval tick as a branch, then polled control messages with a 10ms timeout *after* each tick. Cancel/pause latency was up to 1s.

**Fix:** Spawn a dedicated control-reader task that owns the read half, parses `Cancel`/`Pause`/`Resume`, and sends them over an mpsc channel. The stats loop selects on the channel + interval tick concurrently, giving sub-millisecond cancel/pause latency. This also avoids the LAN-229 desync hazard (`read_bounded_line` as a `select!` branch would cancel mid-line reads).

The reader task is aborted after every loop exit path, including errors, to prevent leaking a task blocked in `read_bounded_line`.

### #14: UDP paced sender bursts after resume

`send_udp_paced` used the default `MissedTickBehavior::Burst`, so ticks queued during pause fired all at once on resume, flooding the link.

**Fix:** Set `MissedTickBehavior::Skip` and call `ticker.reset()` after resume so the first post-pause tick fires a full interval from resume.

### Deferred: Pause does not stop the duration clock

Data-plane senders (TCP/QUIC/UDP) still compute `deadline = start + duration` using wall-clock time. Propagating a pause-aware clock through all sender tasks is tracked as a separate follow-up.

### Changes

- **`src/serve.rs`**: `ControlCommand` enum, `spawn_control_reader` helper, TCP + QUIC test loops rewritten to `select!` on interval + command channel concurrently; `run_test`/`handle_test_request` take reader by value (moved into reader task); `control_handle.abort()` on every exit path; removed unused `CANCEL_CHECK_TIMEOUT` constant
- **`src/udp.rs`**: `MissedTickBehavior::Skip` on pacing ticker, `ticker.reset()` after resume; unit test `test_udp_paced_no_burst_after_resume`
- **`tests/integration.rs`**: `test_tcp_cancel_latency_before_first_tick` (cancel at 200ms, assert result within 800ms), `test_udp_pause_resume_no_burst` (smoke test)

### Verification

- `cargo test --all-features`: 244 lib + 64 integration + 42 + 20 + 2 tests pass
- `cargo clippy --all-targets --all-features -- -D warnings`: clean
- `cargo fmt --check`: clean

Closes LAN-160 (#13 + #14).