### PR TITLE
fix(config): protect embedded PSKs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- **Config-file PSKs now require owner-only permissions on Unix** — `--psk-file` already rejected group/other access, but embedding the same key under `[client]` or `[server]` accepted a typical `0644` config readable by every local user. Secret-bearing configs now fail with their path and mode unless they are private (for example, `chmod 600`); ordinary configs without a PSK keep working with normal permissions.
+
 ### Changed
 - **The TUI no longer rebuilds an unchanged frame twenty times a second** — the client loop drew on every 50 ms tick, and although ratatui only writes cells that differ, every `format!`, `Line` and `Span` in the frame was rebuilt regardless, so a finished, paused or errored test sat at ~0.6% of a core doing nothing visible. The loop now hashes everything the renderer reads (state, stats, sparkline and log history, overlays, settings, theme, terminal size, and the wall-clock values at the resolution they are shown: whole-second elapsed, cell-quantized progress bar, whole-second cancel countdown) and skips the draw when the hash matches the last frame drawn. Idle-screen CPU drops to near zero; a running test redraws only when a visible value changes. The fingerprint destructures `App` exhaustively, so a new field must be classified before the code compiles, and the terminal size is part of it so a resize while idle still re-flows the layout. (LAN-1226)
 - **The server dashboard now skips unchanged frames too** — it previously rebuilt the full header and active-test table before every 100 ms input poll even though its clocks render only whole seconds. An exhaustive render fingerprint now reduces an idle dashboard from ten frame builds per second to one, while test events, help toggles, and terminal resizes still redraw immediately.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ See [Installation](#installation) below for setup instructions.
 - **Result comparison** - `xfr diff` to detect performance regressions
 - **LAN discovery** - find xfr servers with mDNS (`xfr discover`)
 - **Prometheus metrics** - export stats for monitoring dashboards
-- **Config file** - save defaults in `~/.config/xfr/config.toml`
+- **Config file** - save defaults in the platform configuration directory
 - **Environment variables** - `XFR_PORT`, `XFR_DURATION` overrides
 
 ### vs iperf3
@@ -385,12 +385,14 @@ in monochrome, and for colorblind users. Setting the standard
 [`NO_COLOR`](https://no-color.org) environment variable selects `monochrome`
 automatically unless a theme is chosen explicitly.
 
-Your theme preference is auto-saved to `~/.config/xfr/prefs.toml`.
+Your theme preference is auto-saved beside `config.toml` as `xfr/prefs.toml`
+in the same platform configuration directory.
 
 ## Configuration
 
 xfr reads defaults from:
-- **Linux/macOS:** `~/.config/xfr/config.toml`
+- **Linux:** `$XDG_CONFIG_HOME/xfr/config.toml`, or `~/.config/xfr/config.toml` when `XDG_CONFIG_HOME` is unset
+- **macOS:** `~/Library/Application Support/xfr/config.toml`
 - **Windows:** `%APPDATA%\xfr\config.toml`
 
 ```toml
@@ -429,6 +431,17 @@ acl_file = "/path/to/acl.txt"
 push_gateway = "http://pushgateway:9091"
 log_file = "~/.config/xfr/xfr-server.log"
 log_level = "info"
+```
+
+On Unix, a config containing either `psk` must grant no access to group or
+other users, so the shared key is not exposed to another local account:
+
+```bash
+# Linux
+chmod 600 "${XDG_CONFIG_HOME:-$HOME/.config}/xfr/config.toml"
+
+# macOS
+chmod 600 "$HOME/Library/Application Support/xfr/config.toml"
 ```
 
 The value-taking transport and output settings under `[client]` are defaults: an explicit CLI value takes precedence. This includes `omit_secs` and `interval_secs`, so `--omit 0` and `--interval 1.0` override the config file. `bitrate` accepts the same `100M`/`1G` syntax as `--bitrate`; `dscp` accepts the same DSCP names and numeric values as `--dscp`.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -325,7 +325,8 @@ xfr <host> --timestamp-format unix       # "1705316400"
 ### Config File
 
 xfr reads defaults from:
-- **Linux/macOS:** `~/.config/xfr/config.toml`
+- **Linux:** `$XDG_CONFIG_HOME/xfr/config.toml`, or `~/.config/xfr/config.toml` when `XDG_CONFIG_HOME` is unset
+- **macOS:** `~/Library/Application Support/xfr/config.toml`
 - **Windows:** `%APPDATA%\xfr\config.toml`
 
 ```toml
@@ -366,6 +367,17 @@ log_file = "~/.config/xfr/xfr-server.log"
 log_level = "info"
 ```
 
+On Unix, a config containing either `psk` must grant no access to group or
+other users, so the shared key is not exposed to another local account:
+
+```bash
+# Linux
+chmod 600 "${XDG_CONFIG_HOME:-$HOME/.config}/xfr/config.toml"
+
+# macOS
+chmod 600 "$HOME/Library/Application Support/xfr/config.toml"
+```
+
 The value-taking transport and output settings under `[client]` are defaults: an explicit CLI value overrides them. This includes `omit_secs` and `interval_secs`, so `--omit 0` and `--interval 1.0` take precedence over the config file. `bitrate` accepts the same `100M`/`1G` syntax as `--bitrate`; `dscp` accepts the same DSCP names and numeric values as `--dscp`.
 
 ### Environment Variables
@@ -381,7 +393,8 @@ Environment variables override config file settings:
 
 ### User Preferences
 
-Theme preference is saved to `~/.config/xfr/prefs.toml`:
+Theme preference is saved beside `config.toml` as `xfr/prefs.toml` in the same
+platform configuration directory:
 
 ```toml
 theme = "dracula"

--- a/docs/xfr.1
+++ b/docs/xfr.1
@@ -223,7 +223,7 @@ Regression threshold percentage (default: 5)
 Discovery timeout (default: 5s)
 .SH CONFIGURATION
 .B xfr
-reads configuration from \fI~/.config/xfr/config.toml\fR (Linux/macOS) or \fI%APPDATA%\\xfr\\config.toml\fR (Windows) if present.
+reads configuration from \fI$XDG_CONFIG_HOME/xfr/config.toml\fR (Linux, defaulting to \fI~/.config/xfr/config.toml\fR), \fI~/Library/Application Support/xfr/config.toml\fR (macOS), or \fI%APPDATA%\\xfr\\config.toml\fR (Windows) if present.
 CLI arguments override config file values. Environment variables override config file.
 .PP
 Example config:
@@ -246,6 +246,19 @@ psk = "secret"
 rate_limit = 5
 no_mdns = false
 allow = ["192.168.0.0/16"]
+.fi
+.RE
+.PP
+On Unix, a config containing a
+.B psk
+must grant no group or other access. Set owner-only permissions with:
+.RS
+.nf
+# Linux
+chmod 600 "${XDG_CONFIG_HOME:-$HOME/.config}/xfr/config.toml"
+
+# macOS
+chmod 600 "$HOME/Library/Application Support/xfr/config.toml"
 .fi
 .RE
 .PP
@@ -401,10 +414,16 @@ Test was interrupted by SIGINT before server could report a full result (partial
 .SH FILES
 .TP
 .I ~/.config/xfr/config.toml
-User configuration file
+Linux user configuration file (when XDG_CONFIG_HOME is unset)
+.TP
+.I ~/Library/Application\ Support/xfr/config.toml
+macOS user configuration file
 .TP
 .I ~/.config/xfr/prefs.toml
-User preferences (theme)
+Linux user preferences (when XDG_CONFIG_HOME is unset)
+.TP
+.I ~/Library/Application\ Support/xfr/prefs.toml
+macOS user preferences (theme)
 .SH SEE ALSO
 .BR iperf3 (1)
 .SH BUGS

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -55,6 +55,27 @@ fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
     result == 0
 }
 
+/// Reject secret-bearing files that grant any access to group or other users.
+#[cfg(unix)]
+pub(crate) fn require_owner_only_permissions(
+    path: &std::path::Path,
+    metadata: &std::fs::Metadata,
+    description: &str,
+) -> anyhow::Result<()> {
+    use std::os::unix::fs::MetadataExt;
+
+    let mode = metadata.mode() & 0o777;
+    if mode & 0o077 != 0 {
+        anyhow::bail!(
+            "{} {:?} has overly broad permissions ({:03o}): group/other access is not allowed",
+            description,
+            path,
+            mode
+        );
+    }
+    Ok(())
+}
+
 /// Read PSK from file, trimming whitespace.
 ///
 /// On Unix, rejects files that are readable or writable by anyone other than
@@ -63,16 +84,8 @@ fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
 pub fn read_psk_file(path: &std::path::Path) -> anyhow::Result<String> {
     #[cfg(unix)]
     {
-        use std::os::unix::fs::MetadataExt;
         let metadata = std::fs::metadata(path)?;
-        let mode = metadata.mode() & 0o777;
-        if mode & 0o077 != 0 {
-            anyhow::bail!(
-                "PSK file {:?} has overly broad permissions ({:03o}): group/other access is not allowed",
-                path,
-                mode
-            );
-        }
+        require_owner_only_permissions(path, &metadata, "PSK file")?;
     }
 
     let content = std::fs::read_to_string(path)?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,9 +1,11 @@
 //! Configuration file support
 //!
-//! Loads configuration from ~/.config/xfr/config.toml
+//! Loads `xfr/config.toml` from the platform configuration directory returned
+//! by `dirs::config_dir()`.
 
 use anyhow::Context;
 use serde::{Deserialize, Serialize};
+use std::io::Read;
 use std::path::{Path, PathBuf};
 
 use crate::protocol::TimestampFormat;
@@ -157,8 +159,8 @@ impl Config {
     }
 
     fn load_from(config_path: &Path) -> anyhow::Result<Self> {
-        let contents = match std::fs::read_to_string(config_path) {
-            Ok(contents) => contents,
+        let mut file = match std::fs::File::open(config_path) {
+            Ok(file) => file,
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
                 return Ok(Self::default());
             }
@@ -169,8 +171,30 @@ impl Config {
             }
         };
 
-        toml::from_str(&contents)
-            .with_context(|| format!("failed to parse config file {}", config_path.display()))
+        // Capture metadata from the same open handle that supplies the
+        // contents, avoiding a path-swap race during the permissions check.
+        #[cfg(unix)]
+        let metadata = file
+            .metadata()
+            .with_context(|| format!("failed to inspect config file {}", config_path.display()))?;
+
+        let mut contents = String::new();
+        file.read_to_string(&mut contents)
+            .with_context(|| format!("failed to read config file {}", config_path.display()))?;
+
+        let config: Self = toml::from_str(&contents)
+            .with_context(|| format!("failed to parse config file {}", config_path.display()))?;
+
+        #[cfg(unix)]
+        if config.client.psk.is_some() || config.server.psk.is_some() {
+            crate::auth::require_owner_only_permissions(
+                config_path,
+                &metadata,
+                "config file containing a PSK",
+            )?;
+        }
+
+        Ok(config)
     }
 
     /// Get the default config file path
@@ -241,11 +265,50 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let config_path = dir.path().join("config.toml");
         std::fs::write(&config_path, "[server]\npsk = \"secret\"\nrate_limit = 3\n").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&config_path, std::fs::Permissions::from_mode(0o600)).unwrap();
+        }
 
         let config = Config::load_from(&config_path).unwrap();
 
         assert_eq!(config.server.psk.as_deref(), Some("secret"));
         assert_eq!(config.server.rate_limit, Some(3));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn load_rejects_broad_permissions_when_config_contains_psk() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("config.toml");
+        std::fs::write(&config_path, "[server]\npsk = \"secret\"\n").unwrap();
+        std::fs::set_permissions(&config_path, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        let error = Config::load_from(&config_path).unwrap_err();
+        let message = format!("{error:#}");
+
+        assert!(message.contains("config file containing a PSK"));
+        assert!(message.contains("overly broad permissions (644)"));
+        assert!(message.contains(config_path.to_str().unwrap()));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn load_allows_broad_permissions_when_config_has_no_psk() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("config.toml");
+        std::fs::write(&config_path, "[server]\nport = 9000\n").unwrap();
+        std::fs::set_permissions(&config_path, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        let config = Config::load_from(&config_path).unwrap();
+
+        assert_eq!(config.server.port, Some(9000));
+        assert!(config.server.psk.is_none());
     }
 
     #[test]

--- a/src/prefs.rs
+++ b/src/prefs.rs
@@ -1,7 +1,9 @@
 //! User preferences persistence.
 //!
-//! Saves runtime preferences (like last used theme) to ~/.config/xfr/prefs.toml
-//! Separate from config.toml which is for explicit user configuration.
+//! Saves runtime preferences (like the last used theme) as `xfr/prefs.toml`
+//! under the platform configuration directory returned by
+//! `dirs::config_dir()`. This is separate from `config.toml`, which is for
+//! explicit user configuration.
 
 use serde::{Deserialize, Serialize};
 use std::fs;
@@ -33,7 +35,7 @@ pub struct Prefs {
 }
 
 impl Prefs {
-    /// Get prefs file path: ~/.config/xfr/prefs.toml
+    /// Get the preferences path under the platform configuration directory.
     pub fn path() -> Option<PathBuf> {
         dirs::config_dir().map(|p| p.join("xfr").join("prefs.toml"))
     }


### PR DESCRIPTION
## Summary
- Require owner-only Unix permissions when config.toml contains a client or server PSK
- Reuse the existing PSK-file permission policy
- Read metadata and contents from the same open handle
- Leave ordinary non-secret configs compatible with normal permissions
- Document the chmod 600 remedy

## Why
The CLI protected --psk-file, but the documented embedded PSK path accepted a typical mode 0644 file readable by every local user.

## Validation
- 13 config tests and 9 auth tests
- 0644 secret rejection, 0600 secret acceptance, and 0644 non-secret acceptance
- Clippy in both feature modes

## Stack
Based on perf/udp-receive-timer.