### PR TITLE
docs: correct security, ACL, and metrics contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ xfr serve --max-duration 60s # Limit test duration
 xfr serve --push-gateway http://pushgateway:9091  # Push metrics on test complete
 xfr serve --psk mysecret     # Require PSK authentication
 xfr serve --rate-limit 2     # Max 2 concurrent tests per IP
-xfr serve --allow 192.168.0.0/16 --deny 0.0.0.0/0  # IP ACL
+xfr serve --allow 192.168.0.0/16  # Only allow the local subnet
 ```
 
 ### Client
@@ -294,7 +294,10 @@ xfr 192.168.1.1 --quic -R    # QUIC download test
 
 QUIC provides built-in TLS 1.3 encryption with stream multiplexing over a single connection.
 
-**Security Note:** QUIC encrypts traffic but does not verify server identity by default. For authenticated connections, use `--psk` on both client and server to prevent MITM attacks.
+**Security Note:** QUIC encrypts each connection but does not verify server
+identity. PSK authenticates and protects the application control channel, but
+is not cryptographically bound to QUIC bulk streams. Use an authenticated VPN
+when endpoint-verified confidentiality matters.
 
 ### MPTCP Mode
 
@@ -461,12 +464,16 @@ Enable with `--features prometheus`:
 xfr serve --prometheus 9090
 ```
 
-Metrics available at `http://localhost:9090/metrics`:
+Metrics available at `http://localhost:9090/metrics` include:
 
-- `xfr_bytes_total` - Total bytes transferred
-- `xfr_throughput_mbps` - Current throughput
-- `xfr_active_tests` - Number of active tests
-- `xfr_retransmits_total` - TCP retransmissions
+- `xfr_bytes_total`, `xfr_throughput_mbps`, `xfr_tests_total`, and
+  `xfr_active_tests` - aggregate transfer and server state
+- `xfr_test_duration_seconds` - test duration histogram
+- `xfr_stream_bytes_total`, `xfr_stream_throughput_mbps`, and
+  `xfr_stream_retransmits_total` - per-stream metrics labeled by `test_id` and
+  `stream_id`
+- `xfr_tcp_rtt_microseconds` and `xfr_tcp_retransmits_total` - TCP metrics
+  labeled by `test_id`
 
 See `examples/grafana-dashboard.json` for a sample Grafana dashboard.
 
@@ -534,23 +541,31 @@ TCP and UDP tests use random payloads by default to avoid inflated results on WA
 
 ### Transport Encryption
 
-| Mode | Encryption | Certificate Verification |
-|------|------------|-------------------------|
-| TCP | None | N/A |
-| UDP | None | N/A |
-| QUIC | TLS 1.3 | Disabled by default |
+| Mode | Bulk test data | Control channel |
+|------|----------------|-----------------|
+| TCP | Plaintext | Plaintext without PSK; ChaCha20-Poly1305 after PSK authentication |
+| UDP | Plaintext | Uses the same TCP control channel behavior |
+| QUIC | TLS 1.3; server identity is not verified | TLS 1.3; PSK can add protected application control |
 
-**QUIC mode** (`-Q/--quic`) provides TLS 1.3 encryption but does not verify server certificates, making it vulnerable to MITM attacks without additional authentication. **Always use `--psk` with QUIC on untrusted networks.** Alternatively, use a VPN or SSH tunnel.
+**QUIC mode** (`-Q/--quic`) uses a self-signed server certificate without PKI
+verification. An active relay can terminate and forward the QUIC connection.
+PSK protects xfr control messages end to end, but it is not bound to the QUIC
+bulk streams and does not make their data end-to-end authenticated.
 
 ### Authentication
 
-PSK authentication (`--psk`) verifies client identity but does not encrypt TCP/UDP traffic. For encrypted + authenticated connections, use QUIC with PSK:
+PSK authentication (`--psk`) authenticates both peers and protects post-auth
+control messages with ChaCha20-Poly1305. TCP and UDP bulk test payloads remain
+plaintext; QUIC bulk payloads are transport-encrypted but not PSK-authenticated.
+Use an authenticated VPN when endpoint-verified confidentiality is required.
+
+To combine QUIC transport encryption with PSK-protected control:
 
 ```bash
 # Server
 xfr serve --psk "secretkey"
 
-# Client (encrypted + authenticated)
+# Client (QUIC transport + PSK-protected control)
 xfr <host> -Q --psk "secretkey"
 ```
 
@@ -634,6 +649,7 @@ Ensure the server is running and the port is not blocked by a firewall. TCP, UDP
 - [Known Issues](KNOWN_ISSUES.md) - Edge cases and limitations
 - [Roadmap](ROADMAP.md) - Planned features
 - [Contributing](CONTRIBUTING.md) - Development guidelines
+- [Security Policy](SECURITY.md) - Supported versions and private reporting
 
 ## See Also
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,16 +4,14 @@
 
 | Version | Supported |
 | ------- | --------- |
-| 0.4.x   | ✓         |
-| < 0.4   | ✗         |
+| Latest release | ✓ |
+| Older releases | ✗ |
 
 ## Reporting a Vulnerability
 
-If you discover a security vulnerability in xfr, please report it by opening a GitHub issue at:
-
-https://github.com/lance0/xfr/issues
-
-For sensitive vulnerabilities that should not be disclosed publicly, please email the maintainer directly.
+Report security vulnerabilities through [GitHub private vulnerability
+reporting](https://github.com/lance0/xfr/security/advisories/new). Do not include
+vulnerability details in a public issue.
 
 ### What to include
 
@@ -22,18 +20,13 @@ For sensitive vulnerabilities that should not be disclosed publicly, please emai
 - Potential impact
 - Suggested fix (if any)
 
-### Response timeline
-
-- Initial response: within 48 hours
-- Status update: within 7 days
-- Fix timeline: depends on severity
-
 ## Security Considerations
 
 xfr is a network bandwidth testing tool. When running the server:
 
 - The server accepts connections from any client by default
-- Use `--psk` for pre-shared key authentication (HMAC-SHA256 challenge-response)
+- Use `--psk` for mutual pre-shared key authentication and protected control
+  messages
 - Use `--allow` / `--deny` for IP-based access control lists
 - Use `--rate-limit` to prevent abuse from individual IPs
 - Consider firewall rules to restrict access
@@ -41,15 +34,24 @@ xfr is a network bandwidth testing tool. When running the server:
 
 ### Transport Encryption
 
-| Mode | Encryption | Authentication |
-|------|------------|----------------|
-| TCP  | None       | PSK optional   |
-| UDP  | None       | PSK optional   |
-| QUIC | TLS 1.3    | PSK optional   |
+| Mode | Bulk test data | Control channel |
+|------|----------------|-----------------|
+| TCP  | Plaintext | Plaintext without PSK; ChaCha20-Poly1305 after PSK authentication |
+| UDP  | Plaintext | Uses the same TCP control channel behavior |
+| QUIC | TLS 1.3; server identity is not verified | TLS 1.3; PSK can add protected application control |
 
-**Important:** QUIC encrypts traffic but uses self-signed certificates without server verification. This means QUIC alone does not protect against man-in-the-middle attacks. **Always use PSK with QUIC on untrusted networks.**
+With PSK enabled, peers authenticate each other using HMAC-SHA256 proofs and
+post-auth control messages are protected with ChaCha20-Poly1305. TCP and UDP
+bulk payloads remain plaintext.
 
-For encrypted + authenticated connections, use QUIC with PSK:
+QUIC encrypts each TLS connection, but xfr uses a self-signed server certificate
+without PKI verification. The PSK proof and protected control channel are not
+bound to that TLS session or to its bulk streams. An active relay can therefore
+terminate and forward QUIC connections while accessing the bulk payload. QUIC
+with PSK is not end-to-end bulk-data authentication or confidentiality against
+such a relay; use an authenticated VPN when those properties are required.
+
+To combine QUIC transport encryption with PSK-protected control:
 ```bash
 xfr serve --psk "secretkey"
 xfr <host> -Q --psk "secretkey"

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -80,7 +80,7 @@ Encrypted transport over UDP using TLS 1.3:
 ```bash
 xfr <host> --quic              # QUIC transport (short: -Q)
 xfr <host> --quic -P 4         # QUIC with 4 multiplexed streams
-xfr <host> --quic --psk secret # QUIC with PSK authentication
+xfr <host> --quic --psk secret # QUIC with PSK-protected control
 ```
 
 QUIC provides:
@@ -89,7 +89,10 @@ QUIC provides:
 - Connection migration capability
 - Head-of-line blocking avoidance
 
-**Security Note**: QUIC encrypts traffic but uses self-signed certificates by default. For authenticated connections, combine with `--psk` to prevent MITM attacks.
+**Security Note**: QUIC encrypts traffic but does not verify the self-signed
+server certificate. PSK authenticates and protects xfr control messages, but is
+not bound to the QUIC bulk streams. Use an authenticated VPN when
+endpoint-verified confidentiality matters.
 
 ### MPTCP (Multi-Path TCP)
 
@@ -453,7 +456,7 @@ Restrict which IPs can connect:
 
 ```bash
 xfr serve --allow 192.168.0.0/16           # Only allow local network
-xfr serve --allow 10.0.0.0/8 --deny 0.0.0.0/0   # Allow 10.x, deny all else
+xfr serve --allow 10.0.0.0/8 --deny 10.42.0.0/16 # Allow 10.x except 10.42.x
 xfr serve --acl-file /etc/xfr/acl.txt      # Load ACL from file
 ```
 
@@ -461,10 +464,12 @@ ACL file format:
 ```
 allow 192.168.0.0/16
 allow 10.0.0.0/8
-deny 0.0.0.0/0
+deny 192.168.1.0/24
 ```
 
-Rules are evaluated in order. First match wins.
+Deny rules always take precedence. If any allow rules exist, addresses that
+match none of them are rejected; with no allow rules, otherwise-unmatched
+addresses are accepted. Rule order does not change the result.
 
 ### PSK Authentication
 
@@ -479,7 +484,8 @@ xfr serve --psk-file /etc/xfr/psk.txt
 xfr <host> --psk mysecretkey
 ```
 
-Authentication uses HMAC-SHA256 challenge-response.
+Authentication uses HMAC-SHA256 challenge-response. Once both peers are
+authenticated, post-auth control messages use ChaCha20-Poly1305.
 
 > **Security note:** Values supplied via `--psk` or the `XFR_PSK` environment
 > variable are visible through process metadata (`ps`, `/proc/<pid>/environ`,
@@ -506,10 +512,16 @@ xfr serve --prometheus 9090
 Available at `http://localhost:9090/metrics`:
 
 ```
-xfr_bytes_total{direction="upload"} 1234567890
-xfr_throughput_mbps{direction="upload"} 987.65
+xfr_bytes_total 1234567890
+xfr_throughput_mbps 987.65
+xfr_tests_total 3
+xfr_test_duration_seconds_count 3
 xfr_active_tests 2
-xfr_retransmits_total 42
+xfr_stream_bytes_total{test_id="abc",stream_id="0"} 1234567890
+xfr_stream_throughput_mbps{test_id="abc",stream_id="0"} 987.65
+xfr_stream_retransmits_total{test_id="abc",stream_id="0"} 42
+xfr_tcp_rtt_microseconds{test_id="abc"} 1200
+xfr_tcp_retransmits_total{test_id="abc"} 42
 ```
 
 ### Push Gateway

--- a/docs/SCRIPTING.md
+++ b/docs/SCRIPTING.md
@@ -419,6 +419,10 @@ xfr <host> --json --no-tui | jq -r '
 ' | curl --data-binary @- http://pushgateway:9091/metrics/job/xfr/instance/$(hostname)
 ```
 
+The built-in Push Gateway payload uses an `xfr_duration_seconds` gauge. The
+live scrape endpoint is a separate metric contract and uses the
+`xfr_test_duration_seconds` histogram plus labeled per-stream and TCP metrics.
+
 ### Metrics Endpoint
 
 For continuous monitoring (requires `--features prometheus` at build time):
@@ -430,17 +434,23 @@ xfr serve --prometheus 9090
 Metrics available at `http://localhost:9090/metrics`:
 
 ```
-# HELP xfr_bytes_total Total bytes transferred
+# HELP xfr_bytes_total Total bytes transferred across all tests
 # TYPE xfr_bytes_total counter
 xfr_bytes_total 1234567890
 
-# HELP xfr_throughput_mbps Current throughput
+# HELP xfr_throughput_mbps Current aggregate throughput in Mbps
 # TYPE xfr_throughput_mbps gauge
 xfr_throughput_mbps 987.65
 
-# HELP xfr_duration_seconds Test duration
-# TYPE xfr_duration_seconds gauge
-xfr_duration_seconds 10.0
+# HELP xfr_test_duration_seconds Distribution of test durations in seconds
+# TYPE xfr_test_duration_seconds histogram
+xfr_test_duration_seconds_bucket{le="10"} 1
+xfr_test_duration_seconds_sum 10.0
+xfr_test_duration_seconds_count 1
+
+# HELP xfr_tcp_retransmits_total Total TCP retransmits
+# TYPE xfr_tcp_retransmits_total counter
+xfr_tcp_retransmits_total{test_id="abc"} 42
 ```
 
 ### Grafana Dashboard

--- a/docs/xfr.1
+++ b/docs/xfr.1
@@ -1,4 +1,4 @@
-.TH XFR 1 "July 2026" "xfr 0.9.25" "User Commands"
+.TH XFR 1 "2026-08-30" "xfr 0.9.25" "User Commands"
 .SH NAME
 xfr \- modern network bandwidth testing with TUI
 .SH SYNOPSIS
@@ -111,7 +111,7 @@ Log file path (e.g., ~/.config/xfr/xfr.log)
 Log level: error, warn, info, debug, trace
 .TP
 .BI \-\-psk " KEY"
-Pre-shared key for server authentication. Environment: XFR_PSK. Values supplied via \fB\-\-psk\fR or \fBXFR_PSK\fR may be visible through process metadata; prefer \fB\-\-psk\-file\fR.
+Pre-shared key for mutual peer authentication and protected post-auth control messages. Environment: XFR_PSK. Values supplied via \fB\-\-psk\fR or \fBXFR_PSK\fR may be visible through process metadata; prefer \fB\-\-psk\-file\fR.
 .TP
 .BI \-\-psk\-file " FILE"
 Read PSK from file
@@ -171,6 +171,9 @@ Maximum test duration (server-side limit)
 .BI \-\-push\-gateway " URL"
 Prometheus push gateway URL (e.g., http://pushgateway:9091)
 .TP
+.BI \-\-prometheus " PORT"
+Prometheus metrics endpoint port (requires the prometheus build feature)
+.TP
 .BI \-\-log\-file " PATH"
 Log file path
 .TP
@@ -178,7 +181,7 @@ Log file path
 Log level: error, warn, info, debug, trace
 .TP
 .BI \-\-psk " KEY"
-Pre-shared key for authentication. Environment: XFR_PSK. Values supplied via \fB\-\-psk\fR or \fBXFR_PSK\fR may be visible through process metadata; prefer \fB\-\-psk\-file\fR.
+Pre-shared key for mutual peer authentication and protected post-auth control messages. Environment: XFR_PSK. Values supplied via \fB\-\-psk\fR or \fBXFR_PSK\fR may be visible through process metadata; prefer \fB\-\-psk\-file\fR.
 .TP
 .BI \-\-psk\-file " FILE"
 Read PSK from file
@@ -193,14 +196,16 @@ Max concurrent tests per IP
 Rate limit time window (default: 60s)
 .TP
 .BI \-\-allow " IP/SUBNET"
-Allow IP or subnet (can be repeated)
+Allow IP or subnet (can be repeated).
+If any allow rules exist, clients matching none are rejected.
+With no allow rules, otherwise-unmatched clients are accepted.
 .TP
 .BI \-\-deny " IP/SUBNET"
-Deny IP or subnet (can be repeated)
+Deny IP or subnet (can be repeated).
+Deny rules always take precedence.
 .TP
 .BI \-\-acl\-file " FILE"
 Load ACL rules from file
-.TP
 .TP
 .BI \-B ", " \-\-bind " IP"
 Bind to specific address (e.g., 192.168.1.1, ::1). Rejects unspecified addresses; use \fB\-4\fR/\fB\-6\fR instead to control address family. Validates against \fB\-4\fR/\fB\-6\fR flags.
@@ -342,7 +347,7 @@ Start server with live dashboard
 .B xfr serve \-\-psk secret \-\-rate\-limit 2
 Authenticated server with rate limiting
 .TP
-.B xfr serve \-\-allow 192.168.0.0/16 \-\-deny 0.0.0.0/0
+.B xfr serve \-\-allow 192.168.0.0/16
 Server with IP access control
 .TP
 .B xfr diff baseline.json current.json \-\-threshold 5
@@ -351,7 +356,6 @@ Compare results, fail if throughput drops more than 5%
 .B xfr discover
 Find xfr servers on the local network via mDNS
 .SH PROTOCOL
-.PP
 .B xfr
 servers and clients using protocol v1.1 exchange capability strings during the
 .B Hello

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -59,7 +59,7 @@ one_off = false
 no_mdns = false
 
 # Prometheus metrics port (requires --features prometheus)
-# prometheus = 9090
+# prometheus_port = 9090
 
 # Server presets - use with: xfr serve --preset limited
 [[presets]]

--- a/src/acl.rs
+++ b/src/acl.rs
@@ -56,7 +56,7 @@ impl Acl {
     /// # Comment
     /// allow 192.168.0.0/16
     /// allow 10.0.0.0/8
-    /// deny 0.0.0.0/0
+    /// deny 192.168.1.0/24
     /// ```
     pub fn from_file(path: &Path) -> anyhow::Result<Self> {
         let content = std::fs::read_to_string(path)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 //!
 //! xfr can be used as a library for embedding bandwidth tests in your application:
 //!
-//! ```ignore
+//! ```no_run
 //! use xfr::{Client, ClientConfig};
 //! use std::time::Duration;
 //!


### PR DESCRIPTION
## Summary

- document ACL precedence and default-deny behavior accurately, including safe examples
- correct the sample Prometheus config key and distinguish scrape-endpoint metrics from Push Gateway metrics
- bring the man page in sync with `serve --prometheus` and current configuration behavior
- make the README example a compiling doctest
- replace stale security promises with the current support and transport boundaries

## Security documentation

The PSK authenticates and protects xfr's application control channel. Today it is not bound to the QUIC TLS session or bulk streams, so the docs no longer claim end-to-end QUIC payload authentication; they recommend an authenticated VPN when endpoint-verified confidentiality is required. Private vulnerability reporting is now enabled and linked from `SECURITY.md`.

## Validation

- `just check` on the rebased head, including the newly compiled doctest
- `git diff --check`
- `mandoc -T lint docs/xfr.1` (only pre-existing long-line style notices)
- independent review against ACL, Prometheus, Push Gateway, QUIC, and control-crypto implementations
