### PR TITLE
fix(tui): make the monochrome theme survive sunlight, encode loss without hue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- **The monochrome theme is now actually usable in sunlight** — it was built from hardcoded RGB grays whose mid-tone distinctions are exactly what glare washes out, and its fixed white text was invisible on light terminal backgrounds (the setup that works best outdoors, since dark screens mirror). It now renders in the terminal's own default colors at maximum contrast with just three levels, adapting to dark and light backgrounds alike. Loss severity in the throughput sparkline is additionally encoded without color in every theme: light loss underlines the bar, heavy loss reverses the cell into a bright pillar — so lossy intervals survive glare, monochrome, `NO_COLOR`, and colorblindness. Setting the standard `NO_COLOR` environment variable now selects the monochrome theme by default (an explicit `--theme`, config value, or saved preference still wins, and the env-induced choice is never persisted). (#158)
+
 ## [0.9.23] - 2026-07-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -375,6 +375,16 @@ xfr <host> --theme nord        # Arctic blue tones
 
 Available themes: `default`, `kawaii`, `cyber`, `dracula`, `monochrome`, `matrix`, `nord`, `gruvbox`, `catppuccin`, `tokyo_night`, `solarized`
 
+The `monochrome` theme (alias `mono`) is the high-visibility choice: it uses
+the terminal's own default colors at maximum contrast, so it works on both
+dark and light terminal backgrounds — pair it with a light background at full
+brightness when working in direct sunlight. Loss severity in the throughput
+graph is always also encoded without color (light loss underlines the bar,
+heavy loss reverses the cell), so lossy intervals stay visible through glare,
+in monochrome, and for colorblind users. Setting the standard
+[`NO_COLOR`](https://no-color.org) environment variable selects `monochrome`
+automatically unless a theme is chosen explicitly.
+
 Your theme preference is auto-saved to `~/.config/xfr/prefs.toml`.
 
 ## Configuration

--- a/docs/xfr.1
+++ b/docs/xfr.1
@@ -79,7 +79,12 @@ Disable the background check for a newer release. Also honored via the
 DO_NOT_TRACK or XFR_NO_UPDATE_CHECK environment variables.
 .TP
 .BI \-\-theme " THEME"
-Color theme: default, kawaii, cyber, dracula, monochrome, matrix, nord, gruvbox, catppuccin, tokyo_night, solarized
+Color theme: default, kawaii, cyber, dracula, monochrome, matrix, nord, gruvbox, catppuccin, tokyo_night, solarized.
+The monochrome theme (alias: mono) is the high-visibility option for glare
+and monochrome displays: it renders in the terminal's own default colors at
+maximum contrast, and works on light and dark backgrounds alike. Loss
+severity in the throughput graph is always also encoded without color
+(underline for light loss, reverse video for heavy loss).
 .TP
 .BI \-i ", " \-\-interval " SECS"
 Report interval in seconds (default: 1.0)
@@ -256,6 +261,11 @@ accepts the same names and numeric values as
 .TP
 .B XFR_PORT
 Server/client port
+.TP
+.B NO_COLOR
+When set and no theme is chosen via \fB\-\-theme\fR, config, or a saved
+preference, the monochrome theme is used (https://no-color.org). The choice
+is not persisted.
 .TP
 .B XFR_DURATION
 Test duration

--- a/src/prefs.rs
+++ b/src/prefs.rs
@@ -70,9 +70,28 @@ impl Prefs {
         self
     }
 
-    /// Get effective theme name
+    /// Get effective theme name.
+    ///
+    /// With no explicit choice anywhere (CLI, config, saved pref), a set
+    /// `NO_COLOR` environment variable (<https://no-color.org>) selects the
+    /// monochrome theme: crossterm already strips the color escapes under
+    /// NO_COLOR, so without this the RGB-palette themes degrade by
+    /// accident instead of by design. An explicit theme choice outranks
+    /// NO_COLOR — the convention governs *default* output, and an explicit
+    /// flag or saved pref is an explicit request. Because `self.theme`
+    /// stays `None`, the env-induced choice is never persisted to
+    /// prefs.toml.
     pub fn theme_name(&self) -> &str {
-        self.theme.as_deref().unwrap_or("default")
+        let no_color = std::env::var_os("NO_COLOR").is_some_and(|v| !v.is_empty());
+        self.effective_theme_name(no_color)
+    }
+
+    fn effective_theme_name(&self, no_color: bool) -> &str {
+        match self.theme.as_deref() {
+            Some(t) => t,
+            None if no_color => "monochrome",
+            None => "default",
+        }
     }
 }
 
@@ -162,5 +181,22 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(prefs.theme_name(), "dracula");
+    }
+
+    #[test]
+    fn no_color_defaults_to_monochrome_but_never_outranks_a_choice() {
+        // (Tested via the injectable inner fn — the env var itself is
+        // process-global and would race parallel tests.)
+        let prefs = Prefs::default();
+        assert_eq!(prefs.effective_theme_name(true), "monochrome");
+        assert_eq!(prefs.effective_theme_name(false), "default");
+
+        // An explicit choice (CLI/config/saved pref all land in `theme`)
+        // outranks NO_COLOR: the convention governs default output only.
+        let prefs = Prefs {
+            theme: Some("dracula".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(prefs.effective_theme_name(true), "dracula");
     }
 }

--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -132,26 +132,40 @@ impl Theme {
         }
     }
 
-    /// Monochrome theme - grayscale only
+    /// Monochrome theme — high-contrast grayscale for glare, monochrome
+    /// displays, and `NO_COLOR` runs (issue #158).
+    ///
+    /// Built from terminal-adaptive ANSI colors, never `Rgb`: named colors
+    /// are remapped by the terminal's own palette, so the theme stays
+    /// readable on both dark and light backgrounds. (A hardcoded white is
+    /// invisible on a light terminal — and a light background is exactly
+    /// what wins in direct sun, where dark screens act as mirrors.)
+    /// Deliberately few levels: glare washes out mid-tone grays first, so
+    /// everything collapses to Reset / Gray / DarkGray, with maximum
+    /// contrast (the terminal's default foreground) on anything that
+    /// matters. Loss severity stays legible without hue via the modifier
+    /// encoding in the sparkline renderer.
     pub fn monochrome() -> Self {
         Self {
             name: Cow::Borrowed("monochrome"),
 
-            border: Color::Rgb(200, 200, 200),
-            border_focused: Color::Rgb(200, 200, 200),
-            text: Color::Rgb(255, 255, 255),
-            text_dim: Color::Rgb(120, 120, 120),
-            highlight_bg: Color::Rgb(50, 50, 50),
+            border: Color::DarkGray,
+            border_focused: Color::Gray,
+            text: Color::Reset,
+            text_dim: Color::DarkGray,
+            highlight_bg: Color::DarkGray,
 
-            success: Color::Rgb(200, 200, 200),
-            warning: Color::Rgb(170, 170, 170),
-            error: Color::Rgb(255, 255, 255),
+            success: Color::Reset,
+            // A real color, not Reset: also used as a *background* (update
+            // banner renders black-on-warning).
+            warning: Color::Gray,
+            error: Color::Reset,
 
-            accent: Color::Rgb(200, 200, 200),
-            header: Color::Rgb(255, 255, 255),
+            accent: Color::Reset,
+            header: Color::Reset,
 
-            graph_primary: Color::Rgb(200, 200, 200),
-            graph_secondary: Color::Rgb(150, 150, 150),
+            graph_primary: Color::Reset,
+            graph_secondary: Color::Gray,
         }
     }
 

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -23,7 +23,7 @@ fn loss_color(loss_percent: f64, theme: &Theme) -> Color {
     }
 }
 
-/// Color a throughput sparkline cell by the per-interval loss rate. Unknown
+/// Style a throughput sparkline cell by the per-interval loss rate. Unknown
 /// rate stays primary so we don't fake a signal we don't have; clean
 /// intervals stay primary; light loss (<1%) goes warning, heavy loss
 /// (>=1%) goes error. Thresholds intentionally differ from `loss_color`'s
@@ -33,12 +33,24 @@ fn loss_color(loss_percent: f64, theme: &Theme) -> Color {
 /// either — the sparkline's "clean" state is the graph color so the
 /// background blends with the chart, not the success-green used in the
 /// stats panel.
-fn loss_severity_color(rate: Option<f64>, theme: &Theme) -> Color {
+///
+/// Severity is also encoded without hue (issue #158): light loss adds
+/// UNDERLINED (a baseline tick under the bar), heavy loss adds REVERSED
+/// (the column renders as a photographic negative — a bright pillar).
+/// The sparkline is the one display where color was the *only* channel
+/// carrying loss, which fails in sunlight glare, for colorblind users,
+/// in the monochrome theme, and under NO_COLOR. SGR 4/7 are the reliable
+/// modifiers across terminals (DIM is not).
+fn loss_severity_style(rate: Option<f64>, theme: &Theme) -> Style {
     match rate {
-        None => theme.graph_primary,
-        Some(r) if r <= 0.0 => theme.graph_primary,
-        Some(r) if r < 1.0 => theme.warning,
-        Some(_) => theme.error,
+        None => Style::default().fg(theme.graph_primary),
+        Some(r) if r <= 0.0 => Style::default().fg(theme.graph_primary),
+        Some(r) if r < 1.0 => Style::default()
+            .fg(theme.warning)
+            .add_modifier(Modifier::UNDERLINED),
+        Some(_) => Style::default()
+            .fg(theme.error)
+            .add_modifier(Modifier::REVERSED),
     }
 }
 
@@ -296,7 +308,7 @@ fn draw_realtime_stats(frame: &mut Frame, app: &App, theme: &Theme, area: Rect) 
         let styles: Vec<Style> = app
             .throughput_history
             .iter()
-            .map(|s| Style::default().fg(loss_severity_color(s.loss_rate_percent(), theme)))
+            .map(|s| loss_severity_style(s.loss_rate_percent(), theme))
             .collect();
         let sparkline = Sparkline::new(&data)
             .max(app.max_throughput().max(100.0))
@@ -958,4 +970,32 @@ fn draw_settings_buttons(
         Paragraph::new(button_line).alignment(Alignment::Center),
         area,
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn loss_severity_survives_without_hue() {
+        // Issue #158: the sparkline was the one display where color was
+        // the only channel carrying loss. Severity must also ride
+        // modifiers so it survives glare, monochrome, and NO_COLOR.
+        let theme = Theme::default_theme();
+
+        let clean = loss_severity_style(Some(0.0), &theme);
+        assert!(clean.add_modifier.is_empty());
+        assert_eq!(clean.fg, Some(theme.graph_primary));
+
+        let unknown = loss_severity_style(None, &theme);
+        assert!(unknown.add_modifier.is_empty());
+
+        let light = loss_severity_style(Some(0.5), &theme);
+        assert!(light.add_modifier.contains(Modifier::UNDERLINED));
+        assert_eq!(light.fg, Some(theme.warning));
+
+        let heavy = loss_severity_style(Some(5.0), &theme);
+        assert!(heavy.add_modifier.contains(Modifier::REVERSED));
+        assert_eq!(heavy.fg, Some(theme.error));
+    }
 }


### PR DESCRIPTION
## Problem

#158: doing WiFi site surveys in direct sun, the red packet-loss tint is "almost completely lost to glare"; the reporter asked for a monochrome option. The twist: `--theme monochrome` already exists — he never found it, and it wouldn't have helped: it was built from hardcoded RGB grays whose mid-tone distinctions are exactly what glare washes out first, and its fixed white text is invisible on light terminal backgrounds — the setup that actually works outdoors (dark screens mirror).

## Fix (three parts)

**1. The monochrome palette is now terminal-adaptive.** ANSI colors only (`Reset`/`Gray`/`DarkGray`, never `Rgb`): named colors get remapped by the terminal's own scheme, so the theme is correct on dark *and* light backgrounds, and collapses to three high-contrast levels — the research consensus for glare is fewer, stronger levels, not a fine gray ramp. (`warning` stays `Gray` rather than `Reset` because the update banner uses it as a background.)

**2. Sparkline loss severity is additionally encoded without hue, in every theme.** Light loss (<1%) adds `UNDERLINED`; heavy loss (≥1%) adds `REVERSED`, which renders lossy columns as bright photographic-negative pillars readable at arm's length. The sparkline was the one display where color was the *only* channel carrying loss — every other readout sits next to a number. This fixes glare, monochrome, `NO_COLOR`, and colorblind readability in one move. SGR 4/7 chosen because they're the reliably-supported modifiers across real terminals (DIM is not).

**3. `NO_COLOR` (no-color.org) now selects monochrome by default.** Precedence: CLI > config > saved pref > `NO_COLOR` > default — the convention governs *default* output, so any explicit choice wins. crossterm already strips color escapes under `NO_COLOR`; this makes the degraded output designed instead of accidental. The env-induced choice is never persisted to prefs.toml.

## Verification

tmux captures against a lossy proxy (30% loss window), raw escapes inspected:

- `--theme mono`: clean bars at `[39m` (terminal default fg), light-loss column `[4m` + gray, heavy-loss columns `[0;7m` reverse video; zero `38;2` RGB sequences anywhere.
- `NO_COLOR=1`, no theme flag: all color codes gone, `[7m` loss pillars survive.
- Default theme: green bars, yellow+underline, red+reversed — colors and modifiers coexist.
- 437 tests pass (2 new: NO_COLOR precedence, severity-modifier encoding); fmt + clippy `-D warnings` clean. README + man page updated.

Known-untouched: the *server* TUI ignores themes entirely (hardcoded colors) — pre-existing, out of scope here.