### PR TITLE
ci: add cargo-deny job (LAN-231)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,21 @@ jobs:
       - name: Build + compile tests on MSRV
         run: cargo test --all-features --no-run --locked
 
+  cargo-deny:
+    name: cargo-deny (licenses, bans, sources)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install cargo-deny
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-deny@0.19.8
+      # Advisories are deliberately excluded — audit.yml owns cargo-audit and
+      # two advisory gates would double the noise. Policy lives in deny.toml.
+      - name: Check licenses / bans / sources
+        run: cargo deny check licenses bans sources
+
   # Build every shippable release target on each PR (debug, no packaging) with
   # the same toolchains as release.yml, so a target-specific build/link failure
   # is caught before tag. zigbuild covers the Linux gnu/musl targets (Zig bundles

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -177,9 +177,9 @@
 
 ### CI / Infrastructure
 - [x] **CI hardening (batch 1)** — cross-target smoke matrix on every PR (catches the v0.9.15 glibc-symbol class before tag), `--all-features`/`--no-default-features` test + clippy matrices (catches the LAN-172 dead-code-under-no-default-features class), rustdoc `-D warnings` doc check, `--locked` builds, concurrency cancellation, release-target cross builds via pinned cargo-zigbuild (glibc 2.17 floor) with pinned cross for Android, per-job timeouts, and an `audit.yml` PR path filter
-- [ ] **`cargo-deny`** — license compliance, banned crates, and duplicate-version detection (would surface `windows-sys`-style version fan-out); complements `cargo audit`
-- [ ] **`crate-ci/typos`** — cheap typo check over docs, comments, and user-facing strings
-- [ ] **Windows `cargo check`** — no Windows binary is shipped, but live `#[cfg(windows)]` paths (single-port UDP fail-closed to legacy ports, `windows-sys` deps) go uncompiled by CI; a cheap `windows-latest` check keeps them building
+- [x] **`cargo-deny`** — license compliance (permissive allow-list + scoped MPL-2.0 exception in `deny.toml`), wildcard/source pinning, duplicate-version warnings; advisories deliberately left to `audit.yml`
+- [x] **`crate-ci/typos`** — pinned typo check over docs, comments, and user-facing strings
+- [x] **Windows `cargo check`** — compiles the live `#[cfg(windows)]` paths (single-port UDP fail-closed to legacy ports, `windows-sys` deps) on `windows-latest`, which no other job covered
 - [ ] **Nightly concurrency sanitizer** — ThreadSanitizer over the async unit tests, or `loom` model-checking on the small sync primitives (pause/cancel watch-channel state machines, the control-reader mpsc lifecycle). Highest-rigor option for the class of bug this project keeps hitting — busy-loops, control-stream desync, cancel-while-paused freeze, split-codec races. Finicky (TSAN + tokio is flaky; loom needs loom-wrapped types), so nightly rather than per-PR
 
 ### Documentation

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,39 @@
+# cargo-deny configuration (LAN-231).
+#
+# Scope: license compliance + duplicate-version awareness + source pinning.
+# Security advisories are deliberately NOT checked here — audit.yml runs
+# cargo-audit on lockfile changes and nightly, and two advisory gates would
+# just double the noise.
+
+[licenses]
+# Permissive-only. Add to this list deliberately; a new copyleft dependency
+# should be a conscious decision, not a lockfile side effect.
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Zlib",
+    "0BSD",
+    "Unicode-3.0",
+    "CDLA-Permissive-2.0",
+]
+confidence-threshold = 0.8
+
+# MPL-2.0 is file-level weak copyleft — acceptable for us, but scoped to the
+# one crate that needs it (via `dirs`) so new MPL deps still get flagged.
+[[licenses.exceptions]]
+name = "option-ext"
+allow = ["MPL-2.0"]
+
+[bans]
+# Duplicate crate versions bloat the binary but are usually transitive fallout;
+# surface them without failing the build.
+multiple-versions = "warn"
+wildcards = "deny"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"


### PR DESCRIPTION
Adds the **cargo-deny** check from LAN-231. (The other two quick items on that list — typos and the Windows `cargo check` — turned out to already be on master via 7d7b7b4 / 768beec; an earlier revision of this PR duplicated them, which GitHub rejected as a workflow parse error. Now this PR is cargo-deny only, plus ROADMAP bookkeeping for all three.)

## What it checks (`cargo deny check licenses bans sources`, pinned 0.19.8)
- **Licenses**: permissive-only allow-list in `deny.toml`, with one scoped exception — `option-ext` (MPL-2.0, pulled by `dirs`). A new copyleft dependency fails the PR instead of slipping in via the lockfile.
- **Bans**: wildcard version requirements denied; duplicate crate versions **warn** only (24 today, all transitive fallout).
- **Sources**: unknown registries / git sources denied.
- **Advisories deliberately excluded** — `audit.yml` owns cargo-audit; two advisory gates would double the noise.

Validated locally: `cargo deny check licenses bans sources` → `bans ok, licenses ok, sources ok`, and the workflow passes actionlint. The job self-validates on this PR.

Remaining from LAN-231: the nightly ThreadSanitizer/loom concurrency pass.