### PR TITLE
feat(update): allow disabling the update check (LAN-235)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Opt out of the update check** — the background "newer release available" check can now be turned off several ways: the `--no-update-check` flag, the `DO_NOT_TRACK` (cross-tool standard) or `XFR_NO_UPDATE_CHECK` environment variables, `no_update_check = true` under `[client]` in `config.toml`, or the new **Update check** toggle in the TUI settings (Display tab, persisted to `prefs.toml`). It can also be compiled out entirely with `--no-default-features` — the `update-check` cargo feature is on by default, so package builds can drop the phone-home code. (LAN-235)
+
 ## [0.9.21] - 2026-07-06
 
 ### Security

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ dashmap = "6"
 ipnetwork = "0.21"
 
 # Update notifications
-update-informer = { version = "1", features = ["github"] }
+update-informer = { version = "1", features = ["github"], optional = true }
 
 # Socket control (IPv6 dual-stack, flow labels)
 socket2 = { version = "0.6", features = ["all"] }
@@ -90,9 +90,12 @@ socket2 = { version = "0.6", features = ["all"] }
 libc = "0.2"
 
 [features]
-default = ["discovery"]
+default = ["discovery", "update-check"]
 prometheus = ["dep:prometheus", "dep:hyper", "dep:hyper-util", "dep:http-body-util"]
 discovery = ["dep:mdns-sd"]
+# Background check for a newer release via the GitHub API. On by default;
+# package builds can drop the phone-home code with `--no-default-features`.
+update-check = ["dep:update-informer"]
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/README.md
+++ b/README.md
@@ -473,6 +473,7 @@ See `examples/grafana-dashboard.json` for a sample Grafana dashboard.
 | `--omit` | | 0 | Omit first N seconds |
 | `--output` | `-o` | stdout | Output file |
 | `--no-tui` | | false | Disable TUI |
+| `--no-update-check` | | false | Disable the background update check (also honors `DO_NOT_TRACK` / `XFR_NO_UPDATE_CHECK`) |
 | `--theme` | | default | Color theme (dracula, nord, matrix, etc.) |
 | `--tcp-nodelay` | | false | Disable Nagle algorithm |
 | `--window` | `-w` | OS default | Socket buffer size for TCP and UDP (SO_SNDBUF/SO_RCVBUF on both ends); when unset, TCP autotunes and UDP uses the kernel default |

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -547,6 +547,17 @@ xfr checks GitHub for newer versions in the background. If an update is availabl
 
 Press `u` to dismiss the banner.
 
+### Disabling the update check
+
+The background check can be turned off:
+
+- `--no-update-check` for a single run
+- `DO_NOT_TRACK=1` (cross-tool standard) or `XFR_NO_UPDATE_CHECK=1` in the environment
+- `no_update_check = true` under `[client]` in `config.toml`
+- the **Update check** toggle in the TUI settings (Display tab), persisted to `prefs.toml`
+
+Precedence, highest first: compiled-out > env > `--no-update-check` > `config.toml` > saved TUI toggle. Package builds can compile the checker out entirely with `cargo build --no-default-features` (the `update-check` feature is on by default), which drops the `update-informer` dependency.
+
 The check uses a 1-hour cache to avoid GitHub API rate limits.
 
 ## CLI Reference

--- a/docs/xfr.1
+++ b/docs/xfr.1
@@ -62,6 +62,10 @@ Save results to file
 .B \-\-no\-tui
 Disable terminal UI, use plain text output
 .TP
+.B \-\-no\-update\-check
+Disable the background check for a newer release. Also honored via the
+DO_NOT_TRACK or XFR_NO_UPDATE_CHECK environment variables.
+.TP
 .BI \-\-theme " THEME"
 Color theme: default, kawaii, cyber, dracula, monochrome, matrix, nord, gruvbox, catppuccin, tokyo_night, solarized
 .TP
@@ -243,6 +247,12 @@ Log level
 .TP
 .B XFR_TIMESTAMP_FORMAT
 Timestamp format
+.TP
+.B DO_NOT_TRACK
+Set to a non-empty, non-zero value to disable the update check (cross-tool standard)
+.TP
+.B XFR_NO_UPDATE_CHECK
+Set to a non-empty, non-zero value to disable the update check
 .SH EXAMPLES
 .TP
 .B xfr 192.168.1.1

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -20,6 +20,11 @@ json_output = false
 # Disable TUI by default
 no_tui = false
 
+# Disable the background check for a newer xfr release. Also honored via the
+# DO_NOT_TRACK or XFR_NO_UPDATE_CHECK environment variables, the
+# --no-update-check flag, or the Update check toggle in the TUI settings.
+no_update_check = false
+
 # Omit first N seconds from interval output (TCP ramp-up)
 # omit_secs = 3
 

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -23,7 +23,9 @@ no_tui = false
 # Disable the background check for a newer xfr release. Also honored via the
 # DO_NOT_TRACK or XFR_NO_UPDATE_CHECK environment variables, the
 # --no-update-check flag, or the Update check toggle in the TUI settings.
-no_update_check = false
+# Leave this unset (commented) so the TUI toggle can govern — setting it here
+# to either true or false overrides the saved TUI preference.
+# no_update_check = true
 
 # Omit first N seconds from interval output (TCP ramp-up)
 # omit_secs = 3

--- a/src/config.rs
+++ b/src/config.rs
@@ -41,6 +41,9 @@ pub struct ClientDefaults {
     /// Disable TUI by default
     pub no_tui: Option<bool>,
 
+    /// Disable the background check for a newer xfr release
+    pub no_update_check: Option<bool>,
+
     /// Timestamp format for interval output (relative, iso8601, unix)
     #[serde(default)]
     pub timestamp_format: Option<TimestampFormat>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -213,6 +213,11 @@ struct Cli {
     #[arg(long)]
     no_tui: bool,
 
+    /// Disable the background check for a newer xfr release (also honored via
+    /// the DO_NOT_TRACK or XFR_NO_UPDATE_CHECK environment variables)
+    #[arg(long)]
+    no_update_check: bool,
+
     /// Color theme (default, kawaii, cyber, dracula, monochrome, matrix, nord, gruvbox, catppuccin, tokyo_night, solarized)
     #[arg(long, default_value = "default")]
     theme: String,
@@ -1245,11 +1250,27 @@ async fn main() -> Result<()> {
                 let prefs = xfr::prefs::Prefs::load()
                     .with_overrides(Some(&cli.theme), file_config.client.theme.as_deref());
 
-                let final_prefs =
-                    run_client_tui(config, cli.output, timestamp_format, prefs.clone()).await?;
+                // Update check runs unless disabled by any source (compiled
+                // out, env, CLI flag, config.toml, or a saved pref toggle).
+                let update_disabled = !xfr::update::ENABLED
+                    || xfr::update::env_opt_out()
+                    || cli.no_update_check
+                    || file_config.client.no_update_check.unwrap_or(false)
+                    || prefs.disable_update_check.unwrap_or(false);
+
+                let final_prefs = run_client_tui(
+                    config,
+                    cli.output,
+                    timestamp_format,
+                    prefs.clone(),
+                    update_disabled,
+                )
+                .await?;
 
                 // Save prefs if changed
-                if final_prefs.theme != prefs.theme {
+                if final_prefs.theme != prefs.theme
+                    || final_prefs.disable_update_check != prefs.disable_update_check
+                {
                     let _ = final_prefs.save();
                 }
             }
@@ -1560,6 +1581,7 @@ async fn run_client_tui(
     output: Option<PathBuf>,
     timestamp_format: TimestampFormat,
     prefs: xfr::prefs::Prefs,
+    update_disabled: bool,
 ) -> Result<xfr::prefs::Prefs> {
     // Setup terminal
     enable_raw_mode()?;
@@ -1568,7 +1590,14 @@ async fn run_client_tui(
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
 
-    let result = run_tui_loop(&mut terminal, config.clone(), timestamp_format, prefs).await;
+    let result = run_tui_loop(
+        &mut terminal,
+        config.clone(),
+        timestamp_format,
+        prefs,
+        update_disabled,
+    )
+    .await;
 
     // Restore terminal
     disable_raw_mode()?;
@@ -1825,13 +1854,16 @@ async fn run_tui_loop(
     mut config: ClientConfig,
     timestamp_format: TimestampFormat,
     mut prefs: xfr::prefs::Prefs,
+    update_disabled: bool,
 ) -> Result<(Option<xfr::protocol::TestResult>, xfr::prefs::Prefs, bool)> {
-    // Spawn background update check
+    // Spawn the background update check unless it's disabled (flag/env/config/
+    // pref) or compiled out. `update_rx` still exists so the poller is a no-op.
     let (update_tx, update_rx) = std::sync::mpsc::channel();
-    std::thread::spawn(move || {
-        let result = xfr::update::check_for_update();
-        let _ = update_tx.send(result);
-    });
+    if !update_disabled {
+        std::thread::spawn(move || {
+            let _ = update_tx.send(xfr::update::check_for_update());
+        });
+    }
 
     let mut print_json_on_exit = false;
     let mut app = App::with_theme_name(
@@ -1845,9 +1877,12 @@ async fn run_tui_loop(
         timestamp_format,
         prefs.theme_name(),
     );
+    // Reflect the resolved update-check state in the Settings toggle.
+    app.settings.update_check = !update_disabled;
 
-    // Track if we've received the update check result
-    let mut update_check_done = false;
+    // Track if we've received the update check result (start "done" when the
+    // check is disabled so the poller never blocks on the empty channel).
+    let mut update_check_done = update_disabled;
 
     let mut run = Some(spawn_tui_run(&config));
     app.on_connected();
@@ -1868,6 +1903,11 @@ async fn run_tui_loop(
         }
 
         poll_update_check(&mut app, &update_rx, &mut update_check_done);
+
+        // Persist an explicit update-check toggle from the Settings screen.
+        if app.settings.update_check_touched {
+            prefs.disable_update_check = Some(!app.settings.update_check);
+        }
 
         // Refresh the wall-clock-driven parts of app state (elapsed counter) so
         // the UI stays live even when the server's Interval progress messages

--- a/src/main.rs
+++ b/src/main.rs
@@ -1250,13 +1250,14 @@ async fn main() -> Result<()> {
                 let prefs = xfr::prefs::Prefs::load()
                     .with_overrides(Some(&cli.theme), file_config.client.theme.as_deref());
 
-                // Update check runs unless disabled by any source (compiled
-                // out, env, CLI flag, config.toml, or a saved pref toggle).
-                let update_disabled = !xfr::update::ENABLED
-                    || xfr::update::env_opt_out()
-                    || cli.no_update_check
-                    || file_config.client.no_update_check.unwrap_or(false)
-                    || prefs.disable_update_check.unwrap_or(false);
+                // Update check runs unless disabled. Precedence (higher wins):
+                // compiled-out > env > CLI flag > config.toml > saved pref.
+                let update_disabled = xfr::update::check_disabled(
+                    xfr::update::env_opt_out(),
+                    cli.no_update_check,
+                    file_config.client.no_update_check,
+                    prefs.disable_update_check,
+                );
 
                 let final_prefs = run_client_tui(
                     config,

--- a/src/prefs.rs
+++ b/src/prefs.rs
@@ -25,6 +25,11 @@ pub struct Prefs {
     /// Show help overlay on first run
     #[serde(skip_serializing_if = "Option::is_none")]
     pub show_help_on_start: Option<bool>,
+
+    /// User disabled the update check via the TUI settings toggle.
+    /// `None` = never toggled (follows the default / config).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub disable_update_check: Option<bool>,
 }
 
 impl Prefs {
@@ -90,6 +95,7 @@ mod tests {
             last_server: Some("192.168.1.1".to_string()),
             streams: Some(4),
             show_help_on_start: Some(false),
+            disable_update_check: None,
         };
         let toml_str = toml::to_string_pretty(&prefs).unwrap();
         assert!(toml_str.contains("theme = \"dracula\""));
@@ -108,6 +114,7 @@ mod tests {
             last_server: None,
             streams: None,
             show_help_on_start: None,
+            disable_update_check: None,
         };
         let toml_str = toml::to_string_pretty(&prefs).unwrap();
         assert!(toml_str.contains("theme"));

--- a/src/tui/settings.rs
+++ b/src/tui/settings.rs
@@ -111,6 +111,11 @@ pub struct SettingsState {
     pub theme_index: usize,
     pub timestamp_format: TimestampFormat,
     pub units: Units,
+    /// Whether the background update check is enabled (persisted to prefs).
+    pub update_check: bool,
+    /// Set once the user toggles `update_check`, so only an explicit choice is
+    /// persisted (not the env/config-derived initial state).
+    pub update_check_touched: bool,
 
     // Test settings (require restart)
     pub streams: u8,
@@ -140,6 +145,8 @@ impl Default for SettingsState {
             theme_index: 0,
             timestamp_format: TimestampFormat::Relative,
             units: Units::Auto,
+            update_check: true,
+            update_check_touched: false,
 
             streams: 1,
             protocol: Protocol::Tcp,
@@ -177,6 +184,8 @@ impl SettingsState {
             theme_index,
             timestamp_format: TimestampFormat::Relative,
             units: Units::Auto,
+            update_check: true,
+            update_check_touched: false,
 
             streams,
             protocol,
@@ -228,7 +237,7 @@ impl SettingsState {
     /// Number of items in current category
     fn items_in_category(&self) -> usize {
         match self.category {
-            SettingsCategory::Display => 3, // Theme, Timestamp, Units
+            SettingsCategory::Display => 4, // Theme, Timestamp, Units, Update check
             SettingsCategory::Test => 5,    // Streams, Protocol, Duration, Direction, Bitrate
         }
     }
@@ -268,6 +277,12 @@ impl SettingsState {
         self.button_focused = false;
     }
 
+    /// Toggle the update-check setting and mark it as an explicit user choice.
+    fn toggle_update_check(&mut self) {
+        self.update_check = !self.update_check;
+        self.update_check_touched = true;
+    }
+
     /// Cycle selected value to next
     pub fn value_next(&mut self) {
         if self.button_focused {
@@ -287,6 +302,7 @@ impl SettingsState {
                 }
                 1 => self.timestamp_format = self.timestamp_format.next(),
                 2 => self.units = self.units.next(),
+                3 => self.toggle_update_check(),
                 _ => {}
             },
             SettingsCategory::Test => match self.selected_index {
@@ -323,6 +339,7 @@ impl SettingsState {
                 }
                 1 => self.timestamp_format = self.timestamp_format.prev(),
                 2 => self.units = self.units.prev(),
+                3 => self.toggle_update_check(),
                 _ => {}
             },
             SettingsCategory::Test => match self.selected_index {
@@ -498,6 +515,23 @@ mod tests {
         assert_eq!(bitrate_display(None), "unlimited");
         assert_eq!(bitrate_display(Some(1_000_000)), "1 Mbps");
         assert_eq!(bitrate_display(Some(10_000_000_000)), "10 Gbps");
+    }
+
+    #[test]
+    fn update_check_toggle_flips_and_marks_touched() {
+        let mut s = SettingsState::default();
+        assert!(s.update_check, "enabled by default");
+        assert!(!s.update_check_touched, "untouched until the user acts");
+
+        // Display tab, 4th item is the update-check toggle.
+        s.category = SettingsCategory::Display;
+        s.selected_index = 3;
+        s.value_next();
+        assert!(!s.update_check);
+        assert!(s.update_check_touched);
+
+        s.value_prev();
+        assert!(s.update_check, "toggles back");
     }
 
     #[test]

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -817,6 +817,10 @@ fn draw_display_settings(
         ("Theme:", theme_name.to_string()),
         ("Timestamp:", settings.timestamp_format.as_str().to_string()),
         ("Units:", settings.units.as_str().to_string()),
+        (
+            "Update check:",
+            if settings.update_check { "on" } else { "off" }.to_string(),
+        ),
     ];
 
     draw_setting_items(

--- a/src/update.rs
+++ b/src/update.rs
@@ -85,6 +85,28 @@ fn flag_is_truthy(v: &str) -> bool {
     !matches!(v.trim(), "" | "0" | "false")
 }
 
+/// Resolve whether the background update check should be skipped, honoring
+/// precedence (higher layer wins): compiled-out > env opt-out > CLI flag >
+/// `config.toml` > saved pref.
+///
+/// `config` and `pref` are tristate: an explicit `Some(false)` at a higher
+/// layer re-enables the check over a lower layer's opt-out (so editing
+/// `config.toml` can override a stale TUI toggle in `prefs.toml`).
+pub fn check_disabled(
+    env_opt_out: bool,
+    cli_flag: bool,
+    config: Option<bool>,
+    pref: Option<bool>,
+) -> bool {
+    !ENABLED
+        || env_opt_out
+        || cli_flag
+        || match config {
+            Some(explicit) => explicit,
+            None => pref.unwrap_or(false),
+        }
+}
+
 #[cfg(test)]
 mod tests {
     use super::flag_is_truthy;
@@ -97,5 +119,28 @@ mod tests {
         for off in ["", "  ", "0", "false"] {
             assert!(!flag_is_truthy(off), "{off:?} should not opt out");
         }
+    }
+
+    #[test]
+    fn check_disabled_precedence() {
+        use super::{ENABLED, check_disabled};
+        // These cases exercise the config-vs-pref tristate, which only matters
+        // when the check is compiled in.
+        if !ENABLED {
+            assert!(check_disabled(false, false, Some(false), Some(false)));
+            return;
+        }
+        // config's explicit `false` re-enables over a stale pref opt-out
+        assert!(!check_disabled(false, false, Some(false), Some(true)));
+        // config's explicit `true` disables even if the pref says on
+        assert!(check_disabled(false, false, Some(true), Some(false)));
+        // no config -> the saved pref governs
+        assert!(check_disabled(false, false, None, Some(true)));
+        assert!(!check_disabled(false, false, None, Some(false)));
+        // nothing set -> enabled by default
+        assert!(!check_disabled(false, false, None, None));
+        // env or CLI opt-out wins over an explicit config/pref "on"
+        assert!(check_disabled(true, false, Some(false), Some(false)));
+        assert!(check_disabled(false, true, Some(false), Some(false)));
     }
 }

--- a/src/update.rs
+++ b/src/update.rs
@@ -2,8 +2,14 @@
 //!
 //! Checks GitHub releases for newer versions and notifies the user in the TUI.
 
+#[cfg(feature = "update-check")]
 use std::time::Duration;
+#[cfg(feature = "update-check")]
 use update_informer::{Check, registry::GitHub};
+
+/// Whether update checking was compiled in (the `update-check` feature, on by
+/// default). Package builds can drop it with `--no-default-features`.
+pub const ENABLED: bool = cfg!(feature = "update-check");
 
 /// How the user installed xfr - used to show the appropriate update command
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -46,6 +52,7 @@ impl InstallMethod {
 ///
 /// Returns Some(version) if a newer version is available, None otherwise.
 /// Uses a 1-hour cache to avoid excessive GitHub API calls.
+#[cfg(feature = "update-check")]
 pub fn check_for_update() -> Option<String> {
     // Cache for 1 hour to avoid GitHub rate limits
     let informer = update_informer::new(GitHub, "lance0/xfr", env!("CARGO_PKG_VERSION"))
@@ -56,4 +63,39 @@ pub fn check_for_update() -> Option<String> {
         .ok()
         .flatten()
         .map(|v| v.to_string())
+}
+
+/// Update checking compiled out (`--no-default-features`): always "no update".
+#[cfg(not(feature = "update-check"))]
+pub fn check_for_update() -> Option<String> {
+    None
+}
+
+/// True when the user opted out of the update check via environment:
+/// `DO_NOT_TRACK` (the cross-tool standard, <https://consoledonottrack.com>)
+/// or `XFR_NO_UPDATE_CHECK`.
+pub fn env_opt_out() -> bool {
+    ["DO_NOT_TRACK", "XFR_NO_UPDATE_CHECK"]
+        .iter()
+        .any(|k| std::env::var_os(k).is_some_and(|v| flag_is_truthy(&v.to_string_lossy())))
+}
+
+/// An environment flag counts as "set" unless it is empty, `0`, or `false`.
+fn flag_is_truthy(v: &str) -> bool {
+    !matches!(v.trim(), "" | "0" | "false")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::flag_is_truthy;
+
+    #[test]
+    fn env_flag_truthiness() {
+        for on in ["1", "true", "yes", "on"] {
+            assert!(flag_is_truthy(on), "{on:?} should count as opt-out");
+        }
+        for off in ["", "  ", "0", "false"] {
+            assert!(!flag_is_truthy(off), "{off:?} should not opt out");
+        }
+    }
 }


### PR DESCRIPTION
Adds a full opt-out for the background "newer release available" check (`update-informer` → GitHub API, TUI mode only). Requested by a ttl user (lance0/ttl#110) as a standard package-manager/CI courtesy. Closes LAN-235.

## How to turn it off
Precedence (first that applies wins): **compiled-out → env → CLI → config.toml → saved pref**.

| Surface | How |
|---|---|
| **env** | `DO_NOT_TRACK=1` (cross-tool standard) or `XFR_NO_UPDATE_CHECK=1` |
| **config.toml** | `no_update_check = true` under `[client]` |
| **TUI toggle** | Settings → Display → **Update check: on/off**; persisted to `prefs.toml` (`disable_update_check`), sticks across runs |
| **CLI** | `--no-update-check` |
| **compile-out** | `update-check` cargo feature (default-on); `--no-default-features` drops `update-informer` from the tree entirely — no phone-home code shipped |

## Notes for review
- The check only ever ran in TUI mode (single spawn in `run_tui_loop`); the gate sits there.
- The TUI toggle only persists on an **explicit** user change (`update_check_touched`), so untouched users don't get a spurious `prefs.toml` write.
- `env_opt_out` treats an env var as "on" unless empty/`0`/`false`.
- **Not** handled: toggling off mid-run doesn't hide an already-displayed banner (it applies to the next run). Easy to add if wanted.

## Validation
- Builds with **and** without default features; `cargo tree --no-default-features -i update-informer` → absent.
- `clippy -D warnings` clean on `--all-features` and `--no-default-features`; `fmt` clean.
- 270 lib tests pass (added `env_flag_truthiness` + `update_check_toggle_flips_and_marks_touched`).
- `--no-update-check` appears in `--help`.

Files: `update.rs`, `config.rs`, `prefs.rs`, `tui/settings.rs`, `tui/ui.rs`, `main.rs`, `Cargo.toml`, `CHANGELOG.md`, `examples/config.toml`.