### PR TITLE
test(net): tolerate UDP packet loss in dual-stack check

### DIFF
--- a/src/net.rs
+++ b/src/net.rs
@@ -1693,15 +1693,24 @@ mod tests {
         };
         let local = socket.local_addr().unwrap();
 
-        // Send a packet from an IPv4 socket to the dual-stack listener.
+        // Send packets from an IPv4 socket to the dual-stack listener. UDP
+        // delivery is not guaranteed, so retransmit within one bounded wait.
         let sender = UdpSocket::bind("127.0.0.1:0").await.unwrap();
         let target = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), local.port());
-        sender.send_to(b"ping", target).await.unwrap();
 
         let mut buf = [0u8; 4];
-        let result =
-            tokio::time::timeout(std::time::Duration::from_millis(500), socket.recv(&mut buf))
-                .await;
+        let receive = async {
+            let mut retransmit = tokio::time::interval(std::time::Duration::from_millis(50));
+            loop {
+                tokio::select! {
+                    result = socket.recv(&mut buf) => return result,
+                    _ = retransmit.tick() => {
+                        sender.send_to(b"ping", target).await?;
+                    }
+                }
+            }
+        };
+        let result = tokio::time::timeout(std::time::Duration::from_secs(2), receive).await;
         match result {
             Ok(Ok(n)) => assert_eq!(n, 4, "should receive exactly 4 bytes"),
             other => panic!("dual-stack UDP socket should receive IPv4 packets, got {other:?}"),


### PR DESCRIPTION
## Summary

- retransmit the IPv4 probe while the dual-stack UDP test waits for delivery
- keep one two-second outer deadline so a real dual-stack failure still fails quickly
- leave production socket behavior unchanged

## Why

The first post-merge macOS CI run dropped the test's only UDP datagram and timed out after 500 ms. The exact failed job passed on rerun, and UDP send success does not guarantee delivery, so a one-shot receive made this regression test unnecessarily flaky.

## Validation

- `just check`
- 250 consecutive targeted test runs
- targeted test with `--no-default-features`
- independent review of Tokio cancellation and cross-platform behavior
