### PR TITLE
ci: make MPTCP skip explicit and visible on standard runners (LAN-174)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         run: cargo fmt --check
 
   mptcp:
-    name: MPTCP
+    name: MPTCP (requires kernel MPTCP + netem)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -64,6 +64,9 @@ jobs:
       - name: Build release binary
         run: cargo build --release
       - name: Run MPTCP namespace tests
+        # The script emits a ::warning:: annotation and exits 0 when
+        # MPTCP or netem is unavailable, making the skip visible in
+        # the PR check UI without failing the job (LAN-174).
         run: sudo ./test-mptcp-ns.sh --ci
 
   control-channel-skew:

--- a/test-mptcp-ns.sh
+++ b/test-mptcp-ns.sh
@@ -27,18 +27,23 @@ if [[ ! -x "$XFR" ]]; then
 	exit 1
 fi
 
-# Check MPTCP support
+# Check MPTCP support — on runners without MPTCP/netem capability the
+# job is skipped, not failed. GitHub Actions ::warning:: annotation makes
+# the skip visible in the PR check UI (LAN-174).
 if ! sysctl -n net.mptcp.enabled >/dev/null 2>&1; then
+	echo "::warning::MPTCP CI: skipped — net.mptcp.enabled sysctl not available (kernel lacks MPTCP support)"
 	echo "SKIP: MPTCP not available in this kernel"
 	exit 0
 fi
 if [[ "$(sysctl -n net.mptcp.enabled)" != "1" ]]; then
+	echo "::warning::MPTCP CI: skipped — net.mptcp.enabled=0 (MPTCP disabled in kernel config)"
 	echo "SKIP: MPTCP is disabled (sysctl net.mptcp.enabled=0)"
 	exit 0
 fi
 
 # Check netem support
 if ! modprobe sch_netem 2>/dev/null; then
+	echo "::warning::MPTCP CI: skipped — sch_netem kernel module not available"
 	echo "SKIP: sch_netem kernel module not available"
 	exit 0
 fi


### PR DESCRIPTION
Closes LAN-174.

## Problem

The MPTCP CI job exited 0 when MPTCP/netem was unavailable on standard runners, silently hiding real MPTCP regressions under a passing job. There was no visible indication that the MPTCP tests were skipped.

## Fix

Emit GitHub Actions `::warning::` annotations when the MPTCP namespace test script skips due to missing kernel capability:
- `net.mptcp.enabled` sysctl not available (kernel lacks MPTCP)
- `net.mptcp.enabled=0` (MPTCP disabled in kernel config)
- `sch_netem` kernel module not available

The job still passes (no false negatives on standard runners), but the skip is now **visible** in the PR check UI and job logs — regressions are not silently hidden.

Rename the CI job to `MPTCP (requires kernel MPTCP + netem)` to make the runner-capability requirement explicit at a glance.

## Verification

- `bash -n test-mptcp-ns.sh` — shell syntax valid
- Workflow YAML is unchanged in structure (only job name and step comment added)