### PR TITLE
fix(tui): bound quit on a dead control channel, keep the stats, show the wait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Quitting on an effectively-dead link no longer discards your stats** — on a zombie connection (e.g. WiFi that is associated but passing nothing), pressing `q`/Ctrl+C in the TUI waits up to 5 seconds for the server's final summary with a visible `Waiting for server (Ns)...` countdown, then exits with a partial summary built from locally accumulated counters and a warning — previously it printed "Test cancelled." and dropped everything. One genuinely unbounded hang is also closed: the control-channel Cancel write ran before its timeout was armed, so a full send buffer could stall quit until the test-duration deadline. Partial summaries are never written to `--output` files. (#159)
+
 ### Changed
 - **The monochrome theme is now actually usable in sunlight** — it was built from hardcoded RGB grays whose mid-tone distinctions are exactly what glare washes out, and its fixed white text was invisible on light terminal backgrounds (the setup that works best outdoors, since dark screens mirror). It now renders in the terminal's own default colors at maximum contrast with just three levels, adapting to dark and light backgrounds alike. Loss severity in the throughput sparkline is additionally encoded without color in every theme: light loss underlines the bar, heavy loss reverses the cell into a bright pillar — so lossy intervals survive glare, monochrome, `NO_COLOR`, and colorblindness. Setting the standard `NO_COLOR` environment variable now selects the monochrome theme by default (an explicit `--theme`, config value, or saved preference still wins, and the env-induced choice is never persisted). (#158)
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -1236,15 +1236,22 @@ impl Client {
                                 break;
                             }
                         };
-                        let _ = ctrl_writer
-                            .write_message(&mut writer, &serialized)
-                            .await;
-                        let _ = cancel_tx.send(true);
+                        // Arm the post-cancel deadline before writing, and
+                        // bound the write itself: on an effectively-dead link
+                        // (issue #159) the control socket's send buffer can be
+                        // full, and an unbounded write here would hang this
+                        // loop with only the test-duration deadline armed.
                         start_control_cancel_wait(
                             tokio::time::Instant::now(),
                             &mut deadline,
                             &mut pause_started_at,
                         );
+                        let _ = tokio::time::timeout(
+                            CONTROL_CANCEL_RESULT_TIMEOUT,
+                            ctrl_writer.write_message(&mut writer, &serialized),
+                        )
+                        .await;
+                        let _ = cancel_tx.send(true);
                         // Continue loop to receive Cancelled response
                     }
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1825,8 +1825,11 @@ async fn run_client_tui(
     terminal.backend_mut().execute(LeaveAlternateScreen)?;
 
     match result {
-        Ok((test_result, final_prefs, print_json)) => {
+        Ok((test_result, final_prefs, print_json, partial)) => {
             if let Some(ref test_result) = test_result {
+                if partial {
+                    eprintln!("Warning: partial results (server did not respond to cancel)");
+                }
                 // Print JSON if requested via 'j' key
                 if print_json {
                     println!("{}", output_json(test_result)?);
@@ -1834,7 +1837,9 @@ async fn run_client_tui(
                     println!("{}", output_plain(test_result, config.mptcp));
                 }
 
-                if let Some(path) = output {
+                // Don't save incomplete fallback results to file — only real
+                // server results (same rule as the --no-tui fallback path).
+                if !partial && let Some(path) = output {
                     xfr::output::json::save_json(test_result, &path)?;
                     println!("Results saved to {}", path.display());
                 }
@@ -1854,6 +1859,28 @@ struct TuiRun {
     client: Arc<Client>,
     handle: tokio::task::JoinHandle<Result<xfr::protocol::TestResult>>,
     progress_rx: mpsc::Receiver<TestProgress>,
+}
+
+/// How long the TUI waits for the server's final Result after a quit before
+/// giving up and showing a locally-built summary (issue #159). Matches the
+/// --no-tui Ctrl+C fallback.
+const TUI_CANCEL_WAIT: Duration = Duration::from_secs(5);
+
+/// `(result, prefs, print_json_on_exit, partial)`; `partial` marks a
+/// fallback summary built from local counters because the server never
+/// answered the cancel.
+type TuiLoopExit = (
+    Option<xfr::protocol::TestResult>,
+    xfr::prefs::Prefs,
+    bool,
+    bool,
+);
+
+/// Fallback summary for a quit the server never acknowledged, from locally
+/// accumulated counters. `None` when nothing was transferred — there is no
+/// summary worth showing.
+fn tui_fallback_result(bytes: u64, elapsed_ms: u64) -> Option<xfr::protocol::TestResult> {
+    (bytes > 0).then(|| build_fallback_result(bytes, elapsed_ms))
 }
 
 fn spawn_tui_run(config: &ClientConfig) -> TuiRun {
@@ -2076,7 +2103,7 @@ async fn run_tui_loop(
     timestamp_format: TimestampFormat,
     mut prefs: xfr::prefs::Prefs,
     update_disabled: bool,
-) -> Result<(Option<xfr::protocol::TestResult>, xfr::prefs::Prefs, bool)> {
+) -> Result<TuiLoopExit> {
     // Spawn the background update check unless it's disabled (flag/env/config/
     // pref) or compiled out. `update_rx` still exists so the poller is a no-op.
     let (update_tx, update_rx) = std::sync::mpsc::channel();
@@ -2110,19 +2137,28 @@ async fn run_tui_loop(
     let mut run = Some(spawn_tui_run(&config));
     app.on_connected();
 
-    // Track cancel state: when user presses 'q' or Ctrl+C during a running test,
+    // Cumulative counters mirroring the --no-tui fallback path: if the server
+    // never answers a cancel (issue #159), these still let us show a summary.
+    let mut fallback_bytes: u64 = 0;
+    let mut fallback_elapsed_ms: u64 = 0;
+
+    // Cancel state lives in `app.cancel_deadline` so the footer can render the
+    // remaining wait: when user presses 'q' or Ctrl+C during a running test,
     // we cancel and wait briefly for the server Result before exiting.
-    let mut cancel_deadline: Option<std::time::Instant> = None;
 
     loop {
         // If we're waiting for cancel result and deadline expired, exit now
-        if let Some(deadline) = cancel_deadline
+        if let Some(deadline) = app.cancel_deadline
             && deadline.elapsed() > Duration::ZERO
         {
             if let Some(current) = run.take() {
                 abort_tui_run(current).await;
             }
-            return Ok((app.result, prefs, print_json_on_exit));
+            let partial = app.result.is_none();
+            if partial {
+                app.result = tui_fallback_result(fallback_bytes, fallback_elapsed_ms);
+            }
+            return Ok((app.result, prefs, print_json_on_exit, partial));
         }
 
         poll_update_check(&mut app, &update_rx, &mut update_check_done);
@@ -2162,14 +2198,21 @@ async fn run_tui_loop(
                 if handle_tui_settings_key(&mut app, key) == SettingsAction::Restart {
                     prefs.theme = Some(app.theme_name().to_string());
                     apply_tui_settings(&mut config, &mut app);
-                    cancel_deadline = None;
+                    app.cancel_deadline = None;
+                    fallback_bytes = 0;
+                    fallback_elapsed_ms = 0;
                     print_json_on_exit = false;
                     restart_tui_run(terminal, &mut app, &mut run, &config).await?;
                 }
                 continue;
             }
 
-            match tui_quit_action(&key, app.state, cancel_deadline.is_some(), run.is_some()) {
+            match tui_quit_action(
+                &key,
+                app.state,
+                app.cancel_deadline.is_some(),
+                run.is_some(),
+            ) {
                 TuiQuitAction::Noop => {}
                 TuiQuitAction::ExitError => {
                     prefs.theme = Some(app.theme_name().to_string());
@@ -2177,14 +2220,14 @@ async fn run_tui_loop(
                 }
                 TuiQuitAction::ExitOk => {
                     prefs.theme = Some(app.theme_name().to_string());
-                    return Ok((app.result, prefs, print_json_on_exit));
+                    return Ok((app.result, prefs, print_json_on_exit, false));
                 }
                 TuiQuitAction::ForceExit => {
                     if let Some(current) = run.take() {
                         abort_tui_run(current).await;
                     }
                     prefs.theme = Some(app.theme_name().to_string());
-                    return Ok((app.result, prefs, print_json_on_exit));
+                    return Ok((app.result, prefs, print_json_on_exit, false));
                 }
                 TuiQuitAction::Ignore => {
                     continue;
@@ -2193,8 +2236,11 @@ async fn run_tui_loop(
                     if let Some(active) = run.as_ref() {
                         let _ = active.client.cancel();
                     }
-                    cancel_deadline = Some(std::time::Instant::now() + Duration::from_secs(3));
-                    app.log("Cancelling, waiting for summary...");
+                    app.cancel_deadline = Some(std::time::Instant::now() + TUI_CANCEL_WAIT);
+                    app.log(format!(
+                        "Cancelling, waiting up to {}s for the server summary...",
+                        TUI_CANCEL_WAIT.as_secs()
+                    ));
                     continue;
                 }
             }
@@ -2231,7 +2277,9 @@ async fn run_tui_loop(
                     }
                 }
                 KeyCode::Char('r') => {
-                    cancel_deadline = None;
+                    app.cancel_deadline = None;
+                    fallback_bytes = 0;
+                    fallback_elapsed_ms = 0;
                     print_json_on_exit = false;
                     restart_tui_run(terminal, &mut app, &mut run, &config).await?;
                 }
@@ -2252,7 +2300,7 @@ async fn run_tui_loop(
                 }
                 KeyCode::Esc if matches!(app.state, AppState::Completed) => {
                     prefs.theme = Some(app.theme_name().to_string());
-                    return Ok((app.result, prefs, print_json_on_exit));
+                    return Ok((app.result, prefs, print_json_on_exit, false));
                 }
                 KeyCode::Esc if matches!(app.state, AppState::Error) => {
                     prefs.theme = Some(app.theme_name().to_string());
@@ -2274,6 +2322,13 @@ async fn run_tui_loop(
         // Check for progress updates
         if let Some(active) = run.as_mut() {
             while let Ok(progress) = active.progress_rx.try_recv() {
+                // Same accumulation as the --no-tui print loop: interval byte
+                // deltas summed, last server-reported elapsed kept. Feedback-only
+                // updates carry sentinel byte/elapsed fields — skip them.
+                if !progress.udp_feedback_only {
+                    fallback_bytes += progress.total_bytes;
+                    fallback_elapsed_ms = progress.elapsed_ms;
+                }
                 app.on_progress(progress);
             }
         }
@@ -2289,19 +2344,26 @@ async fn run_tui_loop(
                     app.on_result(result);
 
                     // If we were waiting for cancel to complete, exit now with result
-                    if cancel_deadline.is_some() {
+                    if app.cancel_deadline.is_some() {
                         prefs.theme = Some(app.theme_name().to_string());
-                        return Ok((app.result, prefs, print_json_on_exit));
+                        return Ok((app.result, prefs, print_json_on_exit, false));
                     }
 
                     // Show final result for a moment
                     terminal.draw(|f| draw(f, &app))?;
                 }
                 Err(e) => {
-                    // If we were waiting for cancel to complete, just exit
-                    if cancel_deadline.is_some() {
+                    // If we were waiting for cancel to complete, exit with a
+                    // locally-built summary — on a dead link the run errors out
+                    // ("Timeout waiting for server response") well before the
+                    // cancel deadline, and the stats shouldn't be lost with it.
+                    if app.cancel_deadline.is_some() {
                         prefs.theme = Some(app.theme_name().to_string());
-                        return Ok((app.result, prefs, print_json_on_exit));
+                        let partial = app.result.is_none();
+                        if partial {
+                            app.result = tui_fallback_result(fallback_bytes, fallback_elapsed_ms);
+                        }
+                        return Ok((app.result, prefs, print_json_on_exit, partial));
                     }
 
                     app.on_error(e.to_string());
@@ -2677,6 +2739,18 @@ mod tests {
             tui_quit_action(&ctrl_c_key(), AppState::Running, true, true),
             TuiQuitAction::ForceExit
         );
+    }
+
+    #[test]
+    fn tui_fallback_result_only_when_data_was_collected() {
+        // Nothing transferred -> no summary worth showing ("Test cancelled.").
+        assert!(tui_fallback_result(0, 1000).is_none());
+
+        // 1 MB over 2 s -> 4 Mbps, built from the local counters (issue #159).
+        let result = tui_fallback_result(1_000_000, 2000).expect("summary for collected data");
+        assert_eq!(result.bytes_total, 1_000_000);
+        assert_eq!(result.duration_ms, 2000);
+        assert!((result.throughput_mbps - 4.0).abs() < 1e-9);
     }
 
     #[test]

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -125,6 +125,11 @@ pub struct App {
     pub result: Option<TestResult>,
     pub error: Option<String>,
 
+    /// Deadline for the post-quit "waiting for server Result" grace period
+    /// (issue #159). While set, the footer shows a countdown so a quit on a
+    /// dead link reads as a bounded wait instead of a hang.
+    pub cancel_deadline: Option<Instant>,
+
     pub start_time: Option<Instant>,
     pub show_help: bool,
     pub show_streams: bool,
@@ -238,6 +243,8 @@ impl App {
 
             result: None,
             error: None,
+
+            cancel_deadline: None,
 
             start_time: None,
             show_help: false,
@@ -415,6 +422,7 @@ impl App {
 
         self.result = None;
         self.error = None;
+        self.cancel_deadline = None;
         self.start_time = None;
         self.show_help = false;
         self.show_streams = false;

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -561,20 +561,36 @@ fn draw_streams(frame: &mut Frame, app: &App, theme: &Theme, area: Rect) {
 }
 
 fn draw_footer(frame: &mut Frame, app: &App, theme: &Theme, area: Rect) {
-    let status_text = match app.state {
-        AppState::Connecting => "Connecting...",
-        AppState::Running => "Running...",
-        AppState::Paused => "Paused",
-        AppState::Completed => "Complete",
-        AppState::Error => "Error",
+    // A pending quit overrides the state label: show a live countdown so a
+    // cancel on a dead link reads as a bounded wait, not a hang (issue #159).
+    let cancel_wait_secs = app.cancel_deadline.map(|d| {
+        d.saturating_duration_since(std::time::Instant::now())
+            .as_secs_f64()
+            .ceil() as u64
+    });
+
+    let status_text = match cancel_wait_secs {
+        Some(secs) => format!("Waiting for server ({secs}s)..."),
+        None => match app.state {
+            AppState::Connecting => "Connecting...",
+            AppState::Running => "Running...",
+            AppState::Paused => "Paused",
+            AppState::Completed => "Complete",
+            AppState::Error => "Error",
+        }
+        .to_string(),
     };
 
-    let status_color = match app.state {
-        AppState::Connecting => theme.text_dim,
-        AppState::Running => theme.success,
-        AppState::Paused => theme.warning,
-        AppState::Completed => theme.success,
-        AppState::Error => theme.error,
+    let status_color = if cancel_wait_secs.is_some() {
+        theme.warning
+    } else {
+        match app.state {
+            AppState::Connecting => theme.text_dim,
+            AppState::Running => theme.success,
+            AppState::Paused => theme.warning,
+            AppState::Completed => theme.success,
+            AppState::Error => theme.error,
+        }
     };
 
     let mut spans = vec![


### PR DESCRIPTION
## Problem

#159: during WiFi site surveys on links that are "half a step from disconnected", telling xfr to quit takes a long time with no indication of what it's doing.

Investigation (server SIGSTOPped mid-test as the zombie-link stand-in) showed the wall-clock hang in current master was actually already capped at 3s — but three real problems remained:

1. **The TUI silently discarded every stat on a dead-link quit** — it printed "Test cancelled." and dropped the transfer/throughput numbers the user just spent a survey walk collecting. (The `--no-tui` Ctrl+C path already had a proper local fallback summary; the TUI never got it.)
2. **Nothing on screen indicated a bounded wait was happening** — the reported "hang" experience.
3. **One genuinely unbounded hazard**: the control-channel Cancel `write_message` ran *before* `start_control_cancel_wait` armed the post-cancel deadline, and the select loop suspends inside that arm — so a full control-socket send buffer (exactly what a dead link produces) would hang quit with only the test-duration deadline (60s+…) armed. This is most likely what the reporter actually hit.

## Fix

- `src/client.rs`: the cancel deadline is armed *before* the Cancel write, and the write itself is wrapped in a timeout — a full send buffer can no longer stall the cancel path.
- `src/main.rs` TUI loop: the cancel wait (extended 3s→5s to match `--no-tui`) accumulates interval bytes/elapsed exactly like the `--no-tui` print task; on deadline expiry — or when the run task errors while a cancel is pending — it returns a fallback summary built from those counters, flagged `partial`. `run_client_tui` prints a "Warning: partial results" line and never writes partials to `--output` files (same rule as the existing no-tui fallback).
- `src/tui/ui.rs`: while waiting, the footer status shows **"Waiting for server (Ns)..."** counting down live, and History logs the bounded wait — the reporter's requested visible countdown.

## Verification (server SIGSTOPped mid-test, loopback)

| Path | Before | After |
|---|---|---|
| TUI `q` | ~3s exit, **all stats dropped**, no wait indication | ~5s bounded, live countdown, partial warning + real local summary (verified independently: 21.3 GB / 60.98 Gbps shown where before there was nothing) |
| TUI `q`, healthy server | prompt exit, real Result | unchanged — real Result with TCP info, no partial flag, ~1s |
| `--no-tui` SIGINT | 5s + fallback summary (already correct) | unchanged |

438 tests pass (1 new); fmt + clippy `-D warnings` clean.