### PR TITLE
fix(udp): live jitter in download mode reads the client's receiver stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Live jitter now updates during UDP download (`-u -R`)** — the TUI's jitter readout averaged the per-stream jitter reported in the server's `Interval` messages, but in download mode the server is the sender and never measures jitter, so the display stayed frozen at 0.00 ms until the final summary (and forever with `-t 0`). Per-stream intervals now overlay the client's own receiver-side jitter, the same receiver-truth substitution already used for byte counts and packet loss. (#143)
+- **`--locked` builds no longer warn about a yanked dependency** — bumped transitive `spin` 0.9.8 → 0.9.9 (0.9.8 was yanked on crates.io; pulled in via `mdns-sd` → `flume`). (#142)
+
 ### Added
 - **Opt out of the update check** — the background "newer release available" check can now be turned off several ways: the `--no-update-check` flag, the `DO_NOT_TRACK` (cross-tool standard) or `XFR_NO_UPDATE_CHECK` environment variables, `no_update_check = true` under `[client]` in `config.toml`, or the new **Update check** toggle in the TUI settings (Display tab, persisted to `prefs.toml`). It can also be compiled out entirely with `--no-default-features` — the `update-check` cargo feature is on by default, so package builds can drop the phone-home code. (LAN-235)
 - **Client transport defaults in `config.toml`** — `[client]` now supports `bitrate`, `congestion`, `dscp`, `interval_secs`, `bind`, and `cport`, closing the gap with their CLI counterparts. Values use the same forms as the flags (for example, `bitrate = "100M"` and `dscp = "EF"`), and an explicit CLI value takes precedence.

--- a/src/client.rs
+++ b/src/client.rs
@@ -84,6 +84,34 @@ fn udp_recv_interval_deltas(
     (total, deltas)
 }
 
+/// Download-mode per-stream Interval overlay: substitute the client's own
+/// receive-side readings into the server's `StreamInterval`s. The server is
+/// the sender there, so its per-stream bytes track send_to() acceptance
+/// (issue #81) and its `jitter_ms` is always `None` — only the receiver
+/// measures jitter, and without this overlay the TUI's live jitter never
+/// updates in `-u -R` (issue #143).
+fn overlay_udp_recv_intervals(
+    streams: Vec<crate::protocol::StreamInterval>,
+    deltas: &[u64],
+    stats: &crate::stats::TestStats,
+) -> Vec<crate::protocol::StreamInterval> {
+    streams
+        .into_iter()
+        .map(|mut s| {
+            if let Some(delta) = deltas.get(s.id as usize) {
+                s.bytes = *delta;
+            }
+            if let Some(local) = stats.streams.get(s.id as usize) {
+                let jitter_ms = local.udp_jitter_ms();
+                if jitter_ms > 0.0 {
+                    s.jitter_ms = Some(jitter_ms);
+                }
+            }
+            s
+        })
+        .collect()
+}
+
 /// Cumulative UDP receive progress (packets received / lost) summed across
 /// the client's own streams. In download mode the client is the receiver,
 /// so this is the authoritative live-loss source; the server has no
@@ -1032,15 +1060,8 @@ impl Client {
                                             } else {
                                                 0.0
                                             };
-                                            let streams: Vec<StreamInterval> = streams
-                                                .into_iter()
-                                                .map(|mut s| {
-                                                    if let Some(delta) = deltas.get(s.id as usize) {
-                                                        s.bytes = *delta;
-                                                    }
-                                                    s
-                                                })
-                                                .collect();
+                                            let streams =
+                                                overlay_udp_recv_intervals(streams, &deltas, &stats);
                                             (interval_total, mbps, streams)
                                         } else {
                                             (aggregate.bytes, aggregate.throughput_mbps, streams)
@@ -2819,6 +2840,32 @@ mod tests {
         let (total, deltas) = udp_recv_interval_deltas(&stats, &mut last);
         assert_eq!(total, 300);
         assert_eq!(deltas, vec![0, 300]);
+    }
+
+    #[test]
+    fn overlay_udp_recv_intervals_substitutes_bytes_and_jitter() {
+        let stats = test_stats_with_recv_bytes(&[0, 0]);
+        stats.streams[0].set_udp_jitter_us(2500); // 2.5 ms measured locally
+        // stream 1 has no jitter reading yet -> must stay None, not Some(0.0)
+
+        let from_server: Vec<crate::protocol::StreamInterval> = (0..2)
+            .map(|id| crate::protocol::StreamInterval {
+                id,
+                bytes: 999_999, // sender-side count; must be replaced
+                retransmits: None,
+                jitter_ms: None, // server is the sender in -R: never set
+                lost: None,
+                error: None,
+                rtt_us: None,
+                cwnd: None,
+            })
+            .collect();
+
+        let out = overlay_udp_recv_intervals(from_server, &[1000, 500], &stats);
+        assert_eq!(out[0].bytes, 1000);
+        assert_eq!(out[1].bytes, 500);
+        assert_eq!(out[0].jitter_ms, Some(2.5));
+        assert_eq!(out[1].jitter_ms, None);
     }
 
     #[test]


### PR DESCRIPTION
Fixes #143 — live jitter never updated in `-u -R` (and never appeared at all with `-t 0`).

## Root cause
The TUI's live jitter averages per-stream `jitter_ms` from the server's `Interval` messages. In download mode the server is the **sender** — it never measures jitter, so every stream reported `None` and the readout stayed frozen at 0.00 ms until the final summary. Packet loss worked because it already has a dedicated receiver-side overlay (`udp_progress`, #70), which is why the reporter saw loss behaving while jitter didn't.

## Fix
Extend the existing download-mode per-stream substitution (receiver-truth bytes, #81) to also overlay jitter from the client's own `StreamStats`, which the UDP receive path keeps current. Extracted into `overlay_udp_recv_intervals` with a unit test. No wire change — the overlay is entirely client-local.

This also repairs **plain-mode** live intervals in `-R`: they pick their format by jitter-presence, so pre-fix they rendered TCP-style (`rtx: 0`) with neither jitter nor loss shown.

## Verification (Docker + `tc netem delay 2ms 1ms` for real jitter)
Pre-fix binary, `-u -R` intervals:
```
[1.016]  50.0 Mbps  5.93 MB  rtx: 0
[2.017]  50.0 Mbps  5.96 MB  rtx: 0
```
Post-fix, same scenario:
```
[1.015]  49.9 Mbps  5.93 MB  jitter: 0.64ms  lost: 2715
[2.015]  50.0 Mbps  5.96 MB  jitter: 0.61ms  lost: 2688
```
Upload mode unchanged (server-side jitter still flows). Also verified in the live TUI via tmux: pre-fix shows `Jitter: 0.00 ms (10s avg: 0.00 ms)` frozen for the whole run; post-fix updates every interval, including with `-t 0`. Release-build smoke across TCP / UDP upload / reverse / bidir all clean; 273 lib tests pass.