### PR TITLE
fix: server, tui, and transport reliability improvements post-#195

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **mDNS registration no longer silently fails on a 64-byte Linux hostname** — DNS labels are capped at 63 bytes, but Linux `HOST_NAME_MAX` is 64. xfr passed the nodename through to mdns-sd unchanged, which then skipped the oversize records at encode time while still returning success, so `xfr serve` logged a registration that `xfr discover` could not see. Oversized names are now truncated at a UTF-8 boundary with a short stable suffix so two long hostnames that share a prefix stay distinct. (#194)
+- **QUIC rate-limiter slot leak on handler semaphore saturation** — the QUIC acceptor now acquires the handler permit before checking rate limits, preventing connections rejected by concurrency limits from leaking per-IP quota.
+- **TUI byte-budget progress and completion statistics** — `-n` tests now accumulate interval byte deltas and pin final results, fixing progress bar jumps and 0s completion duration.
+- **Multi-instance mDNS discovery** — servers on the same host with distinct ports are no longer deduplicated away, and discovery polling is non-blocking.
+- **Constant-time comparison in protected control channel** — padded comparison avoids early return on length mismatch.
+- **ACL rule matching for IPv4-mapped IPv6** — `matched_rule` now normalizes addresses before checking network rules.
+- **Zerocopy sendfile EINTR retry** — interrupted syscalls in `sendfile_once` are retried rather than failing the transfer.
+- **TUI terminal restoration guard** — RAII guard restores normal terminal mode and leaves the alternate screen on panic or error unwinding.
 
 ## [0.10.0] - 2026-08-31
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3334,28 +3334,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-stream"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
-dependencies = [
- "futures-core",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
-name = "tokio-test"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6d24790a10a7af737693a3e8f1d03faef7e6ca0cc99aae5066f533766de545"
-dependencies = [
- "futures-core",
- "tokio",
- "tokio-stream",
-]
-
-[[package]]
 name = "toml"
 version = "1.1.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4141,7 +4119,6 @@ dependencies = [
  "socket2",
  "tempfile",
  "tokio",
- "tokio-test",
  "toml",
  "tracing",
  "tracing-appender",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,7 @@ discovery = ["dep:mdns-sd"]
 update-check = ["dep:update-informer"]
 
 [dev-dependencies]
-tokio-test = "0.4"
+tokio = { version = "1", features = ["test-util"] }
 criterion = { version = "0.8", features = ["async_tokio"] }
 tempfile = "3"
 

--- a/src/acl.rs
+++ b/src/acl.rs
@@ -139,6 +139,7 @@ impl Acl {
 
     /// Get the rule that matched (for logging)
     pub fn matched_rule(&self, ip: IpAddr) -> Option<String> {
+        let ip = normalize_ip(ip);
         for network in &self.deny {
             if network.contains(ip) {
                 return Some(format!("deny {}", network));
@@ -229,5 +230,30 @@ mod tests {
 
         assert!(acl.is_allowed(IpAddr::V6(Ipv6Addr::LOCALHOST)));
         assert!(!acl.is_allowed(IpAddr::V6(Ipv6Addr::new(0x2001, 0x0db8, 0, 0, 0, 0, 0, 1))));
+    }
+
+    #[test]
+    fn test_matched_rule_normalizes_ipv4_mapped_ipv6() {
+        let mut acl = Acl::new();
+        acl.allow("192.168.0.0/16".parse().unwrap());
+        acl.deny("10.0.0.0/8".parse().unwrap());
+
+        // IPv4-mapped IPv6 for 192.168.1.1
+        let mapped_allow = "::ffff:192.168.1.1".parse().unwrap();
+        assert_eq!(
+            acl.matched_rule(mapped_allow),
+            Some("allow 192.168.0.0/16".to_string())
+        );
+
+        // IPv4-mapped IPv6 for 10.0.0.1
+        let mapped_deny = "::ffff:10.0.0.1".parse().unwrap();
+        assert_eq!(
+            acl.matched_rule(mapped_deny),
+            Some("deny 10.0.0.0/8".to_string())
+        );
+
+        // Unmatched address
+        let unmatched = "172.16.0.1".parse().unwrap();
+        assert_eq!(acl.matched_rule(unmatched), None);
     }
 }

--- a/src/control_crypto.rs
+++ b/src/control_crypto.rs
@@ -586,15 +586,21 @@ impl ControlWriter {
     }
 }
 
-/// Constant-time comparison.
+/// Constant-time comparison to prevent timing attacks.
+///
+/// Padding to the length of the longer input avoids the early-return that
+/// would otherwise leak whether the two slices have different lengths. The
+/// length difference is folded into the accumulator so that trailing zero
+/// bytes do not accidentally produce equality.
 fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
-    if a.len() != b.len() {
-        return false;
-    }
+    let len = a.len().max(b.len());
     let mut result = 0u8;
-    for (x, y) in a.iter().zip(b.iter()) {
+    for i in 0..len {
+        let x = a.get(i).unwrap_or(&0);
+        let y = b.get(i).unwrap_or(&0);
         result |= x ^ y;
     }
+    result |= (a.len() != b.len()) as u8;
     result == 0
 }
 
@@ -823,5 +829,15 @@ mod tests {
             )
             .unwrap()
         );
+    }
+
+    #[test]
+    fn constant_time_eq_works_for_equal_and_different_lengths() {
+        assert!(constant_time_eq(b"secret-value", b"secret-value"));
+        assert!(!constant_time_eq(b"secret-value", b"secret-other"));
+        assert!(!constant_time_eq(b"secret", b"secret-longer"));
+        assert!(!constant_time_eq(b"secret-longer", b"secret"));
+        assert!(!constant_time_eq(b"", b"non-empty"));
+        assert!(constant_time_eq(b"", b""));
     }
 }

--- a/src/discover.rs
+++ b/src/discover.rs
@@ -81,13 +81,13 @@ mod mdns_impl {
                 break;
             }
 
-            // Use recv_timeout to avoid blocking indefinitely
-            // Cap at 100ms to allow periodic deadline checks
+            // Use recv_async with timeout to keep the async executor unblocked.
+            // Cap at 100ms to allow periodic deadline checks.
             let wait_time = remaining.min(Duration::from_millis(100));
-            let event = receiver.recv_timeout(wait_time);
+            let event = tokio::time::timeout(wait_time, receiver.recv_async()).await;
 
             match event {
-                Ok(ServiceEvent::ServiceResolved(info)) => {
+                Ok(Ok(ServiceEvent::ServiceResolved(info))) => {
                     debug!("Service resolved: {:?}", info);
 
                     for addr in info.get_addresses() {
@@ -101,8 +101,11 @@ mod mdns_impl {
                                 .map(|v| v.val_str().to_string()),
                         };
 
-                        // Avoid duplicates
-                        if !servers.iter().any(|s: &DiscoveredServer| s.ip == server.ip) {
+                        // Avoid duplicates (same IP and port)
+                        if !servers
+                            .iter()
+                            .any(|s: &DiscoveredServer| s.ip == server.ip && s.port == server.port)
+                        {
                             info!(
                                 "Found server: {}:{} ({})",
                                 server.ip,
@@ -113,22 +116,28 @@ mod mdns_impl {
                         }
                     }
                 }
-                Ok(ServiceEvent::ServiceFound(service_type, name)) => {
+                Ok(Ok(ServiceEvent::ServiceFound(service_type, name))) => {
                     debug!("Service found: {} {}", service_type, name);
                 }
-                Ok(ServiceEvent::SearchStarted(_)) => {
+                Ok(Ok(ServiceEvent::SearchStarted(_))) => {
                     debug!("mDNS search started");
                 }
-                Ok(event) => {
+                Ok(Ok(event)) => {
                     debug!("mDNS event: {:?}", event);
                 }
+                Ok(Err(_)) => {
+                    // Channel disconnected
+                    break;
+                }
                 Err(_) => {
-                    // Timeout or disconnected - continue to check deadline
+                    // Timeout elapsed - continue to check deadline
                 }
             }
         }
 
-        mdns.shutdown()?;
+        if let Err(e) = mdns.shutdown() {
+            debug!("mDNS shutdown error: {e}");
+        }
         Ok(servers)
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -202,15 +202,14 @@ struct Cli {
     bidir: bool,
 
     /// JSON output
-    #[arg(long, conflicts_with = "csv")]
+    #[arg(long, conflicts_with_all = ["csv", "json_stream"])]
     #[arg(help_heading = "Output Options")]
     json: bool,
 
     /// JSON streaming output (one object per line)
-    #[arg(long, conflicts_with = "csv")]
+    #[arg(long, conflicts_with_all = ["csv", "json"])]
     #[arg(help_heading = "Output Options")]
     json_stream: bool,
-
     /// CSV output
     #[arg(long, conflicts_with_all = ["json", "json_stream"])]
     #[arg(help_heading = "Output Options")]
@@ -1798,6 +1797,17 @@ fn build_fallback_result(cumulative_bytes: u64, elapsed_ms: u64) -> xfr::protoco
     }
 }
 
+/// RAII guard that restores raw mode and leaves the alternate screen on drop,
+/// ensuring terminal recovery even if the TUI event loop panics or exits early.
+struct TerminalGuard;
+
+impl Drop for TerminalGuard {
+    fn drop(&mut self) {
+        let _ = disable_raw_mode();
+        let _ = io::stdout().execute(LeaveAlternateScreen);
+    }
+}
+
 async fn run_client_tui(
     config: ClientConfig,
     output: Option<PathBuf>,
@@ -1809,6 +1819,7 @@ async fn run_client_tui(
     enable_raw_mode()?;
     let mut stdout = io::stdout();
     stdout.execute(EnterAlternateScreen)?;
+    let _guard = TerminalGuard;
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
 
@@ -1822,9 +1833,7 @@ async fn run_client_tui(
     .await;
 
     // Restore terminal
-    disable_raw_mode()?;
-    terminal.backend_mut().execute(LeaveAlternateScreen)?;
-
+    drop(_guard);
     match result {
         Ok((test_result, final_prefs, print_json, partial)) => {
             if let Some(ref test_result) = test_result {
@@ -2400,9 +2409,9 @@ async fn run_server_tui(mut config: ServerConfig) -> Result<()> {
     enable_raw_mode()?;
     let mut stdout = io::stdout();
     stdout.execute(EnterAlternateScreen)?;
+    let _guard = TerminalGuard;
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
-
     let server = Server::new(config);
     let server_handle = tokio::spawn(async move { server.run().await });
 
@@ -2473,9 +2482,7 @@ async fn run_server_tui(mut config: ServerConfig) -> Result<()> {
     }
 
     // Restore terminal
-    disable_raw_mode()?;
-    terminal.backend_mut().execute(LeaveAlternateScreen)?;
-
+    drop(_guard);
     Ok(())
 }
 

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -673,17 +673,6 @@ impl Server {
                         continue;
                     }
 
-                    // Check rate limit
-                    if let Some(ref limiter) = quic_rate_limiter
-                        && let Err(e) = limiter.check(peer_ip)
-                    {
-                        warn!("QUIC rate limit exceeded for {}: {}", peer_addr, e);
-                        if let Some(tx) = &quic_security.tui_tx {
-                            let _ = tx.try_send(ServerEvent::ConnectionBlocked);
-                        }
-                        continue;
-                    }
-
                     // Acquire semaphore permit to limit concurrent handlers
                     let permit = match quic_semaphore.clone().try_acquire_owned() {
                         Ok(permit) => permit,
@@ -695,6 +684,17 @@ impl Server {
                             continue;
                         }
                     };
+
+                    // Check rate limit
+                    if let Some(ref limiter) = quic_rate_limiter
+                        && let Err(e) = limiter.check(peer_ip)
+                    {
+                        warn!("QUIC rate limit exceeded for {}: {}", peer_addr, e);
+                        if let Some(tx) = &quic_security.tui_tx {
+                            let _ = tx.try_send(ServerEvent::ConnectionBlocked);
+                        }
+                        continue;
+                    }
 
                     info!("QUIC client connected: {}", peer_addr);
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -577,7 +577,7 @@ impl App {
         // anyway, producing a one-frame flash of the server-authoritative
         // value that users couldn't perceive. `on_result()` pins the final
         // once the test completes.
-        self.total_bytes = progress.total_bytes;
+        self.total_bytes = self.total_bytes.saturating_add(progress.total_bytes);
         self.current_throughput_mbps = progress.throughput_mbps;
 
         // Bidirectional split: when the server reports per-direction counts
@@ -766,8 +766,12 @@ impl App {
 
     pub fn on_result(&mut self, result: TestResult) {
         self.state = AppState::Completed;
-        self.elapsed = self.duration; // Show full duration on completion
-
+        if self.is_infinite() {
+            self.elapsed = Duration::from_millis(result.duration_ms);
+        } else {
+            self.elapsed = self.duration; // Show full duration on completion
+        }
+        self.total_bytes = result.bytes_total;
         // Sum retransmits from streams (captured after transfer, accurate for download mode)
         self.total_retransmits = result.streams.iter().filter_map(|s| s.retransmits).sum();
 
@@ -1962,6 +1966,62 @@ mod tests {
         app.elapsed = Duration::from_secs(3);
         app.total_bytes = 999_999;
         assert_eq!(app.progress_percent(), 30.0);
+    }
+
+    #[test]
+    fn on_progress_accumulates_total_bytes_across_intervals() {
+        let mut app = App::default();
+        assert_eq!(app.total_bytes, 0);
+
+        let mut progress = TestProgress {
+            elapsed_ms: 1000,
+            total_bytes: 1000,
+            throughput_mbps: 8.0,
+            streams: vec![],
+            rtt_us: None,
+            cwnd: None,
+            total_retransmits: None,
+            bytes_sent: None,
+            bytes_received: None,
+            throughput_send_mbps: None,
+            throughput_recv_mbps: None,
+            udp_progress: None,
+            udp_feedback_only: false,
+        };
+        app.on_progress(progress.clone());
+        assert_eq!(app.total_bytes, 1000);
+
+        progress.elapsed_ms = 2000;
+        progress.total_bytes = 1500;
+        app.on_progress(progress);
+        assert_eq!(app.total_bytes, 2500);
+    }
+
+    #[test]
+    fn on_result_sets_elapsed_and_total_bytes_for_byte_budget_test() {
+        let mut app = App::default();
+        app.duration = Duration::ZERO;
+        app.byte_budget = Some(10_000);
+        assert!(app.is_infinite());
+
+        let result = TestResult {
+            id: "test-123".to_string(),
+            duration_ms: 3500,
+            bytes_total: 10_000,
+            throughput_mbps: 22.8,
+            streams: vec![],
+            tcp_info: None,
+            udp_stats: None,
+            bytes_sent: None,
+            bytes_received: None,
+            throughput_send_mbps: None,
+            throughput_recv_mbps: None,
+            mtu_probe: None,
+        };
+        app.on_result(result);
+        assert_eq!(app.elapsed, Duration::from_millis(3500));
+        assert_eq!(app.total_bytes, 10_000);
+        assert_eq!(app.progress_percent(), 100.0);
     }
 
     #[test]

--- a/src/zerocopy.rs
+++ b/src/zerocopy.rs
@@ -111,11 +111,17 @@ impl ZerocopyPayload {
             return Ok(0);
         }
         let mut off = offset as libc::off_t;
-        let n = unsafe { libc::sendfile(socket_fd, self.file.as_raw_fd(), &mut off, remaining) };
-        if n < 0 {
-            Err(io::Error::last_os_error())
-        } else {
-            Ok(n as usize)
+        loop {
+            let n =
+                unsafe { libc::sendfile(socket_fd, self.file.as_raw_fd(), &mut off, remaining) };
+            if n < 0 {
+                let err = io::Error::last_os_error();
+                if err.kind() == io::ErrorKind::Interrupted {
+                    continue;
+                }
+                return Err(err);
+            }
+            return Ok(n as usize);
         }
     }
 


### PR DESCRIPTION
## Summary

Addresses reliability, security, and edge-case issues identified during a comprehensive post-#195 codebase audit:

- **QUIC rate-limit leak (`src/serve.rs`):** Acquire the QUIC handler semaphore permit before checking rate limits, preventing connections rejected by concurrency limits from leaking per-IP quota.
- **TUI byte-budget progress and completion statistics (`src/tui/app.rs`):**
  - Accumulate `total_bytes` across intervals in `on_progress` so `-n` (byte budget) progress bars and Transfer displays show cumulative progress rather than jumping per-interval deltas.
  - In `on_result`, set `total_bytes` from `result.bytes_total`, and if `is_infinite()`, set `elapsed = Duration::from_millis(result.duration_ms)` so completed `-n` tests show actual elapsed duration and 100% completion.
- **mDNS discovery dedup & non-blocking polling (`src/discover.rs`):**
  - Deduplicate discovered servers by `(ip, port)` rather than `ip` alone, so multiple xfr servers running on the same host on different ports are both discovered.
  - Use `tokio::time::timeout(wait_time, receiver.recv_async())` instead of thread-blocking `recv_timeout(100ms)`, keeping the async executor cooperative.
  - Log rather than error when `mdns.shutdown()` encounters cleanup issues.
- **Constant-time comparison timing leak (`src/control_crypto.rs`):** Replace `control_crypto::constant_time_eq`'s early return on length mismatch with a padded constant-time comparison (matching `auth::constant_time_eq`).
- **ACL rule lookup normalization (`src/acl.rs`):** Call `normalize_ip` in `matched_rule` so IPv4-mapped IPv6 addresses match configured IPv4 network rules consistently with `is_allowed`.
- **Zerocopy `sendfile` retry (`src/zerocopy.rs`):** Retry `sendfile` syscall on `EINTR` in `sendfile_once` instead of terminating the transfer.
- **TUI terminal restoration guard (`src/main.rs`):** Add `TerminalGuard` with RAII `Drop` to ensure raw mode and alternate screen are restored even if the TUI event loop panics or unwinds.
- **CLI conflict detection (`src/main.rs`):** Add mutual `conflicts_with_all` between `--json` and `--json-stream`.
- **Dependency cleanup (`Cargo.toml`):** Replace unused `tokio-test = "0.4"` dev-dependency with direct `tokio = { version = "1", features = ["test-util"] }`.

## Validation

- `just check` (`fmt-check`, `clippy` on `--all-features` and `--no-default-features`, full tests on both configurations, `doc` with `-D warnings`)
- `cargo test --locked --all-features` (479 tests passed)
- `cargo test --locked --no-default-features` (478 tests passed)
- `cargo audit` (0 vulnerabilities)
- `cargo deny check licenses bans sources` (ok)
- `typos` (clean)
