### PR TITLE
chore: remove dead code and finish the auth-path unwrap audit

### DIFF
--- a/src/control_crypto.rs
+++ b/src/control_crypto.rs
@@ -234,7 +234,11 @@ impl ControlCodec {
         if payload.len() < 8 + 16 {
             return Err(anyhow!("protected frame too short"));
         }
-        let seq = u64::from_le_bytes(payload[..8].try_into().unwrap());
+        let seq = u64::from_le_bytes(
+            payload[..8]
+                .try_into()
+                .expect("length checked above; an 8-byte slice always converts"),
+        );
         if seq != self.seq {
             return Err(anyhow!(
                 "sequence mismatch: expected {}, got {}",

--- a/src/tui/widgets.rs
+++ b/src/tui/widgets.rs
@@ -121,12 +121,6 @@ impl ProgressBar {
         }
     }
 
-    #[allow(dead_code)]
-    pub fn style(mut self, style: Style) -> Self {
-        self.style = style;
-        self
-    }
-
     pub fn filled_style(mut self, style: Style) -> Self {
         self.filled_style = style;
         self


### PR DESCRIPTION
## What

Two small ROADMAP hygiene items, one tidy diff (+5/−7):

- **Removed the unused `ProgressBar::style()` builder** (and its `#[allow(dead_code)]`) — zero callers across src/ and tests/; the `style` field itself stays because `render()` uses it for the unfilled bar segment.
- **Finished the auth-path unwrap audit:** the one remaining bare `unwrap()` in the protected control channel's frame parsing (`control_crypto.rs` sequence-header conversion) now carries the house-style infallibility message. Everything else was already clean: `auth.rs` HMAC init and the PSK paths in `serve.rs`/`client.rs` either propagate errors or document why they can't fail.

## Notes from the audit (no action taken)

- ROADMAP's "complete `InstallMethod::update_command`" is stale — it's fully implemented and used by the TUI update prompt.
- The `#[allow(dead_code)]` items in `serve.rs` (multi-port fallback paths) and `discover.rs` (feature-parity stub) are deliberate per their own comments and were left alone.
- The whole `ProgressBar` widget is unreferenced outside its own tests but is public API; flagged rather than removed.

No changelog entry — internal hygiene with no user-visible change.

## Verification

fmt, clippy `-D warnings`, full test suite pass. Live PSK smoke on the release build: correct-PSK run authenticates and completes; wrong-PSK run exits 1 with a clean auth error, no panic.