### PR TITLE
build(deps): update typos and preserve MSRV check

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,10 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    ignore:
+      # The action ref is the Rust toolchain version, not an action release.
+      # Keep the MSRV selector aligned with package.rust-version manually.
+      - dependency-name: dtolnay/rust-toolchain
     groups:
       github-actions:
         patterns:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
-      - uses: crate-ci/typos@v1.49.1
+      - uses: crate-ci/typos@v1.50.0
 
   doc:
     name: Doc (deny rustdoc warnings)


### PR DESCRIPTION
## Summary

- update `crate-ci/typos` from 1.49.1 to 1.50.0
- tell Dependabot to leave `dtolnay/rust-toolchain` refs alone

## Why

The grouped Actions update in #189 correctly found Typos 1.50.0, but also changed the intentional MSRV selector from Rust 1.88 to nonexistent Rust 1.100. The toolchain action's ref is the Rust version to install, not an action release, so it must stay aligned manually with `package.rust-version`.

This replaces #189 without weakening the MSRV job and prevents the same bot churn from recurring.

## Validation

- both YAML files parse successfully
- `just check`
- Typos 1.50.0 passes on this worktree
- independent Dependabot configuration review
