### PR TITLE
fix: pause-aware duration clock in senders and server stats (LAN-230)

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -938,9 +938,13 @@ impl Client {
             self.config.duration + Duration::from_secs(30)
         };
         let mut deadline = tokio::time::Instant::now() + timeout_duration;
-        let local_end_deadline =
+        let mut local_end_deadline =
             local_stop_deadline(tokio::time::Instant::now(), self.config.duration);
         let mut local_stop_sent = false;
+        // Pause-aware clocks (LAN-230): while paused, freeze the response
+        // timeout and local-end deadline; on resume, extend both by the
+        // paused duration so pause time isn't charged against them.
+        let mut pause_started_at: Option<tokio::time::Instant> = None;
 
         let mut test_result: anyhow::Result<TestResult> =
             Err(anyhow::anyhow!("Connection closed without result"));
@@ -1171,6 +1175,17 @@ impl Client {
                         pause_request_open = false;
                     } else {
                         let paused = *pause_request_rx.borrow();
+                        if paused {
+                            if pause_started_at.is_none() {
+                                pause_started_at = Some(tokio::time::Instant::now());
+                            }
+                        } else if let Some(started) = pause_started_at.take() {
+                            let paused_for = started.elapsed();
+                            deadline += paused_for;
+                            if let Some(local_end) = &mut local_end_deadline {
+                                *local_end += paused_for;
+                            }
+                        }
                         // Always pause local data loops
                         let _ = pause_tx.send(paused);
                         // Send protocol message only if server supports it
@@ -1204,7 +1219,7 @@ impl Client {
                     if let Some(local_end) = local_end_deadline {
                         tokio::time::sleep_until(local_end).await;
                     }
-                }, if !local_stop_sent && local_end_deadline.is_some() => {
+                }, if !local_stop_sent && local_end_deadline.is_some() && pause_started_at.is_none() => {
                     // Stop local data loops at local test end instead of waiting for Result.
                     // This narrows the race where server-side teardown can trigger RSTs while
                     // client send loops are still writing.
@@ -1212,11 +1227,13 @@ impl Client {
                     let _ = cancel_tx.send(true);
                     debug!("Local test duration reached; stopping data streams while awaiting final control message");
                 }
-                _ = tokio::time::sleep_until(deadline) => {
+                _ = tokio::time::sleep_until(deadline), if pause_started_at.is_none() => {
                     // Overall response timeout — the old loop wrapped
                     // read_message in timeout_at(deadline, ...).  Now that
                     // the reader task owns the read, we enforce the deadline
                     // here so the loop cannot hang waiting for the channel.
+                    // Gated off while paused (LAN-230) so pause time isn't
+                    // charged against the server-response budget.
                     test_result = Err(anyhow::anyhow!(
                         "Timeout waiting for server response"
                     ));
@@ -2155,6 +2172,9 @@ impl Client {
                 self.config.duration + Duration::from_secs(30)
             };
             let mut deadline = tokio::time::Instant::now() + timeout_duration;
+            // Pause-aware response timeout (LAN-230): frozen while paused,
+            // extended by the paused duration on resume.
+            let mut pause_started_at: Option<tokio::time::Instant> = None;
 
             loop {
                 // Select on the dedicated reader task's channel (not the raw
@@ -2253,6 +2273,13 @@ impl Client {
                             pause_request_open = false;
                         } else {
                             let paused = *pause_request_rx.borrow();
+                            if paused {
+                                if pause_started_at.is_none() {
+                                    pause_started_at = Some(tokio::time::Instant::now());
+                                }
+                            } else if let Some(started) = pause_started_at.take() {
+                                deadline += started.elapsed();
+                            }
                             let _ = pause_tx.send(paused);
                             if supports_pause {
                                 let msg = if paused {
@@ -2273,11 +2300,12 @@ impl Client {
                             }
                         }
                     }
-                    _ = tokio::time::sleep_until(deadline) => {
+                    _ = tokio::time::sleep_until(deadline), if pause_started_at.is_none() => {
                         // Overall response timeout — the old loop wrapped
                         // read_message in timeout_at(deadline, ...).  Now
                         // the reader task owns the read, so we enforce the
                         // deadline here to prevent hanging on the channel.
+                        // Gated off while paused (LAN-230).
                         let _ = cancel_tx.send(true);
                         break 'control Err(anyhow::anyhow!(
                             "Timeout waiting for server response"

--- a/src/pause.rs
+++ b/src/pause.rs
@@ -43,6 +43,19 @@ pub(crate) async fn wait_while_paused(
     false
 }
 
+/// Like [`wait_while_paused`] but also returns the wall-clock time spent
+/// in the paused state, so callers can accumulate `paused_total` and
+/// extend their deadline accordingly (LAN-230).
+pub(crate) async fn wait_while_paused_timed(
+    pause: &mut watch::Receiver<bool>,
+    cancel: &mut watch::Receiver<bool>,
+) -> (bool, std::time::Duration) {
+    let pause_start = std::time::Instant::now();
+    let cancelled = wait_while_paused(pause, cancel).await;
+    let paused = pause_start.elapsed();
+    (cancelled, paused)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -104,4 +117,32 @@ mod tests {
             "dropped pause sender should be treated as resumed, not cancelled"
         );
     }
+
+    /// Regression for LAN-230: `wait_while_paused_timed` must return the
+    /// wall-clock duration spent paused so callers can extend their deadline.
+    #[tokio::test]
+    async fn wait_while_paused_timed_returns_pause_duration() {
+        let (pause_tx, mut pause_rx) = watch::channel(true);
+        let (_cancel_tx, mut cancel_rx) = watch::channel(false);
+
+        // Spawn the wait task while pause is active
+        let task = tokio::spawn(async move {
+            wait_while_paused_timed(&mut pause_rx, &mut cancel_rx).await
+        });
+
+        // Let it block for ~50ms, then resume
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        pause_tx.send(false).unwrap();
+
+        let (cancelled, paused) = tokio::time::timeout(Duration::from_secs(1), task)
+            .await
+            .expect("timed out waiting for task")
+            .expect("task panicked");
+        assert!(!cancelled, "should not be cancelled");
+        assert!(
+            paused >= Duration::from_millis(40),
+            "paused duration {paused:?} should be >= 40ms"
+        );
+    }
+
 }

--- a/src/pause.rs
+++ b/src/pause.rs
@@ -126,9 +126,10 @@ mod tests {
         let (_cancel_tx, mut cancel_rx) = watch::channel(false);
 
         // Spawn the wait task while pause is active
-        let task = tokio::spawn(async move {
-            wait_while_paused_timed(&mut pause_rx, &mut cancel_rx).await
-        });
+        let task =
+            tokio::spawn(
+                async move { wait_while_paused_timed(&mut pause_rx, &mut cancel_rx).await },
+            );
 
         // Let it block for ~50ms, then resume
         tokio::time::sleep(Duration::from_millis(50)).await;
@@ -144,5 +145,4 @@ mod tests {
             "paused duration {paused:?} should be >= 40ms"
         );
     }
-
 }

--- a/src/quic.rs
+++ b/src/quic.rs
@@ -341,8 +341,9 @@ pub async fn send_quic_data(
     mut pause: watch::Receiver<bool>,
 ) -> anyhow::Result<()> {
     let buffer = vec![0u8; DEFAULT_BUFFER_SIZE];
-    let deadline = tokio::time::Instant::now() + duration;
+    let mut deadline = tokio::time::Instant::now() + duration;
     let is_infinite = duration == Duration::ZERO;
+    let mut paused_total = Duration::ZERO;
 
     loop {
         if *cancel.borrow() {
@@ -351,9 +352,14 @@ pub async fn send_quic_data(
         }
 
         if crate::pause::is_paused(&pause) {
-            if crate::pause::wait_while_paused(&mut pause, &mut cancel).await {
+            let (cancelled, paused) =
+                crate::pause::wait_while_paused_timed(&mut pause, &mut cancel).await;
+            if cancelled {
                 break;
             }
+            // Extend the deadline by the time spent paused (LAN-230)
+            paused_total += paused;
+            deadline += paused;
             continue;
         }
 
@@ -362,11 +368,33 @@ pub async fn send_quic_data(
             break;
         }
 
-        match send.write(&buffer).await {
-            Ok(n) => stats.add_bytes_sent(n as u64),
-            Err(e) => {
-                error!("QUIC send error: {}", e);
-                return Err(e.into());
+        // Race the write against cancel, deadline, and pause so a blocked
+        // write can be interrupted (LAN-230).
+        tokio::select! {
+            biased;
+            res = cancel.changed() => {
+                if res.is_err() || *cancel.borrow() {
+                    debug!("QUIC send cancelled during write");
+                    break;
+                }
+            }
+            _ = pause.changed(), if crate::pause::channel_is_open(&pause) => {
+                // Pause toggled during write — loop back to handle it
+                // and extend the deadline (LAN-230).
+                continue;
+            }
+            _ = tokio::time::sleep_until(deadline), if !is_infinite => {
+                debug!("QUIC send deadline reached during write");
+                break;
+            }
+            result = send.write(&buffer) => {
+                match result {
+                    Ok(n) => stats.add_bytes_sent(n as u64),
+                    Err(e) => {
+                        error!("QUIC send error: {}", e);
+                        return Err(e.into());
+                    }
+                }
             }
         }
     }

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -1805,6 +1805,23 @@ fn directional_totals(
     )
 }
 
+fn active_elapsed(
+    start: std::time::Instant,
+    paused_total: Duration,
+    pause_start: Option<std::time::Instant>,
+) -> Duration {
+    let active_pause = pause_start.map(|p| p.elapsed()).unwrap_or_default();
+    start.elapsed().saturating_sub(paused_total + active_pause)
+}
+
+fn active_elapsed_ms(
+    start: std::time::Instant,
+    paused_total: Duration,
+    pause_start: Option<std::time::Instant>,
+) -> u64 {
+    active_elapsed(start, paused_total, pause_start).as_millis() as u64
+}
+
 /// Run a QUIC bandwidth test
 #[allow(clippy::too_many_arguments)]
 async fn run_quic_test(
@@ -1980,9 +1997,9 @@ async fn run_quic_test(
                     // Duration::ZERO means infinite - only break if duration is set.
                     // Subtract paused_total plus any in-progress pause so the
                     // clock doesn't expire while paused (LAN-230).
-                    let active_pause = pause_start.map(|p| p.elapsed()).unwrap_or_default();
+                    let active_elapsed = active_elapsed(start, paused_total, pause_start);
                     if duration != Duration::ZERO
-                        && start.elapsed() - paused_total - active_pause >= duration
+                        && active_elapsed >= duration
                     {
                         break;
                     }
@@ -1996,7 +2013,7 @@ async fn run_quic_test(
 
                     let interval_msg = ControlMessage::Interval {
                         id: id.to_string(),
-                        elapsed_ms: stats.elapsed_ms(),
+                        elapsed_ms: active_elapsed.as_millis() as u64,
                         streams: stream_intervals,
                         aggregate: aggregate.clone(),
                     };
@@ -2090,7 +2107,7 @@ async fn run_quic_test(
         }
 
         // Send final result
-        let duration_ms = stats.elapsed_ms();
+        let duration_ms = active_elapsed_ms(start, paused_total, pause_start);
         let bytes_total = stats.total_bytes();
         let throughput_mbps = if duration_ms > 0 {
             (bytes_total as f64 * 8.0) / (duration_ms as f64 / 1000.0) / 1_000_000.0
@@ -2523,9 +2540,9 @@ async fn run_test(
                 // Duration::ZERO means infinite - only break if duration is set.
                 // Subtract paused_total plus any in-progress pause so the
                 // clock doesn't expire while paused (LAN-230).
-                let active_pause = pause_start.map(|p| p.elapsed()).unwrap_or_default();
+                let active_elapsed = active_elapsed(start, paused_total, pause_start);
                 if duration != Duration::ZERO
-                    && start.elapsed() - paused_total - active_pause >= duration
+                    && active_elapsed >= duration
                 {
                     break;
                 }
@@ -2539,7 +2556,7 @@ async fn run_test(
 
                 let interval_msg = ControlMessage::Interval {
                     id: id.to_string(),
-                    elapsed_ms: stats.elapsed_ms(),
+                    elapsed_ms: active_elapsed.as_millis() as u64,
                     streams: stream_intervals,
                     aggregate: aggregate.clone(),
                 };
@@ -2663,7 +2680,7 @@ async fn run_test(
     }
 
     // Send final result
-    let duration_ms = stats.elapsed_ms();
+    let duration_ms = active_elapsed_ms(start, paused_total, pause_start);
     let bytes_total = stats.total_bytes();
     let throughput_mbps = if duration_ms > 0 {
         (bytes_total as f64 * 8.0) / (duration_ms as f64 / 1000.0) / 1_000_000.0

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -1970,13 +1970,20 @@ async fn run_quic_test(
         // surfaces correctly on the next live tick and at end-of-test.
         interval_timer.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
         let start = std::time::Instant::now();
+        let mut paused_total = Duration::ZERO;
+        let mut pause_start: Option<std::time::Instant> = None;
 
         let mut loop_err: Option<anyhow::Error> = None;
         loop {
             tokio::select! {
                 _ = interval_timer.tick() => {
-                    // Duration::ZERO means infinite - only break if duration is set
-                    if duration != Duration::ZERO && start.elapsed() >= duration {
+                    // Duration::ZERO means infinite - only break if duration is set.
+                    // Subtract paused_total plus any in-progress pause so the
+                    // clock doesn't expire while paused (LAN-230).
+                    let active_pause = pause_start.map(|p| p.elapsed()).unwrap_or_default();
+                    if duration != Duration::ZERO
+                        && start.elapsed() - paused_total - active_pause >= duration
+                    {
                         break;
                     }
 
@@ -2035,12 +2042,18 @@ async fn run_quic_test(
                         }
                         Some(ControlCommand::Pause) => {
                             info!("QUIC test {} paused", id);
+                            if pause_start.is_none() {
+                                pause_start = Some(std::time::Instant::now());
+                            }
                             if let Some(test) = active_tests.lock().await.get(id) {
                                 let _ = test.pause_tx.send(true);
                             }
                         }
                         Some(ControlCommand::Resume) => {
                             info!("QUIC test {} resumed", id);
+                            if let Some(pause_instant) = pause_start.take() {
+                                paused_total += pause_instant.elapsed();
+                            }
                             if let Some(test) = active_tests.lock().await.get(id) {
                                 let _ = test.pause_tx.send(false);
                             }
@@ -2491,8 +2504,8 @@ async fn run_test(
     // Split the transport: the reader task owns the recv half + the
     // buffered reader; the stats loop owns the send half.  This gives
     // prompt cancel/pause latency (not serialized behind the 1s stats
-    // tick, LAN-160 #13) while avoiding the LAN-229 desync hazard
-    // (read_message is never cancelled mid-frame).
+    // interval tick) without the LAN-229 desync hazard (read_message is
+    // never cancelled mid-frame).
     let (ctrl_reader, mut ctrl_writer) = transport.split();
     let (mut cmd_rx, control_handle) = spawn_control_reader(reader, ctrl_reader, id.to_string());
 
@@ -2500,13 +2513,20 @@ async fn run_test(
     let mut interval_timer = tokio::time::interval(STATS_INTERVAL);
     interval_timer.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     let start = std::time::Instant::now();
+    let mut paused_total = Duration::ZERO;
+    let mut pause_start: Option<std::time::Instant> = None;
 
     let mut loop_err: Option<anyhow::Error> = None;
     loop {
         tokio::select! {
             _ = interval_timer.tick() => {
-                // Duration::ZERO means infinite - only break if duration is set
-                if duration != Duration::ZERO && start.elapsed() >= duration {
+                // Duration::ZERO means infinite - only break if duration is set.
+                // Subtract paused_total plus any in-progress pause so the
+                // clock doesn't expire while paused (LAN-230).
+                let active_pause = pause_start.map(|p| p.elapsed()).unwrap_or_default();
+                if duration != Duration::ZERO
+                    && start.elapsed() - paused_total - active_pause >= duration
+                {
                     break;
                 }
 
@@ -2566,12 +2586,18 @@ async fn run_test(
                     }
                     Some(ControlCommand::Pause) => {
                         info!("Test {} paused", id);
+                        if pause_start.is_none() {
+                            pause_start = Some(std::time::Instant::now());
+                        }
                         if let Some(test) = active_tests.lock().await.get(id) {
                             let _ = test.pause_tx.send(true);
                         }
                     }
                     Some(ControlCommand::Resume) => {
                         info!("Test {} resumed", id);
+                        if let Some(pause_instant) = pause_start.take() {
+                            paused_total += pause_instant.elapsed();
+                        }
                         if let Some(test) = active_tests.lock().await.get(id) {
                             let _ = test.pause_tx.send(false);
                         }

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -465,8 +465,9 @@ pub async fn send_data(
     }
     let mut zerocopy = setup_zerocopy(&config, &buffer, stats.stream_id);
     let start = tokio::time::Instant::now();
-    let deadline = start + duration;
+    let mut deadline = start + duration;
     let is_infinite = duration == Duration::ZERO;
+    let mut paused_total = Duration::ZERO;
     let mut pace_start = start;
     let mut pace_bytes_offset: u64 = 0;
     let mut chunk_offset: usize = 0;
@@ -479,9 +480,14 @@ pub async fn send_data(
         }
 
         if crate::pause::is_paused(&pause) {
-            if crate::pause::wait_while_paused(&mut pause, &mut cancel).await {
+            let (cancelled, paused) =
+                crate::pause::wait_while_paused_timed(&mut pause, &mut cancel).await;
+            if cancelled {
                 break;
             }
+            // Extend the deadline by the time spent paused (LAN-230)
+            paused_total += paused;
+            deadline += paused;
             // Reset pacing baseline after resume to prevent catch-up burst
             pace_start = tokio::time::Instant::now();
             pace_bytes_offset = stats.bytes_sent.load(std::sync::atomic::Ordering::Relaxed);
@@ -507,8 +513,6 @@ pub async fn send_data(
                         debug!("Send cancelled during write for stream {}", stats.stream_id);
                     }
                     Ok(()) => {
-                        // Value changed but not to true — no-op in practice since
-                        // cancel is one-shot; defensive against future reuse.
                         debug!("Cancel signal toggled for stream {}, stopping", stats.stream_id);
                     }
                     Err(_) => {
@@ -516,6 +520,12 @@ pub async fn send_data(
                     }
                 }
                 break;
+            }
+            _ = pause.changed(), if crate::pause::channel_is_open(&pause) => {
+                // Pause toggled during write — loop back to handle it,
+                // which calls wait_while_paused_timed and extends the
+                // deadline by the paused duration (LAN-230).
+                continue;
             }
             _ = tokio::time::sleep_until(deadline), if !is_infinite => {
                 debug!("Deadline reached during write for stream {}", stats.stream_id);
@@ -799,8 +809,9 @@ pub async fn send_data_half(
     }
     let mut zerocopy = setup_zerocopy(&config, &buffer, stats.stream_id);
     let start = tokio::time::Instant::now();
-    let deadline = start + duration;
+    let mut deadline = start + duration;
     let is_infinite = duration == Duration::ZERO;
+    let mut paused_total = Duration::ZERO;
     let mut pace_start = start;
     let mut pace_bytes_offset: u64 = 0;
     let mut chunk_offset: usize = 0;
@@ -813,9 +824,14 @@ pub async fn send_data_half(
         }
 
         if crate::pause::is_paused(&pause) {
-            if crate::pause::wait_while_paused(&mut pause, &mut cancel).await {
+            let (cancelled, paused) =
+                crate::pause::wait_while_paused_timed(&mut pause, &mut cancel).await;
+            if cancelled {
                 break;
             }
+            // Extend the deadline by the time spent paused (LAN-230)
+            paused_total += paused;
+            deadline += paused;
             pace_start = tokio::time::Instant::now();
             pace_bytes_offset = stats.bytes_sent.load(std::sync::atomic::Ordering::Relaxed);
             continue;
@@ -826,9 +842,9 @@ pub async fn send_data_half(
             break;
         }
 
-        // Race write against cancel + deadline so a blocked write (e.g. under
-        // heavy tc rate limiting with full kernel send buffer) doesn't prevent
-        // the loop from noticing the test is over. See send_data for details.
+        // Race write against cancel + deadline + pause so a blocked write
+        // (e.g. under heavy tc rate limiting with full kernel send buffer)
+        // doesn't prevent the loop from noticing the test is over or paused.
         let write_result = tokio::select! {
             biased;
             res = cancel.changed() => {
@@ -844,6 +860,12 @@ pub async fn send_data_half(
                     }
                 }
                 break;
+            }
+            _ = pause.changed(), if crate::pause::channel_is_open(&pause) => {
+                // Pause toggled during write — loop back to handle it,
+                // which calls wait_while_paused_timed and extends the
+                // deadline by the paused duration (LAN-230).
+                continue;
             }
             _ = tokio::time::sleep_until(deadline), if !is_infinite => {
                 debug!("Deadline reached during write for stream {}", stats.stream_id);

--- a/src/udp.rs
+++ b/src/udp.rs
@@ -600,8 +600,9 @@ pub async fn send_udp_paced(
         t
     };
     let start = Instant::now();
-    let deadline = start + duration;
+    let mut deadline = start + duration;
     let is_infinite = duration == Duration::ZERO;
+    let mut paused_total = Duration::ZERO;
 
     let mut packet = vec![0u8; packet_size];
     if random_payload {
@@ -613,11 +614,15 @@ pub async fn send_udp_paced(
             debug!("UDP send cancelled");
             break;
         }
-
         if crate::pause::is_paused(&pause) {
-            if crate::pause::wait_while_paused(&mut pause, &mut cancel).await {
+            let (cancelled, paused) =
+                crate::pause::wait_while_paused_timed(&mut pause, &mut cancel).await;
+            if cancelled {
                 break;
             }
+            // Extend the deadline by the time spent paused (LAN-230)
+            paused_total += paused;
+            deadline += paused;
             // Reset the pacing ticker after resume so the first post-pause
             // tick fires a full interval from now, not immediately (the
             // queued tick from before pause would fire instantly and cause
@@ -697,8 +702,9 @@ async fn send_udp_unlimited(
     let packet_size = UDP_PAYLOAD_SIZE;
     let mut sequence: u64 = 0;
     let start = Instant::now();
-    let deadline = start + duration;
+    let mut deadline = start + duration;
     let is_infinite = duration == Duration::ZERO;
+    let mut paused_total = Duration::ZERO;
     let mut packet = vec![0u8; packet_size];
     if random_payload {
         rand::RngExt::fill(&mut rand::rng(), &mut packet[UDP_HEADER_SIZE..]);
@@ -712,11 +718,15 @@ async fn send_udp_unlimited(
             debug!("UDP send cancelled");
             break;
         }
-
         if crate::pause::is_paused(&pause) {
-            if crate::pause::wait_while_paused(&mut pause, &mut cancel).await {
+            let (cancelled, paused) =
+                crate::pause::wait_while_paused_timed(&mut pause, &mut cancel).await;
+            if cancelled {
                 break;
             }
+            // Extend the deadline by the time spent paused (LAN-230)
+            paused_total += paused;
+            deadline += paused;
             continue;
         }
 


### PR DESCRIPTION
Closes LAN-230.

## Problem

When a test is paused, the duration clock kept ticking. All data-plane sender tasks computed `deadline = start + duration` using wall-clock time that did not account for paused intervals. The server stats loops similarly checked `start.elapsed() >= duration` without subtracting paused time.

A 10-second test paused for 5 seconds ran only 5 seconds of active transfer but reported a 10-second duration — the test expired during the pause.

## Fix

### `pause.rs`: `wait_while_paused_timed`
New helper that returns `(cancelled, paused_duration)` so callers can accumulate `paused_total` and extend their deadline.

### TCP/QUIC/UDP senders (`tcp.rs`, `quic.rs`, `udp.rs`)
- Track `paused_total: Duration` and make `deadline` mutable
- On resume: `paused_total += paused; deadline += paused`
- Add `pause.changed()` arms (guarded by `channel_is_open`) to every blocking `select!` so pause interrupts a blocked `write()` before the deadline fires — the `continue` returns to the loop top where `wait_while_paused_timed` extends the deadline
- Covers: `send_data`, `send_data_half`, `send_quic_data`, `send_udp_paced`, `send_udp_unlimited`

### Server stats loops (`serve.rs`)
- Track `paused_total` and `pause_start: Option<Instant>`
- On Pause: record `pause_start = Some(Instant::now())`
- On Resume: `paused_total += pause_start.take().unwrap().elapsed()`
- Duration check: `start.elapsed() - paused_total - active_pause >= duration` where `active_pause = pause_start.map(|p| p.elapsed()).unwrap_or_default()` — accounts for in-progress pause so the clock doesn't expire while paused

## Tests

- `wait_while_paused_timed_returns_pause_duration`: verifies the helper returns correct pause duration (≥40ms after 50ms pause)
- 389 tests pass (258 lib + 42 + 67 integration + 20 + 2). clippy clean, fmt clean.