### PR TITLE
ci: add typo checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,14 @@ jobs:
       - name: Check formatting
         run: cargo fmt --check
 
+  typos:
+    name: Typos
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+      - uses: crate-ci/typos@v1.48.0
+
   doc:
     name: Doc (deny rustdoc warnings)
     runs-on: ubuntu-latest

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,6 @@
+[default.extend-words]
+ESnet = "ESnet"
+RTO = "RTO"
+Snet = "Snet"
+ratatui = "ratatui"
+rto = "rto"

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,5 +1,4 @@
 [default.extend-words]
-ESnet = "ESnet"
 RTO = "RTO"
 Snet = "Snet"
 ratatui = "ratatui"


### PR DESCRIPTION
## Summary

Adds a pinned `crate-ci/typos@v1.48.0` check to the pull-request workflow.

The repository-level `.typos.toml` allowlist is limited to the project terms `ratatui`, `ESnet`, and TCP RTO identifiers, so ordinary source, documentation, comments, and user-facing strings remain checked.

Validated with `typos`, `cargo fmt --check`, workflow YAML parsing, and diff checks.