### PR TITLE
feat(config): add client transport defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **Opt out of the update check** — the background "newer release available" check can now be turned off several ways: the `--no-update-check` flag, the `DO_NOT_TRACK` (cross-tool standard) or `XFR_NO_UPDATE_CHECK` environment variables, `no_update_check = true` under `[client]` in `config.toml`, or the new **Update check** toggle in the TUI settings (Display tab, persisted to `prefs.toml`). It can also be compiled out entirely with `--no-default-features` — the `update-check` cargo feature is on by default, so package builds can drop the phone-home code. (LAN-235)
+- **Client transport defaults in `config.toml`** — `[client]` now supports `bitrate`, `congestion`, `dscp`, `interval_secs`, `bind`, and `cport`, closing the gap with their CLI counterparts. Values use the same forms as the flags (for example, `bitrate = "100M"` and `dscp = "EF"`), and an explicit CLI value takes precedence.
 
 ## [0.9.21] - 2026-07-06
 

--- a/README.md
+++ b/README.md
@@ -389,12 +389,18 @@ duration_secs = 10
 parallel_streams = 1
 tcp_nodelay = false
 window_size = "1M"           # TCP/UDP socket buffer size (SO_SNDBUF/SO_RCVBUF), e.g. "512K", "2M"
+# bitrate = "100M"            # target bitrate; accepts the same units as --bitrate
+# congestion = "bbr"          # TCP congestion-control algorithm
+# dscp = "EF"                 # DSCP name or raw TOS byte (0-255)
+interval_secs = 1.0           # report interval; default is 1.0 seconds
 json_output = false
 no_tui = false
 theme = "default"            # or dracula, catppuccin, nord, matrix, etc.
 timestamp_format = "relative" # or "iso8601", "unix"
 address_family = "dual"      # "ipv4", "ipv6", or "dual"
 omit_secs = 0                # omit first N seconds (TCP ramp-up)
+# bind = "192.168.1.100"      # local address, optionally with :port
+# cport = 5202                # client source port for firewall traversal
 psk = "my-secret-key"
 log_file = "~/.config/xfr/xfr.log"
 log_level = "info"
@@ -415,7 +421,7 @@ log_file = "~/.config/xfr/xfr-server.log"
 log_level = "info"
 ```
 
-`[client] omit_secs` sets the default for `--omit`. An explicit CLI `--omit` value, including `--omit 0`, takes precedence over the config file.
+The value-taking transport and output settings under `[client]` are defaults: an explicit CLI value takes precedence. This includes `omit_secs` and `interval_secs`, so `--omit 0` and `--interval 1.0` override the config file. `bitrate` accepts the same `100M`/`1G` syntax as `--bitrate`; `dscp` accepts the same DSCP names and numeric values as `--dscp`.
 
 Environment variables override config file:
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -334,12 +334,18 @@ duration_secs = 10
 parallel_streams = 1
 tcp_nodelay = false
 window_size = "1M"
+# bitrate = "100M"             # same units as --bitrate
+# congestion = "bbr"           # TCP congestion-control algorithm
+# dscp = "EF"                  # DSCP name or raw TOS byte (0-255)
+interval_secs = 1.0            # report interval in seconds
 json_output = false
 no_tui = false
 theme = "default"
 timestamp_format = "relative"  # relative, iso8601, unix
 address_family = "dual"        # ipv4, ipv6, dual
 omit_secs = 0                  # omit first N seconds (TCP ramp-up)
+# bind = "192.168.1.100"       # local address, optionally with :port
+# cport = 5202                  # client source port for firewall traversal
 psk = "my-secret-key"
 log_file = "~/.config/xfr/xfr.log"
 log_level = "info"
@@ -360,7 +366,7 @@ log_file = "~/.config/xfr/xfr-server.log"
 log_level = "info"
 ```
 
-`[client] omit_secs` sets the default for `--omit`. An explicit CLI `--omit` value, including `--omit 0`, overrides the config file.
+The value-taking transport and output settings under `[client]` are defaults: an explicit CLI value overrides them. This includes `omit_secs` and `interval_secs`, so `--omit 0` and `--interval 1.0` take precedence over the config file. `bitrate` accepts the same `100M`/`1G` syntax as `--bitrate`; `dscp` accepts the same DSCP names and numeric values as `--dscp`.
 
 ### Environment Variables
 

--- a/docs/xfr.1
+++ b/docs/xfr.1
@@ -215,6 +215,12 @@ Example config:
 [client]
 duration_secs = 30
 parallel_streams = 4
+bitrate = "100M"
+congestion = "bbr"
+dscp = "EF"
+interval_secs = 1.0
+bind = "192.168.1.100"
+cport = 5202
 theme = "dracula"
 
 [server]
@@ -225,6 +231,15 @@ no_mdns = false
 allow = ["192.168.0.0/16"]
 .fi
 .RE
+.PP
+These client transport and output configuration values are defaults: an explicit CLI value takes precedence. The
+.B bitrate
+value accepts the same 100M/1G syntax as
+.BR \-\-bitrate ,
+and
+.B dscp
+accepts the same names and numeric values as
+.BR \-\-dscp .
 .SH ENVIRONMENT
 .TP
 .B XFR_PORT

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -14,6 +14,18 @@ tcp_nodelay = false
 # Default TCP window size
 # window_size = "1M"
 
+# Default target bitrate (e.g., "100M", "1G")
+# bitrate = "100M"
+
+# Default TCP congestion control algorithm
+# congestion = "bbr"
+
+# Default DSCP/TOS marking (e.g., "EF", "AF11", "46")
+# dscp = "EF"
+
+# Default report interval in seconds
+# interval_secs = 1.0
+
 # Default to JSON output
 json_output = false
 
@@ -29,6 +41,12 @@ no_tui = false
 
 # Omit first N seconds from interval output (TCP ramp-up)
 # omit_secs = 3
+
+# Local address to bind to (e.g., "192.168.1.100" or "[::1]:0")
+# bind = "192.168.1.100"
+
+# Client source port for firewall traversal
+# cport = 5202
 
 [server]
 # Default port

--- a/src/config.rs
+++ b/src/config.rs
@@ -35,6 +35,18 @@ pub struct ClientDefaults {
     /// Default TCP window size (e.g., "1M", "512K")
     pub window_size: Option<String>,
 
+    /// Default target bitrate (e.g., "100M", "1G")
+    pub bitrate: Option<String>,
+
+    /// Default TCP congestion control algorithm (e.g., "cubic", "bbr")
+    pub congestion: Option<String>,
+
+    /// Default DSCP/TOS marking (e.g., "EF", "AF11", "46")
+    pub dscp: Option<String>,
+
+    /// Default interval between reports in seconds
+    pub interval_secs: Option<f64>,
+
     /// Default to JSON output
     pub json_output: Option<bool>,
 
@@ -62,6 +74,12 @@ pub struct ClientDefaults {
 
     /// Address family preference (ipv4, ipv6, dual)
     pub address_family: Option<String>,
+
+    /// Local address to bind to (e.g., "192.168.1.100" or "\[::1\]:0")
+    pub bind: Option<String>,
+
+    /// Client source port for firewall traversal
+    pub cport: Option<u16>,
 
     /// Omit first N seconds from interval output (TCP ramp-up)
     pub omit_secs: Option<u64>,
@@ -210,6 +228,27 @@ omit_secs = 3
 
         let config: Config = toml::from_str(toml).unwrap();
         assert_eq!(config.client.omit_secs, Some(3));
+    }
+
+    #[test]
+    fn test_parse_client_transport_defaults() {
+        let toml = r#"
+[client]
+bitrate = "100M"
+congestion = "bbr"
+dscp = "EF"
+interval_secs = 2.5
+bind = "192.168.1.10"
+cport = 5202
+"#;
+
+        let config: Config = toml::from_str(toml).unwrap();
+        assert_eq!(config.client.bitrate.as_deref(), Some("100M"));
+        assert_eq!(config.client.congestion.as_deref(), Some("bbr"));
+        assert_eq!(config.client.dscp.as_deref(), Some("EF"));
+        assert_eq!(config.client.interval_secs, Some(2.5));
+        assert_eq!(config.client.bind.as_deref(), Some("192.168.1.10"));
+        assert_eq!(config.client.cport, Some(5202));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -222,9 +222,9 @@ struct Cli {
     #[arg(long, default_value = "default")]
     theme: String,
 
-    /// Report interval in seconds
-    #[arg(short = 'i', long, default_value = "1.0")]
-    interval: f64,
+    /// Report interval in seconds (default: 1.0)
+    #[arg(short = 'i', long)]
+    interval: Option<f64>,
 
     /// Omit first N seconds from interval output (TCP ramp-up)
     #[arg(long)]
@@ -508,6 +508,41 @@ fn resolve_client_duration(
             .map(Duration::from_secs)
             .unwrap_or(Duration::from_secs(10))
     }
+}
+
+#[derive(Debug, PartialEq)]
+struct ResolvedClientNetworkOptions {
+    bitrate: Option<u64>,
+    congestion: Option<String>,
+    dscp: Option<String>,
+    interval_secs: f64,
+    bind: Option<String>,
+    cport: Option<u16>,
+}
+
+/// Resolve client transport and output defaults with CLI values taking precedence.
+fn resolve_client_network_options(
+    cli_bitrate: Option<u64>,
+    cli_congestion: Option<String>,
+    cli_dscp: Option<String>,
+    cli_interval: Option<f64>,
+    cli_bind: Option<String>,
+    cli_cport: Option<u16>,
+    defaults: &xfr::config::ClientDefaults,
+) -> Result<ResolvedClientNetworkOptions, String> {
+    let bitrate = match cli_bitrate {
+        Some(bitrate) => Some(bitrate),
+        None => defaults.bitrate.as_deref().map(parse_bitrate).transpose()?,
+    };
+
+    Ok(ResolvedClientNetworkOptions {
+        bitrate,
+        congestion: cli_congestion.or_else(|| defaults.congestion.clone()),
+        dscp: cli_dscp.or_else(|| defaults.dscp.clone()),
+        interval_secs: cli_interval.or(defaults.interval_secs).unwrap_or(1.0),
+        bind: cli_bind.or_else(|| defaults.bind.clone()),
+        cport: cli_cport.or(defaults.cport),
+    })
 }
 
 fn parse_bitrate(s: &str) -> Result<u64, String> {
@@ -1033,6 +1068,16 @@ async fn main() -> Result<()> {
 
             let random_payload = effective_random_payload(&cli);
             let zerocopy = effective_zerocopy(&cli, protocol);
+            let network_options = resolve_client_network_options(
+                cli.bitrate,
+                cli.congestion.clone(),
+                cli.dscp.clone(),
+                cli.interval,
+                cli.bind.clone(),
+                cli.cport,
+                &file_config.client,
+            )
+            .map_err(|e| anyhow::anyhow!("invalid [client] bitrate: {e}"))?;
 
             if let Some(msg) = random_payload_notice(protocol, direction, random_payload) {
                 eprintln!("Warning: {msg}");
@@ -1042,7 +1087,7 @@ async fn main() -> Result<()> {
                 eprintln!("Warning: {msg}");
             }
 
-            if cli.dscp.is_some() && protocol == xfr::protocol::Protocol::Quic {
+            if network_options.dscp.is_some() && protocol == xfr::protocol::Protocol::Quic {
                 eprintln!("Warning: --dscp is ignored with QUIC (QUIC manages its own socket)");
             }
 
@@ -1052,7 +1097,7 @@ async fn main() -> Result<()> {
             if protocol == xfr::protocol::Protocol::Quic {
                 for (set, msg) in [
                     (
-                        cli.bitrate.is_some(),
+                        network_options.bitrate.is_some(),
                         "-b/--bitrate is ignored with QUIC (pacing is not implemented for QUIC)",
                     ),
                     (
@@ -1060,7 +1105,7 @@ async fn main() -> Result<()> {
                         "-w/--window is ignored with QUIC (QUIC flow control manages buffering)",
                     ),
                     (
-                        cli.congestion.is_some(),
+                        network_options.congestion.is_some(),
                         "--congestion is ignored with QUIC (kernel TCP CC does not apply)",
                     ),
                     (
@@ -1075,7 +1120,7 @@ async fn main() -> Result<()> {
             }
 
             #[cfg(not(unix))]
-            if cli.dscp.is_some() && protocol != xfr::protocol::Protocol::Quic {
+            if network_options.dscp.is_some() && protocol != xfr::protocol::Protocol::Quic {
                 eprintln!("Warning: --dscp is not supported on this platform");
             }
 
@@ -1145,14 +1190,14 @@ async fn main() -> Result<()> {
             };
 
             // Parse bind address (can be "IP" or "IP:port")
-            let mut bind_addr = if let Some(ref bind_str) = cli.bind {
+            let mut bind_addr = if let Some(ref bind_str) = network_options.bind {
                 Some(parse_bind_address(bind_str)?)
             } else {
                 None
             };
 
             // Merge --cport into bind_addr
-            let cport = cli.cport;
+            let cport = network_options.cport;
             if let Some(port) = cport {
                 if port == 0 {
                     anyhow::bail!("--cport must be a non-zero port number");
@@ -1205,9 +1250,9 @@ async fn main() -> Result<()> {
                 streams,
                 duration,
                 direction,
-                bitrate: cli.bitrate,
+                bitrate: network_options.bitrate,
                 tcp_nodelay,
-                tcp_congestion: cli.congestion.clone(),
+                tcp_congestion: network_options.congestion,
                 window_size,
                 psk: client_psk,
                 address_family: client_address_family,
@@ -1218,7 +1263,7 @@ async fn main() -> Result<()> {
                 zerocopy,
                 mtu_probe: cli.probe_mtu,
                 connect_timeout: cli.connect_timeout,
-                dscp: cli
+                dscp: network_options
                     .dscp
                     .as_ref()
                     .map(|s| parse_dscp(s).map_err(|e| anyhow::anyhow!(e)))
@@ -1234,7 +1279,7 @@ async fn main() -> Result<()> {
                 omit_secs: cli
                     .omit
                     .unwrap_or_else(|| file_config.client.omit_secs.unwrap_or(0)),
-                interval_secs: cli.interval,
+                interval_secs: network_options.interval_secs,
                 timestamp_format,
             };
 
@@ -2249,6 +2294,94 @@ mod tests {
         assert_eq!(
             resolve_client_duration(None, false, &cfg),
             Duration::from_secs(10)
+        );
+    }
+
+    #[test]
+    fn resolve_client_network_options_uses_config_defaults() {
+        let defaults = xfr::config::ClientDefaults {
+            bitrate: Some("100M".into()),
+            congestion: Some("bbr".into()),
+            dscp: Some("EF".into()),
+            interval_secs: Some(2.5),
+            bind: Some("192.168.1.10".into()),
+            cport: Some(5202),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            resolve_client_network_options(None, None, None, None, None, None, &defaults).unwrap(),
+            ResolvedClientNetworkOptions {
+                bitrate: Some(100_000_000),
+                congestion: Some("bbr".into()),
+                dscp: Some("EF".into()),
+                interval_secs: 2.5,
+                bind: Some("192.168.1.10".into()),
+                cport: Some(5202),
+            }
+        );
+    }
+
+    #[test]
+    fn resolve_client_network_options_cli_overrides_config() {
+        let defaults = xfr::config::ClientDefaults {
+            bitrate: Some("100M".into()),
+            congestion: Some("bbr".into()),
+            dscp: Some("EF".into()),
+            interval_secs: Some(2.5),
+            bind: Some("192.168.1.10".into()),
+            cport: Some(5202),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            resolve_client_network_options(
+                Some(1_000_000_000),
+                Some("cubic".into()),
+                Some("AF11".into()),
+                Some(1.0),
+                Some("10.0.0.10".into()),
+                Some(5203),
+                &defaults,
+            )
+            .unwrap(),
+            ResolvedClientNetworkOptions {
+                bitrate: Some(1_000_000_000),
+                congestion: Some("cubic".into()),
+                dscp: Some("AF11".into()),
+                interval_secs: 1.0,
+                bind: Some("10.0.0.10".into()),
+                cport: Some(5203),
+            }
+        );
+    }
+
+    #[test]
+    fn resolve_client_network_options_rejects_invalid_config_bitrate() {
+        let defaults = xfr::config::ClientDefaults {
+            bitrate: Some("fast".into()),
+            ..Default::default()
+        };
+        assert!(
+            resolve_client_network_options(None, None, None, None, None, None, &defaults).is_err()
+        );
+    }
+
+    #[test]
+    fn test_cli_interval_is_only_set_when_explicit() {
+        use clap::Parser;
+
+        assert!(
+            Cli::try_parse_from(["xfr", "host"])
+                .unwrap()
+                .interval
+                .is_none()
+        );
+        assert_eq!(
+            Cli::try_parse_from(["xfr", "host", "--interval", "2.5"])
+                .unwrap()
+                .interval,
+            Some(2.5)
         );
     }
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -772,7 +772,7 @@ impl App {
 
     pub fn on_error(&mut self, error: String) {
         self.state = AppState::Error;
-        self.log(format!("Error: {}", &error));
+        self.log(format!("Error: {}", error));
         self.error = Some(error);
     }
 


### PR DESCRIPTION
## Summary

Adds missing `[client]` defaults for `bitrate`, `congestion`, `dscp`, `interval_secs`, `bind`, and `cport`.

## Behavior

- Explicit CLI values override the corresponding config value.
- Config values use the same accepted forms as their flags, including `bitrate = "100M"` and `dscp = "EF"`.
- `--interval` remains a 1.0-second default while preserving whether it was explicitly supplied, so `interval_secs` can take effect.
- Configured QUIC-incompatible bitrate, congestion, and DSCP values now produce the existing CLI warnings.

README, feature docs, manpage, example config, and the Unreleased changelog cover the new settings.

Also removes a redundant format argument borrow newly denied by stable Clippy.