### PR TITLE
ci: migrate cross builds to cargo-zigbuild

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,34 +96,64 @@ jobs:
       - name: Build + compile tests on MSRV
         run: cargo test --all-features --no-run --locked
 
-  # Cross-compile every shippable Linux/Android target on each PR (debug, no
-  # packaging). release.yml builds these with an old-glibc cross image; v0.9.15
-  # died at release time on a glibc symbol (memfd_create, glibc 2.27+) that
-  # linked fine on the ubuntu/macos test jobs. Same pinned cross version as
-  # release.yml so the toolchain (and its glibc) match — linking is what catches
-  # missing symbols. aarch64-apple-darwin is already built by the macOS test job.
+  # Build every shippable release target on each PR (debug, no packaging) with
+  # the same toolchains as release.yml, so a target-specific build/link failure
+  # is caught before tag. zigbuild covers the Linux gnu/musl targets (Zig bundles
+  # musl and pins a low glibc floor) — it replaces cross 0.2.5, whose stale images
+  # failed build scripts under modern Rust (glibc 2.28+ symbol errors). Android
+  # stays on cross (from git main, current glibc); macOS builds natively.
   cross-smoke:
-    name: Cross build (${{ matrix.target }})
-    runs-on: ubuntu-latest
+    name: Build (${{ matrix.target }})
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:
-        target:
-          - x86_64-unknown-linux-musl
-          - aarch64-unknown-linux-gnu
-          - aarch64-unknown-linux-musl
-          - aarch64-linux-android
+        include:
+          - target: x86_64-unknown-linux-musl
+            triple: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+            tool: zigbuild
+          - target: aarch64-unknown-linux-gnu
+            triple: aarch64-unknown-linux-gnu.2.17
+            os: ubuntu-latest
+            tool: zigbuild
+          - target: aarch64-unknown-linux-musl
+            triple: aarch64-unknown-linux-musl
+            os: ubuntu-latest
+            tool: zigbuild
+          - target: aarch64-linux-android
+            triple: aarch64-linux-android
+            os: ubuntu-latest
+            tool: cross
+          - target: aarch64-apple-darwin
+            triple: aarch64-apple-darwin
+            os: macos-latest
+            tool: native
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - name: Install cross
-        uses: taiki-e/install-action@v2
         with:
-          tool: cross@0.2.5
-      - name: Cross build
-        run: cross build --target ${{ matrix.target }} --features prometheus --locked
+          targets: ${{ matrix.target }}
+      - uses: Swatinem/rust-cache@v2
+      - name: Install Zig
+        if: matrix.tool == 'zigbuild'
+        uses: goto-bus-stop/setup-zig@v2
+      - name: Install cargo-zigbuild
+        if: matrix.tool == 'zigbuild'
+        run: cargo install cargo-zigbuild --locked
+      - name: Install cross (git main)
+        if: matrix.tool == 'cross'
+        run: cargo install cross --git https://github.com/cross-rs/cross --locked
+      - name: Build (zigbuild)
+        if: matrix.tool == 'zigbuild'
+        run: cargo zigbuild --target ${{ matrix.triple }} --features prometheus --locked
+      - name: Build (cross)
+        if: matrix.tool == 'cross'
+        run: cross build --target ${{ matrix.triple }} --features prometheus --locked
+      - name: Build (native)
+        if: matrix.tool == 'native'
+        run: cargo build --target ${{ matrix.triple }} --features prometheus --locked
 
   mptcp:
     name: MPTCP (requires kernel MPTCP + netem)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,12 +139,14 @@ jobs:
       - name: Install Zig
         if: matrix.tool == 'zigbuild'
         uses: goto-bus-stop/setup-zig@v2
+        with:
+          version: 0.16.0
       - name: Install cargo-zigbuild
         if: matrix.tool == 'zigbuild'
-        run: cargo install cargo-zigbuild --locked
-      - name: Install cross (git main)
+        run: cargo install cargo-zigbuild --version 0.23.0 --locked
+      - name: Install cross (pinned main commit)
         if: matrix.tool == 'cross'
-        run: cargo install cross --git https://github.com/cross-rs/cross --locked
+        run: cargo install cross --git https://github.com/cross-rs/cross --rev 64b5bb4d --locked
       - name: Build (zigbuild)
         if: matrix.tool == 'zigbuild'
         run: cargo zigbuild --target ${{ matrix.triple }} --features prometheus --locked

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,11 @@ jobs:
       - name: Build (native)
         if: matrix.tool == 'native'
         run: cargo build --target ${{ matrix.triple }} --features prometheus --locked
+      # ABI check on the zigbuild targets: glibc floor (2.17) for gnu, static
+      # for musl. Guards against a build that succeeds but links the wrong ABI.
+      - name: Verify binary ABI
+        if: matrix.tool == 'zigbuild'
+        run: bash scripts/verify-target-binary.sh "${{ matrix.target }}" "${{ matrix.triple }}" debug
 
   mptcp:
     name: MPTCP (requires kernel MPTCP + netem)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,18 +112,15 @@ jobs:
         if: matrix.tool == 'native'
         run: cargo build --release --locked --target ${{ matrix.triple }} --features prometheus
 
+      # Resolve the binary (tolerant of zigbuild's glibc-suffixed dir), verify
+      # its ABI (glibc floor for gnu, static for musl), and fail loudly if the
+      # binary is missing or the floor is breached — then package by base target
+      # so artifact names stay stable (xfr-<target>.tar.gz).
       - name: Package binary
         shell: bash
         run: |
-          # zigbuild may emit into the glibc-suffixed target dir; check both.
-          for d in "target/${{ matrix.triple }}/release" "target/${{ matrix.target }}/release"; do
-            if [[ -f "$d/xfr" ]]; then bindir="$d"; break; fi
-          done
-          if [[ -z "${bindir:-}" ]]; then
-            echo "::error::xfr binary not found under target/*/release"; ls -R target 2>/dev/null | grep -B1 -A3 release | head -40; exit 1
-          fi
-          echo "packaging from $bindir"
-          tar czvf "xfr-${{ matrix.target }}.tar.gz" -C "$bindir" xfr
+          bin="$(bash scripts/verify-target-binary.sh '${{ matrix.target }}' '${{ matrix.triple }}' release)"
+          tar czvf "xfr-${{ matrix.target }}.tar.gz" -C "$(dirname "$bin")" xfr
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,31 +37,31 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Linux x86_64 (static musl for glibc compatibility)
+          # Linux x86_64 — static musl (Zig bundles musl); generic Linux + container amd64
           - target: x86_64-unknown-linux-musl
+            triple: x86_64-unknown-linux-musl
             os: ubuntu-latest
-            cross: false
-            features: prometheus
-          # Linux aarch64
+            tool: zigbuild
+          # Linux aarch64 — glibc, floored at 2.17 for old distros/embedded
           - target: aarch64-unknown-linux-gnu
+            triple: aarch64-unknown-linux-gnu.2.17
             os: ubuntu-latest
-            cross: true
-            features: prometheus
-          # Linux aarch64 (static musl, used by the container image)
+            tool: zigbuild
+          # Linux aarch64 — static musl (container arm64)
           - target: aarch64-unknown-linux-musl
+            triple: aarch64-unknown-linux-musl
             os: ubuntu-latest
-            cross: true
-            features: prometheus
-          # Android aarch64 (Termux)
+            tool: zigbuild
+          # Android aarch64 (Termux) — NDK target, cross from git main
           - target: aarch64-linux-android
+            triple: aarch64-linux-android
             os: ubuntu-latest
-            cross: true
-            features: prometheus
-          # macOS aarch64 (Apple Silicon)
+            tool: cross
+          # macOS aarch64 (Apple Silicon) — native
           - target: aarch64-apple-darwin
+            triple: aarch64-apple-darwin
             os: macos-latest
-            cross: false
-            features: prometheus
+            tool: native
           # Note: Intel Mac (x86_64-apple-darwin) removed - users can build from crate
 
     steps:
@@ -82,30 +82,48 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-
 
-      - name: Install cross
-        if: matrix.cross
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cross@0.2.5
+      # zigbuild handles the Linux gnu/musl targets: Zig bundles musl and lets us
+      # pin a low glibc floor (.2.17) without stale cross images. Replaces cross
+      # 0.2.5, whose old images could not run build scripts under modern Rust
+      # (glibc 2.28+ symbol errors on the aarch64 images).
+      - name: Install Zig
+        if: matrix.tool == 'zigbuild'
+        uses: goto-bus-stop/setup-zig@v2
 
-      - name: Install musl-tools
-        if: contains(matrix.target, 'musl')
-        run: sudo apt-get update && sudo apt-get install -y musl-tools
+      - name: Install cargo-zigbuild
+        if: matrix.tool == 'zigbuild'
+        run: cargo install cargo-zigbuild --locked
 
-      - name: Build (native)
-        if: ${{ !matrix.cross }}
-        run: cargo build --release --locked --target ${{ matrix.target }} --features "${{ matrix.features }}"
+      # Android is an NDK target zigbuild does not handle; keep cross, but from
+      # git main (images track current glibc) rather than the stale 0.2.5.
+      - name: Install cross (git main)
+        if: matrix.tool == 'cross'
+        run: cargo install cross --git https://github.com/cross-rs/cross --locked
+
+      - name: Build (zigbuild)
+        if: matrix.tool == 'zigbuild'
+        run: cargo zigbuild --release --locked --target ${{ matrix.triple }} --features prometheus
 
       - name: Build (cross)
-        if: matrix.cross
-        run: cross build --release --locked --target ${{ matrix.target }} --features "${{ matrix.features }}"
+        if: matrix.tool == 'cross'
+        run: cross build --release --locked --target ${{ matrix.triple }} --features prometheus
+
+      - name: Build (native)
+        if: matrix.tool == 'native'
+        run: cargo build --release --locked --target ${{ matrix.triple }} --features prometheus
 
       - name: Package binary
         shell: bash
         run: |
-          cd target/${{ matrix.target }}/release
-          tar czvf ../../../xfr-${{ matrix.target }}.tar.gz xfr
-          cd -
+          # zigbuild may emit into the glibc-suffixed target dir; check both.
+          for d in "target/${{ matrix.triple }}/release" "target/${{ matrix.target }}/release"; do
+            if [[ -f "$d/xfr" ]]; then bindir="$d"; break; fi
+          done
+          if [[ -z "${bindir:-}" ]]; then
+            echo "::error::xfr binary not found under target/*/release"; ls -R target 2>/dev/null | grep -B1 -A3 release | head -40; exit 1
+          fi
+          echo "packaging from $bindir"
+          tar czvf "xfr-${{ matrix.target }}.tar.gz" -C "$bindir" xfr
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,16 +89,18 @@ jobs:
       - name: Install Zig
         if: matrix.tool == 'zigbuild'
         uses: goto-bus-stop/setup-zig@v2
+        with:
+          version: 0.16.0
 
       - name: Install cargo-zigbuild
         if: matrix.tool == 'zigbuild'
-        run: cargo install cargo-zigbuild --locked
+        run: cargo install cargo-zigbuild --version 0.23.0 --locked
 
       # Android is an NDK target zigbuild does not handle; keep cross, but from
       # git main (images track current glibc) rather than the stale 0.2.5.
-      - name: Install cross (git main)
+      - name: Install cross (pinned main commit)
         if: matrix.tool == 'cross'
-        run: cargo install cross --git https://github.com/cross-rs/cross --locked
+        run: cargo install cross --git https://github.com/cross-rs/cross --rev 64b5bb4d --locked
 
       - name: Build (zigbuild)
         if: matrix.tool == 'zigbuild'

--- a/scripts/verify-target-binary.sh
+++ b/scripts/verify-target-binary.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Locate the built `xfr` binary for a (target, triple, profile) and verify its
+# platform ABI, then print the resolved path on stdout (diagnostics go to
+# stderr, so callers can `bin=$(verify-target-binary.sh ...)`).
+#
+# Handles cargo-zigbuild's glibc-suffixed target dir: `--target foo-gnu.2.17`
+# may emit under `target/foo-gnu.2.17/` or the normalized `target/foo-gnu/`.
+#
+# ABI checks (fail the build if breached):
+#   *-gnu   -> no GLIBC symbol newer than the pinned floor (2.17)
+#   *-musl  -> statically linked (no GLIBC symbols, no dynamic interpreter)
+#   others  -> no ABI check (android NDK, macОS Mach-O)
+#
+# Usage: verify-target-binary.sh <rustup-target> <build-triple> [profile]
+set -euo pipefail
+
+target="$1"
+triple="$2"
+profile="${3:-release}"
+glibc_floor="2.17"
+
+bin=""
+for d in "target/${triple}/${profile}" "target/${target}/${profile}"; do
+    if [[ -x "$d/xfr" ]]; then
+        bin="$d/xfr"
+        break
+    fi
+done
+
+if [[ -z "$bin" ]]; then
+    echo "::error::xfr binary not found for ${target} / ${triple} (${profile})" >&2
+    echo "searched: target/${triple}/${profile}/xfr and target/${target}/${profile}/xfr" >&2
+    find target -maxdepth 4 -type f -name xfr -print >&2 || true
+    exit 1
+fi
+
+echo "resolved binary: ${bin}" >&2
+file "$bin" >&2 || true
+
+case "$triple" in
+    *-musl*)
+        # Static musl: must not reference glibc or carry a dynamic interpreter.
+        if readelf -W --version-info "$bin" 2>/dev/null | grep -q 'GLIBC_'; then
+            echo "::error::${bin} references GLIBC symbols but should be static musl" >&2
+            exit 1
+        fi
+        if readelf -W -l "$bin" 2>/dev/null | grep -qi 'program interpreter'; then
+            echo "::error::${bin} has a dynamic interpreter but should be static musl" >&2
+            exit 1
+        fi
+        echo "OK: static musl (no glibc, no interpreter)" >&2
+        ;;
+    *-gnu*)
+        # glibc floor: no required GLIBC symbol above ${glibc_floor}.
+        maxglibc="$(readelf -W --version-info "$bin" 2>/dev/null \
+            | grep -oE 'GLIBC_[0-9]+\.[0-9]+' | sed 's/GLIBC_//' | sort -V | tail -1)"
+        echo "max GLIBC required: ${maxglibc:-none} (floor ${glibc_floor})" >&2
+        if [[ -n "$maxglibc" \
+            && "$(printf '%s\n%s\n' "$maxglibc" "$glibc_floor" | sort -V | tail -1)" != "$glibc_floor" ]]; then
+            echo "::error::${bin} requires glibc ${maxglibc}, above the ${glibc_floor} floor" >&2
+            exit 1
+        fi
+        echo "OK: glibc floor <= ${glibc_floor}" >&2
+        ;;
+    *)
+        echo "no ABI check for ${triple}" >&2
+        ;;
+esac
+
+# stdout: the resolved path, for the caller to package.
+echo "$bin"


### PR DESCRIPTION
Fixes the aarch64 cross-build glibc failures that landed on master (`bf773ae`).

## Root cause
cross 0.2.5's `aarch64-unknown-linux-{gnu,musl}:0.2.5` images ship an x86_64 glibc too old to run build scripts compiled by modern Rust (1.96 → GLIBC_2.28+ symbols). Fresh builds fail; CI caching masked it intermittently (green on #135, red on the master push). `release.yml` used the same cross 0.2.5, so the next fresh release build was at the same risk — the cross-smoke job caught a latent release regression, which is exactly its job.

## Change (per spec)
- **Linux gnu/musl → `cargo-zigbuild`.** Zig bundles musl and pins a glibc floor (`aarch64-unknown-linux-gnu.2.17`), no stale images.
- **Android → cross from git `main`** (current-glibc images); zigbuild doesn't do NDK targets.
- **macOS → native `cargo`.**
- Removed cross 0.2.5 and the `musl-tools` install.
- `ci.yml` cross-smoke now builds all 5 release targets (debug) on every PR; `release.yml` uses the same split for release + packaging (artifact names unchanged; packaging tolerates zigbuild's glibc-suffixed output dir).

## Verify
This PR's `Build (…)` matrix must go green for all 5 targets — especially `aarch64-unknown-linux-gnu` and `aarch64-unknown-linux-musl`, the arms that were failing.