### PR TITLE
fix(config): reject unusable existing files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **QUIC now honors the advertised 128-stream CLI maximum** — upload and download data use unidirectional streams, but both endpoints raised only Quinn's bidirectional limit and left its unidirectional credit at the default 100. A `-Q -P 128` run therefore started exactly 100 active streams and left 28 blocked. Client and server now advertise all 128 unidirectional data streams, with a loopback regression opening the full set in both directions.
+- **Existing config files now fail closed when they cannot be read or parsed** — startup previously used `unwrap_or_default()`, silently discarding the whole file on any error. A malformed file could therefore drop a server PSK, ACL, or rate limit while still launching with permissive defaults. Missing files still use defaults; present but unusable files now stop startup with the config path and underlying error.
 
 ## [0.9.25] - 2026-07-31
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,8 +2,9 @@
 //!
 //! Loads configuration from ~/.config/xfr/config.toml
 
+use anyhow::Context;
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::protocol::TimestampFormat;
 
@@ -152,13 +153,24 @@ impl Config {
     /// Load configuration from the default path.
     /// Returns default config if file doesn't exist.
     pub fn load() -> anyhow::Result<Self> {
-        let config_path = Self::config_path();
-        if config_path.exists() {
-            let contents = std::fs::read_to_string(&config_path)?;
-            Ok(toml::from_str(&contents)?)
-        } else {
-            Ok(Self::default())
-        }
+        Self::load_from(&Self::config_path())
+    }
+
+    fn load_from(config_path: &Path) -> anyhow::Result<Self> {
+        let contents = match std::fs::read_to_string(config_path) {
+            Ok(contents) => contents,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                return Ok(Self::default());
+            }
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!("failed to read config file {}", config_path.display())
+                });
+            }
+        };
+
+        toml::from_str(&contents)
+            .with_context(|| format!("failed to parse config file {}", config_path.display()))
     }
 
     /// Get the default config file path
@@ -184,6 +196,56 @@ mod tests {
         let config = Config::default();
         assert!(config.presets.is_empty());
         assert!(config.client.duration_secs.is_none());
+    }
+
+    #[test]
+    fn load_returns_defaults_only_when_config_is_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("missing").join("config.toml");
+
+        let config = Config::load_from(&config_path).unwrap();
+
+        assert!(config.presets.is_empty());
+        assert!(config.client.duration_secs.is_none());
+        assert!(config.server.psk.is_none());
+    }
+
+    #[test]
+    fn load_rejects_malformed_existing_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("config.toml");
+        std::fs::write(&config_path, "[server\npsk = \"secret\"").unwrap();
+
+        let error = Config::load_from(&config_path).unwrap_err();
+        let message = format!("{error:#}");
+
+        assert!(message.contains("failed to parse config file"));
+        assert!(message.contains(config_path.to_str().unwrap()));
+    }
+
+    #[test]
+    fn load_rejects_unreadable_existing_config_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("config.toml");
+        std::fs::create_dir(&config_path).unwrap();
+
+        let error = Config::load_from(&config_path).unwrap_err();
+        let message = format!("{error:#}");
+
+        assert!(message.contains("failed to read config file"));
+        assert!(message.contains(config_path.to_str().unwrap()));
+    }
+
+    #[test]
+    fn load_parses_existing_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("config.toml");
+        std::fs::write(&config_path, "[server]\npsk = \"secret\"\nrate_limit = 3\n").unwrap();
+
+        let config = Config::load_from(&config_path).unwrap();
+
+        assert_eq!(config.server.psk.as_deref(), Some("secret"));
+        assert_eq!(config.server.rate_limit, Some(3));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -896,8 +896,9 @@ async fn main() -> Result<()> {
         return Ok(());
     }
 
-    // Load config file (falls back to defaults if not found)
-    let file_config = Config::load().unwrap_or_default();
+    // A missing config is fine, but an existing config must be usable. Silently
+    // dropping settings such as PSKs, ACLs, or rate limits is unsafe.
+    let file_config = Config::load()?;
 
     // Determine logging config based on command (server vs client)
     let (effective_log_file, effective_log_level, tui_enabled) = match &cli.command {


### PR DESCRIPTION
## Summary
- Default only when config.toml is absent
- Propagate existing read and parse failures with path context
- Remove the startup unwrap_or_default fallback
- Cover missing, valid, malformed, and unreadable paths

## Why
A malformed or unreadable existing config silently launched with defaults, which could discard server PSKs, ACLs, and rate limits.

## Validation
- 11 focused config tests
- Clippy in both feature modes

## Stack
Based on perf/udp-pacing-schedule.