### PR TITLE
perf(tui): skip unchanged server dashboard frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **The TUI no longer rebuilds an unchanged frame twenty times a second** — the client loop drew on every 50 ms tick, and although ratatui only writes cells that differ, every `format!`, `Line` and `Span` in the frame was rebuilt regardless, so a finished, paused or errored test sat at ~0.6% of a core doing nothing visible. The loop now hashes everything the renderer reads (state, stats, sparkline and log history, overlays, settings, theme, terminal size, and the wall-clock values at the resolution they are shown: whole-second elapsed, cell-quantized progress bar, whole-second cancel countdown) and skips the draw when the hash matches the last frame drawn. Idle-screen CPU drops to near zero; a running test redraws only when a visible value changes. The fingerprint destructures `App` exhaustively, so a new field must be classified before the code compiles, and the terminal size is part of it so a resize while idle still re-flows the layout. (LAN-1226)
+- **The server dashboard now skips unchanged frames too** — it previously rebuilt the full header and active-test table before every 100 ms input poll even though its clocks render only whole seconds. An exhaustive render fingerprint now reduces an idle dashboard from ten frame builds per second to one, while test events, help toggles, and terminal resizes still redraw immediately.
 
 ## [0.9.25] - 2026-07-31
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2406,10 +2406,17 @@ async fn run_server_tui(mut config: ServerConfig) -> Result<()> {
     let server_handle = tokio::spawn(async move { server.run().await });
 
     let mut app = ServerApp::new();
+    // The dashboard's uptime and active-test timers render at one-second
+    // resolution. Keep the 100 ms event poll for responsive input, but skip
+    // frame construction until visible state (or terminal size) changes.
+    let mut last_drawn: Option<u64> = None;
 
     loop {
-        // Draw UI
-        terminal.draw(|f| server_draw(f, &app))?;
+        let fingerprint = app.render_fingerprint(terminal.size()?);
+        if last_drawn != Some(fingerprint) {
+            terminal.draw(|f| server_draw(f, &app))?;
+            last_drawn = Some(fingerprint);
+        }
 
         // Handle keyboard events with timeout
         if event::poll(Duration::from_millis(100))?
@@ -2457,9 +2464,6 @@ async fn run_server_tui(mut config: ServerConfig) -> Result<()> {
                 }
             }
         }
-
-        // Update bandwidth history
-        app.update_bandwidth();
 
         // Check if server task ended
         if server_handle.is_finished() {

--- a/src/tui/server.rs
+++ b/src/tui/server.rs
@@ -3,6 +3,7 @@
 //! Real-time monitoring of active tests and server statistics.
 
 use std::collections::VecDeque;
+use std::hash::{DefaultHasher, Hash, Hasher};
 use std::net::IpAddr;
 use std::time::{Duration, Instant};
 
@@ -29,7 +30,7 @@ pub enum ServerEvent {
 
 use crate::stats::mbps_to_human;
 use ratatui::Frame;
-use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::layout::{Constraint, Direction, Layout, Rect, Size};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Paragraph, Row, Table};
@@ -133,6 +134,68 @@ impl ServerApp {
 
     pub fn toggle_help(&mut self) {
         self.show_help = !self.show_help;
+    }
+
+    /// Hash of every value rendered by [`draw`]. The server loop compares
+    /// this with the last drawn frame so its 100 ms event poll can stay
+    /// responsive without rebuilding an identical dashboard ten times per
+    /// second. Wall-clock values are reduced to the whole seconds the UI
+    /// displays, and the terminal size is included so resize reflow is never
+    /// skipped.
+    pub fn render_fingerprint(&self, size: Size) -> u64 {
+        self.render_fingerprint_at(size, Instant::now())
+    }
+
+    fn render_fingerprint_at(&self, size: Size, now: Instant) -> u64 {
+        // Keep these destructures exhaustive: a newly rendered field should
+        // fail compilation here until its cache behavior is decided.
+        let ServerApp {
+            active_tests,
+            total_tests,
+            failed_tests,
+            total_bytes: _,       // accumulated for bookkeeping, not rendered
+            bandwidth_history: _, // reserved history is not currently rendered
+            connections_blocked,
+            auth_failures,
+            start_time,
+            show_help,
+        } = self;
+
+        let mut h = DefaultHasher::new();
+        size.hash(&mut h);
+        now.saturating_duration_since(*start_time)
+            .as_secs()
+            .hash(&mut h);
+        total_tests.hash(&mut h);
+        failed_tests.hash(&mut h);
+        connections_blocked.hash(&mut h);
+        auth_failures.hash(&mut h);
+        show_help.hash(&mut h);
+
+        active_tests.len().hash(&mut h);
+        for ActiveTestInfo {
+            id: _, // row identity used for updates, not rendered
+            client_ip,
+            protocol,
+            direction,
+            streams,
+            started,
+            duration_secs,
+            bytes: _, // accumulated for bookkeeping, not rendered
+            throughput_mbps,
+        } in active_tests
+        {
+            client_ip.hash(&mut h);
+            protocol.hash(&mut h);
+            direction.hash(&mut h);
+            streams.hash(&mut h);
+            now.saturating_duration_since(*started)
+                .as_secs()
+                .hash(&mut h);
+            duration_secs.hash(&mut h);
+            throughput_mbps.to_bits().hash(&mut h);
+        }
+        h.finish()
     }
 }
 
@@ -386,5 +449,51 @@ mod tests {
         assert_eq!(app.total_tests, 2);
         assert_eq!(app.failed_tests, 1);
         assert_eq!(app.total_bytes, 150);
+    }
+
+    #[test]
+    fn render_fingerprint_tracks_visible_server_state() {
+        let now = Instant::now();
+        let size = Size::new(120, 40);
+        let mut app = ServerApp::new();
+        app.start_time = now - Duration::from_secs(10);
+
+        let idle = app.render_fingerprint_at(size, now);
+        assert_eq!(
+            idle,
+            app.render_fingerprint_at(size, now + Duration::from_millis(999)),
+            "sub-second uptime drift is not visible"
+        );
+        assert_ne!(
+            idle,
+            app.render_fingerprint_at(size, now + Duration::from_secs(1)),
+            "whole-second uptime changes the header"
+        );
+        assert_ne!(
+            idle,
+            app.render_fingerprint_at(Size::new(100, 30), now),
+            "terminal resize reflows the dashboard"
+        );
+
+        let mut test = active_test("visible");
+        test.started = now - Duration::from_secs(2);
+        app.add_test(test);
+        let active = app.render_fingerprint_at(size, now);
+        assert_ne!(idle, active, "a new row must dirty the frame");
+
+        app.update_test("visible", 1024, 42.0);
+        let updated = app.render_fingerprint_at(size, now);
+        assert_ne!(active, updated, "visible throughput changed");
+        assert_ne!(
+            updated,
+            app.render_fingerprint_at(size, now + Duration::from_secs(1)),
+            "active-test elapsed time changed"
+        );
+
+        app.toggle_help();
+        let help = app.render_fingerprint_at(size, now);
+        assert_ne!(updated, help, "help overlay changed");
+        app.record_blocked();
+        assert_ne!(help, app.render_fingerprint_at(size, now));
     }
 }


### PR DESCRIPTION
## Summary
- Fingerprint every value rendered by the server dashboard
- Skip draws when visible state and terminal size are unchanged
- Stop mutating unused bandwidth history in the server loop

## Why
The server dashboard rebuilt its full frame every 100 ms even while idle, although its clocks render only whole seconds.

## Validation
- Focused server render-fingerprint tests
- Clippy with all features and with no default features

## Stack
This is stacked directly on #172. Review the diff against perf/lan-1226-tui-dirty-skip.