### PR TITLE
deps: unify control-channel crypto on one RustCrypto generation (LAN-582)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Control-channel crypto moved onto one RustCrypto generation** — `chacha20poly1305` 0.10 → 0.11 and `hkdf` 0.12 → 0.13, which lets the protected control channel share `sha2` 0.11 / `hmac` 0.13 with PSK authentication instead of pinning a second copy of the older `crypto-common` 0.1 stack alongside it. Two duplicate dependencies (the renamed `sha2_010` / `hmac_012`) are gone and the build no longer compiles two generations of the same crates. The wire format is unchanged: key derivation, AEAD framing, and the server proof are byte-for-byte identical, verified against fixed vectors captured from the previous release and by running PSK-protected tests in both directions between old and new binaries.
+
 ### Fixed
 - **Sparkline no longer jumps forward with green bars after a loss episode** — when upload saturation clogs the control channel, the queued `Interval` messages flush in a burst once the loss eases; each one appended its own bar (the graph "jumped" several columns) and, because their stale cumulative loss counts were filtered out, those bars rendered primary-colored right after heavy loss. Bar appends are now rate-limited to the report cadence, and the bar that does render takes its loss tint from the freshest feedback state — the same source the stall-synthesized bars already use. (#93)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,12 +10,12 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aead"
-version = "0.5.2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
 dependencies = [
- "crypto-common 0.1.7",
- "generic-array",
+ "crypto-common 0.2.2",
+ "inout",
 ]
 
 [[package]]
@@ -316,37 +316,26 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
-dependencies = [
- "cfg-if",
- "cipher",
- "cpufeatures 0.2.17",
-]
-
-[[package]]
-name = "chacha20"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
+ "cipher",
  "cpufeatures 0.3.0",
  "rand_core 0.10.1",
 ]
 
 [[package]]
 name = "chacha20poly1305"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+checksum = "9b89e1c441e926b9c82a8d023f6e1b7ae0adcfaa7d621814e4d60789bac751cb"
 dependencies = [
  "aead",
- "chacha20 0.9.1",
+ "chacha20",
  "cipher",
  "poly1305",
- "zeroize",
 ]
 
 [[package]]
@@ -392,13 +381,13 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.4.4"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
- "crypto-common 0.1.7",
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
  "inout",
- "zeroize",
 ]
 
 [[package]]
@@ -689,7 +678,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -699,7 +687,9 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
+ "getrandom 0.4.3",
  "hybrid-array",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -831,7 +821,6 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "crypto-common 0.1.7",
- "subtle",
 ]
 
 [[package]]
@@ -1224,20 +1213,11 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hkdf"
-version = "0.12.4"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
 dependencies = [
- "hmac 0.12.1",
-]
-
-[[package]]
-name = "hmac"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest 0.10.7",
+ "hmac",
 ]
 
 [[package]]
@@ -1553,11 +1533,11 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.1.4"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1973,12 +1953,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
-name = "opaque-debug"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2202,12 +2176,11 @@ dependencies = [
 
 [[package]]
 name = "poly1305"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+checksum = "6e2d0073b297041425c7c3df6eb4792d598a15323fe63346852b092eca02904c"
 dependencies = [
- "cpufeatures 0.2.17",
- "opaque-debug",
+ "cpufeatures 0.3.0",
  "universal-hash",
 ]
 
@@ -2370,7 +2343,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "chacha20 0.10.1",
+ "chacha20",
  "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
@@ -2380,9 +2353,6 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
-]
 
 [[package]]
 name = "rand_core"
@@ -3593,12 +3563,12 @@ checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "universal-hash"
-version = "0.5.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
 dependencies = [
- "crypto-common 0.1.7",
- "subtle",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -4148,8 +4118,7 @@ dependencies = [
  "dirs",
  "futures",
  "hkdf",
- "hmac 0.12.1",
- "hmac 0.13.0",
+ "hmac",
  "hostname",
  "http-body-util",
  "humantime",
@@ -4169,7 +4138,6 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
- "sha2 0.10.9",
  "sha2 0.11.0",
  "socket2",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,18 +66,13 @@ quinn = "0.11"
 rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
 rcgen = "0.14"
 
-# Auth (existing PSK challenge-response)
+# Auth (PSK challenge-response) and control-channel protection (AEAD + HKDF).
+# One RustCrypto generation throughout: digest 0.11 / crypto-common 0.2.
 hmac = "0.13"
 sha2 = "0.11"
 rand = "0.10"
-
-# Control-channel protection (AEAD + HKDF)
-# Uses the crypto-common 0.1 ecosystem (sha2 0.10 / hmac 0.12 / hkdf 0.12 /
-# chacha20poly1305 0.10), separate from auth's hmac 0.13 / sha2 0.11.
-sha2_010 = { package = "sha2", version = "0.10" }
-hmac_012 = { package = "hmac", version = "0.12" }
-chacha20poly1305 = "0.10"
-hkdf = "0.12"
+chacha20poly1305 = "0.11"
+hkdf = "0.13"
 
 # Rate limiting / ACL
 dashmap = "6"

--- a/src/control_crypto.rs
+++ b/src/control_crypto.rs
@@ -48,8 +48,8 @@ use chacha20poly1305::{
     aead::{Aead, Payload},
 };
 use hkdf::Hkdf;
-use hmac_012::{Hmac, Mac};
-use sha2_010::Sha256;
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
 
 /// Capability string for the protected control channel.
 pub const PROTECTED_CONTROL_CAPABILITY: &str = "protected_control_v1";
@@ -128,8 +128,9 @@ pub fn compute_server_proof(
     psk: &str,
 ) -> Result<String> {
     let (_, _, s2c_auth_key) = derive_keys(client_nonce, server_nonce, psk)?;
-    let mut mac =
-        <HmacSha256 as Mac>::new_from_slice(&s2c_auth_key).expect("HMAC can take key of any size");
+    // Fully qualified: `chacha20poly1305::KeyInit` is also in scope here.
+    let mut mac = <HmacSha256 as hmac::KeyInit>::new_from_slice(&s2c_auth_key)
+        .expect("HMAC can take key of any size");
     mac.update(client_hello_bytes);
     mac.update(server_hello_bytes);
     Ok(hex::encode(mac.finalize().into_bytes().as_slice()))
@@ -557,6 +558,65 @@ mod tests {
 
     fn test_keys() -> ([u8; 32], [u8; 32], [u8; 32]) {
         derive_keys("deadbeef", "cafebabe", "shared-secret").unwrap()
+    }
+
+    /// Known-answer vectors captured from the v0.9.22 release build.
+    ///
+    /// Every value here is visible to a peer, so any change breaks interop
+    /// with an older `xfr` across the protected control channel. The
+    /// roundtrip tests below all encrypt and decrypt with the same code and
+    /// would happily pass on a silently-changed KDF or frame layout — this
+    /// one pins the actual bytes, so a RustCrypto version bump that alters
+    /// them fails loudly instead.
+    #[test]
+    fn wire_bytes_match_v0_9_22_vectors() {
+        const NONCE_C: &str = "client-nonce-kat";
+        const NONCE_S: &str = "server-nonce-kat";
+        const PSK: &str = "correct horse battery";
+
+        let (c2s_key, s2c_key, auth_key) = derive_keys(NONCE_C, NONCE_S, PSK).unwrap();
+        assert_eq!(
+            hex::encode(&c2s_key),
+            "3e61833962ee0b447fc147f1c83afa1daae4768684c4e5b31d199f9ea6f7b18e",
+        );
+        assert_eq!(
+            hex::encode(&s2c_key),
+            "bc87e8f6ad57215649232e7cc1fedb304f9a708fa1b1b0030f48fecf9b56f3e2",
+        );
+        assert_eq!(
+            hex::encode(&auth_key),
+            "6cd7aee3092250493d4213f51c9d6a5f84f2c99dfa910f526ee228ee1be25197",
+        );
+
+        let (mut c2s, mut s2c) = ControlCodec::derive_pair(NONCE_C, NONCE_S, PSK).unwrap();
+        // seq 0 and seq 1 on the same codec: pins nonce and AAD derivation
+        // as well as the ciphertext itself.
+        assert_eq!(
+            hex::encode(&c2s.seal(b"{\"type\":\"ping\"}").unwrap()),
+            "000000000000000023caf9761c0896387ca9f022e5601dd02bc58916daa52e20f61b266ef84de7",
+        );
+        assert_eq!(
+            hex::encode(&c2s.seal(b"second frame").unwrap()),
+            "0100000000000000209ac414bc87110901827d9df057b0073dcbb3d5d4f188cb972f644d",
+        );
+        // Same plaintext, same seq, other direction — must differ (direction
+        // byte in the AAD, different key).
+        assert_eq!(
+            hex::encode(&s2c.seal(b"{\"type\":\"ping\"}").unwrap()),
+            "0000000000000000895afd8fe06575dfeed6bd15d61034a3c12240e3507b8c3733283b064eb593",
+        );
+
+        assert_eq!(
+            compute_server_proof(
+                b"{\"hello\":\"client\"}",
+                b"{\"hello\":\"server\"}",
+                NONCE_C,
+                NONCE_S,
+                PSK,
+            )
+            .unwrap(),
+            "c038a4929ae7dccb6b8ad3799cb00cf544878239e3a10b983b1e9d5458cbd2a3",
+        );
     }
 
     #[test]


### PR DESCRIPTION
Takes the `chacha20poly1305` 0.10 → 0.11 and `hkdf` 0.12 → 0.13 bumps that were split out of the last dependency refresh, and removes the reason they were stuck.

### Why it was blocked

`src/control_crypto.rs` sat on the `crypto-common` 0.1 generation (`chacha20poly1305` 0.10, `hkdf` 0.12) and carried its own renamed copies of `sha2` 0.10 and `hmac` 0.12 to match — while `src/auth.rs` had already moved to `sha2` 0.11 / `hmac` 0.13 on the `digest` 0.11 generation. Bumping just the AEAD pair drags in `digest` 0.11 types that can't meet the 0.1-generation bounds, which is why #144 (and now #149) fails every job.

### What changed

- `chacha20poly1305` 0.11, `hkdf` 0.13; the renamed `sha2_010` / `hmac_012` dependencies are deleted, so control crypto now shares `sha2` 0.11 / `hmac` 0.13 with PSK auth.
- One source change beyond the imports: `new_from_slice` moved from `Mac` to `KeyInit` in `hmac` 0.13, and `chacha20poly1305::KeyInit` is also in scope in that module, so the call is fully qualified.
- The host build no longer compiles two generations of `crypto-common` / `digest` / `block-buffer` (`cargo tree -i digest@0.10.7` now reports nothing).

### Interop

The wire format is unchanged, and this is worth being sure about rather than assuming — the protected control channel has to keep talking to older peers.

- **Fixed vectors.** New test `wire_bytes_match_v0_9_22_vectors` pins the three derived keys, two sealed frames from one codec (seq 0 and seq 1, so nonce and AAD derivation are covered too), the same plaintext sealed in the other direction, and the server proof. The values were captured by running the same inputs through the **pre-port** crate versions; they pass unchanged on the new ones. The existing tests all seal and open with the same code, so they'd have passed on a silently-changed KDF — this one wouldn't.
- **Live cross-version runs.** PSK-protected tests, old server ↔ new client and new server ↔ old client, both complete clean; a wrong-PSK run against the ported server is still rejected. With PSK active the server installs the AEAD transport unconditionally after auth, so every post-auth control message in those runs went through `seal`/`open` across the version boundary.

Also validated: `cargo fmt --check`, `clippy -D warnings` and the full test suite in both `--all-features` and `--no-default-features`.

Supersedes #149.

Closes LAN-582